### PR TITLE
Pulsar Runtime: merge GenAI ToolKit Agents

### DIFF
--- a/api/src/main/java/com/datastax/oss/sga/api/model/TopicDefinition.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/model/TopicDefinition.java
@@ -18,9 +18,11 @@ package com.datastax.oss.sga.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
+@ToString
 public class TopicDefinition extends Connection.Connectable {
 
     public static final String CREATE_MODE_NONE = "none";

--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/AgentImplementationProvider.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/AgentImplementationProvider.java
@@ -5,11 +5,40 @@ import com.datastax.oss.sga.api.model.Module;
 
 public interface AgentImplementationProvider {
 
+    /**
+     * Create an Implementation of an Agent that can be deployed on the give runtimes.
+     * @param agentConfiguration
+     * @param module
+     * @param physicalApplicationInstance
+     * @param clusterRuntime
+     * @param pluginsRegistry
+     * @param streamingClusterRuntime
+     * @return the Agent
+     */
     AgentImplementation createImplementation(AgentConfiguration agentConfiguration,
                                              Module module,
                                              PhysicalApplicationInstance physicalApplicationInstance,
                                              ClusterRuntime clusterRuntime,
-                                             PluginsRegistry pluginsRegistry, StreamingClusterRuntime streamingClusterRuntime);
+                                             PluginsRegistry pluginsRegistry,
+                                             StreamingClusterRuntime streamingClusterRuntime);
 
+    /**
+     * Returns the ability of an Agent to be deployed on the give runtimes.
+     * @param type
+     * @param clusterRuntime
+     * @return true if this provider that can create the implementation
+     */
     boolean supports(String type, ClusterRuntime clusterRuntime);
+
+    /**
+     * Returns the ability of an Agent to be merged with the previous version.
+     * @return true if the agents can be merged
+     */
+    default boolean canMerge(AgentImplementation previousAgent, AgentImplementation agentImplementation) {
+        return false;
+    }
+
+    default AgentImplementation mergeAgents(AgentImplementation previousAgent, AgentImplementation agentImplementation, PhysicalApplicationInstance instance) {
+        throw new UnsupportedOperationException("This provider cannot merge agents");
+    }
 }

