### PR TITLE
Runtime: commit offsets in the main loop and introduce the agent Id

### DIFF
--- a/api/src/main/java/com/datastax/oss/sga/api/runner/topics/TopicConnectionsRuntime.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/topics/TopicConnectionsRuntime.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public interface TopicConnectionsRuntime {
 
-    TopicConsumer createConsumer(StreamingCluster streamingCluster, Map<String, Object> configuration);
+    TopicConsumer createConsumer(String agentId, StreamingCluster streamingCluster, Map<String, Object> configuration);
 
-    TopicProducer createProducer(StreamingCluster streamingCluster, Map<String, Object> configuration);
+    TopicProducer createProducer(String agentId,StreamingCluster streamingCluster, Map<String, Object> configuration);
 }

--- a/api/src/main/java/com/datastax/oss/sga/api/runner/topics/TopicConsumer.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/topics/TopicConsumer.java
@@ -6,11 +6,14 @@ import java.util.List;
 
 public interface TopicConsumer {
 
-    default void start() {}
+    default void start() throws Exception {}
 
-    default void close() {}
+    default void close() throws Exception  {}
 
-    default List<Record> read() {
+    default List<Record> read()throws Exception  {
         return List.of();
+    }
+
+    default void commit() throws Exception {
     }
 }

--- a/runtime/src/main/java/com/datastax/oss/sga/runtime/agent/AgentSpec.java
+++ b/runtime/src/main/java/com/datastax/oss/sga/runtime/agent/AgentSpec.java
@@ -2,7 +2,10 @@ package com.datastax.oss.sga.runtime.agent;
 
 import java.util.Map;
 
-public record AgentSpec (ComponentType componentType, String agentType, Map<String, Object> configuration){
+public record AgentSpec (ComponentType componentType,
+                         String agentId,
+                         String applicationId,
+                         String agentType, Map<String, Object> configuration){
     public enum ComponentType {
         FUNCTION,
         SOURCE,

--- a/runtime/src/test/java/com/datastax/oss/sga/kafka/GenIAgentsRunnerTest.java
+++ b/runtime/src/test/java/com/datastax/oss/sga/kafka/GenIAgentsRunnerTest.java
@@ -100,7 +100,10 @@ class GenIAgentsRunnerTest {
         RuntimePodConfiguration runtimePodConfiguration = new RuntimePodConfiguration(
                 podAgentConfiguration.input(),
                 podAgentConfiguration.output(),
-                new AgentSpec(AgentSpec.ComponentType.valueOf(podAgentConfiguration.agentConfiguration().componentType()),
+                new AgentSpec(AgentSpec.ComponentType.valueOf(
+                        podAgentConfiguration.agentConfiguration().componentType()),
+                        podAgentConfiguration.agentConfiguration().agentId(),
+                        "application",
                         podAgentConfiguration.agentConfiguration().agentType(),
                         podAgentConfiguration.agentConfiguration().configuration()),
                 applicationInstance.getInstance().streamingCluster()

--- a/runtime/src/test/java/com/datastax/oss/sga/kafka/KafkaRunnerDockerTest.java
+++ b/runtime/src/test/java/com/datastax/oss/sga/kafka/KafkaRunnerDockerTest.java
@@ -78,7 +78,7 @@ class KafkaRunnerDockerTest {
         RuntimePodConfiguration runtimePodConfiguration = new RuntimePodConfiguration(
                 Map.of("topic", "input-topic"),
                 Map.of("topic", "output-topic"),
-                new AgentSpec(AgentSpec.ComponentType.FUNCTION, "identity", Map.of()),
+                new AgentSpec(AgentSpec.ComponentType.FUNCTION, "agent", "application", "identity", Map.of()),
                 applicationInstance.getInstance().streamingCluster()
         );
 


### PR DESCRIPTION
Summary:
-  Add TopicConsumer.commit()
-  Exit the main loop in case of error
-  Allow to pass the agentId and the application id to the PodJavaRuntime
-  On Kafka agentId and applicationId are used to set the "groupId" for the consumer group
-  On Kafka set manual management of the offsets