### PR TITLE
Operator: schedule delete job when the app is deleted

### DIFF
--- a/k8s-deployer/k8s-deployer-operator/src/main/java/com/datastax/oss/sga/deployer/k8s/util/SerializationUtil.java
+++ b/k8s-deployer/k8s-deployer-operator/src/main/java/com/datastax/oss/sga/deployer/k8s/util/SerializationUtil.java
@@ -25,7 +25,8 @@ import lombok.SneakyThrows;
 public class SerializationUtil {
 
     private static final ObjectMapper mapper = new ObjectMapper()
-            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     private static final ObjectMapper yamlMapper = new ObjectMapper(YAMLFactory.builder()
             .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
             .disable(YAMLGenerator.Feature.SPLIT_LINES)

--- a/k8s-deployer/k8s-deployer-operator/src/test/java/com/datastax/oss/sga/deployer/k8s/controllers/AppControllerIT.java
+++ b/k8s-deployer/k8s-deployer-operator/src/test/java/com/datastax/oss/sga/deployer/k8s/controllers/AppControllerIT.java
@@ -1,18 +1,16 @@
 package com.datastax.oss.sga.deployer.k8s.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.datastax.oss.sga.deployer.k8s.api.crds.apps.ApplicationCustomResource;
 import com.datastax.oss.sga.deployer.k8s.util.SerializationUtil;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
-import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -51,6 +49,26 @@ public class AppControllerIT {
             assertEquals(1, client.batch().v1().jobs().inNamespace(namespace).list().getItems().size());
         });
         final Job job = client.batch().v1().jobs().inNamespace(namespace).list().getItems().get(0);
+        checkJob(job, false);
+
+
+        client.resource(resource).inNamespace(namespace).delete();
+
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(2, client.batch().v1().jobs().inNamespace(namespace).list().getItems().size());
+        });
+        final Job cleanupJob =
+                client.batch().v1().jobs().inNamespace(namespace).withName("sga-runtime-deployer-cleanup-test-app")
+                        .get();
+
+        assertNotNull(cleanupJob);
+        checkJob(cleanupJob, true);
+
+        // it has to wait for the cleanup job to complete before actually deleting the application
+        assertNotNull(client.resource(resource).inNamespace(namespace).get());
+    }
+
+    private void checkJob(Job job, boolean cleanup) {
         final JobSpec spec = job.getSpec();
         assertEquals(spec.getTemplate().getMetadata().getLabels().get("app"), "sga");
         assertEquals(spec.getTemplate().getMetadata().getLabels().get("tenant"), "my-tenant");
@@ -66,6 +84,20 @@ public class AppControllerIT {
         assertEquals("app-config", container.getVolumeMounts().get(0).getName());
         assertEquals("/app-secrets", container.getVolumeMounts().get(1).getMountPath());
         assertEquals("app-secrets", container.getVolumeMounts().get(1).getName());
+        assertEquals(0, container.getCommand().size());
+        if (cleanup) {
+            int args = 0;
+            assertEquals("deployer-runtime", container.getArgs().get(args++));
+            assertEquals("delete", container.getArgs().get(args++));
+            assertEquals("/app-config/config", container.getArgs().get(args++));
+            assertEquals("/app-secrets/secrets", container.getArgs().get(args++));
+        } else {
+            int args = 0;
+            assertEquals("deployer-runtime", container.getArgs().get(args++));
+            assertEquals("deploy", container.getArgs().get(args++));
+            assertEquals("/app-config/config", container.getArgs().get(args++));
+            assertEquals("/app-secrets/secrets", container.getArgs().get(args++));
+        }
 
         final Container initContainer = templateSpec.getInitContainers().get(0);
         assertEquals("ubuntu", initContainer.getImage());

--- a/runtime/src/main/java/com/datastax/oss/sga/runtime/deployer/RuntimeDeployer.java
+++ b/runtime/src/main/java/com/datastax/oss/sga/runtime/deployer/RuntimeDeployer.java
@@ -7,6 +7,8 @@ import com.datastax.oss.sga.api.runtime.ExecutionPlan;
 import com.datastax.oss.sga.api.runtime.PluginsRegistry;
 import com.datastax.oss.sga.impl.deploy.ApplicationDeployer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
 import java.nio.file.Path;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,12 +31,18 @@ public class RuntimeDeployer {
     public static void main(String... args) {
         try {
             if (args.length < 1) {
+                throw new IllegalArgumentException("Missing runtime deployer command");
+            }
+
+            final String arg0 = args[0];
+
+            if (args.length < 2) {
                 throw new IllegalArgumentException("Missing runtime deployer configuration");
             }
-            Path configPath = Path.of(args[0]);
+            Path configPath = Path.of(args[1]);
             Secrets secrets = null;
             if (args.length > 1) {
-                Path secretsPath = Path.of(args[1]);
+                Path secretsPath = Path.of(args[2]);
                 log.info("Loading secrets from {}", secretsPath);
                 secrets = MAPPER.readValue(secretsPath.toFile(), Secrets.class);
 
@@ -43,27 +51,64 @@ public class RuntimeDeployer {
             final RuntimeDeployerConfiguration configuration =
                     MAPPER.readValue(configPath.toFile(), RuntimeDeployerConfiguration.class);
 
-            final String applicationName = configuration.getName();
-            final String applicationConfig = configuration.getApplication();
-
-            final Application appInstance =
-                    MAPPER.readValue(applicationConfig, Application.class);
-            appInstance.setSecrets(secrets);
-
-            ApplicationDeployer deployer = ApplicationDeployer
-                    .builder()
-                    .registry(new ClusterRuntimeRegistry())
-                    .pluginsRegistry(new PluginsRegistry())
-                    .build();
-
-            log.info("Deploying application {}", applicationName);
-            final ExecutionPlan implementation = deployer.createImplementation(appInstance);
-            deployer.deploy(implementation);
-            log.info("Application {} deployed", applicationName);
+            switch (arg0) {
+                case "delete":
+                    delete(configuration, secrets);
+                    break;
+                case "deploy":
+                    deploy(configuration, secrets);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown command " + arg0);
+            }
         } catch (Throwable error) {
             errorHandler.handleError(error);
             return;
         }
+    }
+
+    private static void deploy(RuntimeDeployerConfiguration configuration, Secrets secrets) throws IOException {
+
+
+        final String applicationName = configuration.getName();
+        log.info("Deploying application {}", applicationName);
+        final String applicationConfig = configuration.getApplication();
+
+        final Application appInstance =
+                MAPPER.readValue(applicationConfig, Application.class);
+        appInstance.setSecrets(secrets);
+
+        ApplicationDeployer deployer = ApplicationDeployer
+                .builder()
+                .registry(new ClusterRuntimeRegistry())
+                .pluginsRegistry(new PluginsRegistry())
+                .build();
+
+        final ExecutionPlan implementation = deployer.createImplementation(appInstance);
+        deployer.deploy(implementation);
+        log.info("Application {} deployed", applicationName);
+    }
+
+    private static void delete(RuntimeDeployerConfiguration configuration, Secrets secrets) throws IOException {
+
+
+        final String applicationName = configuration.getName();
+        final String applicationConfig = configuration.getApplication();
+
+        final Application appInstance =
+                MAPPER.readValue(applicationConfig, Application.class);
+        appInstance.setSecrets(secrets);
+
+        ApplicationDeployer deployer = ApplicationDeployer
+                .builder()
+                .registry(new ClusterRuntimeRegistry())
+                .pluginsRegistry(new PluginsRegistry())
+                .build();
+
+        log.info("Deleting application {}", applicationName);
+        final ExecutionPlan implementation = deployer.createImplementation(appInstance);
+        deployer.delete(implementation);
+        log.info("Application {} deleted", applicationName);
     }
 }
 


### PR DESCRIPTION
* When the app is deleted, the operator now intercepts the deletion and:
  * Schedule a job calling the runtime delete function
  * When the job is completed, then proceed to delete the app

It's important that an app is still there until the delete procedure is completed. 
We could in future create a `force` parameter to not wait for the cleanup completion