--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/PhysicalApplicationInstance.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/PhysicalApplicationInstance.java
@@ -87,6 +87,17 @@ public final class PhysicalApplicationInstance {
     }
 
     /**
+     * Discard a topic implementation
+     * @param topicImplementation
+     */
+    public void discardTopic(ConnectionImplementation topicImplementation) {
+        topics.entrySet()
+                .stream()
+                .filter(e -> e.getValue().equals(topicImplementation)).findFirst()
+                .ifPresent(e -> topics.remove(e.getKey()));
+    }
+
+    /**
      * Get an existing agent implementation
      * @param module
      * @param id

--- a/core/src/main/java/com/datastax/oss/sga/impl/common/AbstractAgentProvider.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/common/AbstractAgentProvider.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,11 +33,11 @@ public abstract class AbstractAgentProvider implements AgentImplementationProvid
     public static class DefaultAgentImplementation implements AgentImplementation {
         private final String id;
         private final String type;
-        private final Map<String, Object> configuration;
+        private Map<String, Object> configuration;
         private final Object runtimeMetadata;
 
         private final ConnectionImplementation inputConnection;
-        private final ConnectionImplementation outputConnection;
+        private ConnectionImplementation outputConnection;
 
         public DefaultAgentImplementation(String id, String type, Map<String, Object> configuration, Object runtimeMetadata,
                                           ConnectionImplementation inputConnection,
@@ -51,6 +52,11 @@ public abstract class AbstractAgentProvider implements AgentImplementationProvid
 
         public <T> T getPhysicalMetadata() {
             return (T) runtimeMetadata;
+        }
+
+        public void overrideConfiguration(Map<String, Object> newConfiguration, ConnectionImplementation newOutput) {
+            this.configuration = new HashMap<>(newConfiguration);
+            this.outputConnection = newOutput;
         }
     }
 

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/AbstractPulsarFunctionAgentProvider.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/AbstractPulsarFunctionAgentProvider.java
@@ -1,6 +1,7 @@
 package com.datastax.oss.sga.pulsar.agents;
 
 import com.datastax.oss.sga.api.model.AgentConfiguration;
+import com.datastax.oss.sga.api.runtime.AgentImplementation;
 import com.datastax.oss.sga.api.runtime.ClusterRuntime;
 import com.datastax.oss.sga.api.runtime.PhysicalApplicationInstance;
 import com.datastax.oss.sga.api.runtime.StreamingClusterRuntime;
@@ -9,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 public abstract class AbstractPulsarFunctionAgentProvider extends AbstractPulsarAgentProvider {
 
@@ -36,6 +39,5 @@ public abstract class AbstractPulsarFunctionAgentProvider extends AbstractPulsar
         final PulsarName pulsarName = computePulsarName(physicalApplicationInstance, agentConfiguration);
         return new PulsarFunctionMetadata(pulsarName, getFunctionType(agentConfiguration), getFunctionClassname(agentConfiguration));
     }
-
 
 }

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/ai/GenAIToolKitFunctionAgentProvider.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/ai/GenAIToolKitFunctionAgentProvider.java
@@ -4,19 +4,25 @@ import com.datastax.oss.sga.api.model.AgentConfiguration;
 import com.datastax.oss.sga.api.model.ApplicationInstance;
 import com.datastax.oss.sga.api.model.Module;
 import com.datastax.oss.sga.api.model.Resource;
+import com.datastax.oss.sga.api.runtime.AgentImplementation;
 import com.datastax.oss.sga.api.runtime.ClusterRuntime;
 import com.datastax.oss.sga.api.runtime.ConnectionImplementation;
 import com.datastax.oss.sga.api.runtime.PhysicalApplicationInstance;
 import com.datastax.oss.sga.pulsar.PulsarClusterRuntime;
 import com.datastax.oss.sga.pulsar.PulsarTopic;
 import com.datastax.oss.sga.pulsar.agents.AbstractPulsarFunctionAgentProvider;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+@Slf4j
 public class GenAIToolKitFunctionAgentProvider extends AbstractPulsarFunctionAgentProvider {
+
+    private static final String FUNCTION_TYPE = "ai-tools";
 
     public GenAIToolKitFunctionAgentProvider(String stepType) {
         super(List.of(stepType), List.of(PulsarClusterRuntime.CLUSTER_TYPE));
@@ -25,7 +31,7 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractPulsarFunctionAge
     @Override
     protected String getFunctionType(AgentConfiguration agentConfiguration) {
         // https://github.com/datastax/pulsar-transformations/tree/master/pulsar-ai-tools
-        return "ai-tools";
+        return FUNCTION_TYPE;
     }
 
     @Override
@@ -71,5 +77,53 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractPulsarFunctionAge
         configuration.put("steps", steps);
         generateSteps(originalConfiguration, steps);
         return configuration;
+    }
+
+
+    @Override
+    public boolean canMerge(AgentImplementation previousAgent, AgentImplementation agentImplementation) {
+        if (previousAgent instanceof DefaultAgentImplementation agent1
+                && agent1.getRuntimeMetadata() instanceof PulsarFunctionMetadata metadata1
+                && agentImplementation instanceof DefaultAgentImplementation agent2
+                && agent2.getRuntimeMetadata() instanceof PulsarFunctionMetadata metadata2)
+            if (Objects.equals(metadata1.getFunctionType(), FUNCTION_TYPE)
+                    && Objects.equals(metadata2.getFunctionType(), FUNCTION_TYPE)) {
+                Map<String, Object> configurationWithoutSteps1 = new HashMap<>(agent1.getConfiguration());
+                configurationWithoutSteps1.remove("steps");
+                Map<String, Object> configurationWithoutSteps2 = new HashMap<>(agent2.getConfiguration());
+                configurationWithoutSteps2.remove("steps");
+                log.info("Comparing {} and {}", configurationWithoutSteps1, configurationWithoutSteps2);
+                return configurationWithoutSteps1.equals(configurationWithoutSteps2);
+            }
+        return false;
+    }
+
+    @Override
+    public AgentImplementation mergeAgents(AgentImplementation previousAgent, AgentImplementation agentImplementation,
+                                           PhysicalApplicationInstance applicationInstance) {
+        if (previousAgent instanceof DefaultAgentImplementation agent1
+                && agent1.getRuntimeMetadata() instanceof PulsarFunctionMetadata metadata1
+                && agentImplementation instanceof DefaultAgentImplementation agent2
+                && agent2.getRuntimeMetadata() instanceof PulsarFunctionMetadata metadata2) {
+            Map<String, Object> configurationWithoutSteps1 = new HashMap<>(agent1.getConfiguration());
+            List<Map<String, Object>> steps1 = (List<Map<String, Object>>) configurationWithoutSteps1.remove("steps");
+            Map<String, Object> configurationWithoutSteps2 = new HashMap<>(agent2.getConfiguration());
+            List<Map<String, Object>> steps2 = (List<Map<String, Object>>) configurationWithoutSteps2.remove("steps");
+
+            List<Map<String, Object>> mergedSteps = new ArrayList<>();
+            mergedSteps.addAll(steps2);
+            mergedSteps.addAll(steps1);
+
+            Map<String, Object> result = new HashMap<>();
+            result.putAll(configurationWithoutSteps1);
+            result.put("steps", mergedSteps);
+
+            agent1.overrideConfiguration(result, agent2.getOutputConnection());
+
+            log.info("Discarding topic {}", agent1.getInputConnection());
+            applicationInstance.discardTopic(agent1.getInputConnection());
+            return previousAgent;
+        }
+        throw new IllegalStateException();
     }
 }


### PR DESCRIPTION
Summary:
- when using the Pulsar ComputeRuntime optimise the case in which you have two GenAI ToolKit agents next to each other
- remove the unneeded intermediate topic
