### PR TITLE
Pod runtime: add basic implementation for Pulsar Topics

### DIFF
--- a/api/src/main/java/com/datastax/oss/sga/api/runner/topics/TopicConnectionsRuntime.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/topics/TopicConnectionsRuntime.java
@@ -24,7 +24,13 @@ import java.util.Map;
  */
 public interface TopicConnectionsRuntime {
 
+    default void init(StreamingCluster streamingCluster){
+    }
+
     TopicConsumer createConsumer(String agentId, StreamingCluster streamingCluster, Map<String, Object> configuration);
 
     TopicProducer createProducer(String agentId,StreamingCluster streamingCluster, Map<String, Object> configuration);
+
+    default void close(){
+    }
 }

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarClientUtils.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarClientUtils.java
@@ -1,0 +1,57 @@
+package com.datastax.oss.sga.pulsar;
+
+import com.datastax.oss.sga.api.model.StreamingCluster;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PulsarClientUtils {
+    public static PulsarAdmin buildPulsarAdmin(StreamingCluster streamingCluster) throws Exception {
+        final PulsarClusterRuntimeConfiguration pulsarClusterRuntimeConfiguration =
+                getPulsarClusterRuntimeConfiguration(streamingCluster);
+        Map<String, Object> adminConfig = pulsarClusterRuntimeConfiguration.getAdmin();
+        if (adminConfig == null) {
+            adminConfig = new HashMap<>();
+        } else {
+            adminConfig = new HashMap<>(adminConfig);
+        }
+        if (pulsarClusterRuntimeConfiguration.getAuthentication() != null) {
+            adminConfig.putAll(pulsarClusterRuntimeConfiguration.getAuthentication());
+        }
+        if (adminConfig.get("serviceUrl") == null) {
+            adminConfig.put("serviceUrl", "http://localhost:8080");
+        }
+        return PulsarAdmin
+                .builder()
+                .loadConf(adminConfig)
+                .build();
+    }
+
+    public static PulsarClient buildPulsarClient(StreamingCluster streamingCluster) throws Exception {
+        final PulsarClusterRuntimeConfiguration pulsarClusterRuntimeConfiguration =
+                getPulsarClusterRuntimeConfiguration(streamingCluster);
+        Map<String, Object> clientConfig = pulsarClusterRuntimeConfiguration.getService();
+        if (clientConfig == null) {
+            clientConfig = new HashMap<>();
+        } else {
+            clientConfig = new HashMap<>(clientConfig);
+        }
+        if (pulsarClusterRuntimeConfiguration.getAuthentication() != null) {
+            clientConfig.putAll(pulsarClusterRuntimeConfiguration.getAuthentication());
+        }
+        if (clientConfig.get("serviceUrl") == null) {
+            clientConfig.put("serviceUrl", "pulsar://localhost:6650");
+        }
+        return PulsarClient
+                .builder()
+                .loadConf(clientConfig)
+                .build();
+    }
+
+    public static PulsarClusterRuntimeConfiguration getPulsarClusterRuntimeConfiguration(StreamingCluster streamingCluster) {
+        final Map<String, Object> configuration = streamingCluster.configuration();
+        return PulsarClusterRuntime.mapper.convertValue(configuration, PulsarClusterRuntimeConfiguration.class);
+    }
+}

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarClusterRuntimeConfiguration.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarClusterRuntimeConfiguration.java
@@ -11,6 +11,9 @@ import lombok.NoArgsConstructor;
 public class PulsarClusterRuntimeConfiguration {
 
     private Map<String, Object> admin;
+    private Map<String, Object> service;
+
+    private Map<String, Object> authentication;
     private String defaultTenant = "public";
     private String defaultNamespace = "default";
 

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/AbstractPulsarAgentProvider.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/AbstractPulsarAgentProvider.java
@@ -13,7 +13,7 @@ import com.datastax.oss.sga.pulsar.PulsarName;
 import java.util.List;
 import java.util.Set;
 
-import static com.datastax.oss.sga.pulsar.PulsarClusterRuntime.getPulsarClusterRuntimeConfiguration;
+import static com.datastax.oss.sga.pulsar.PulsarClientUtils.getPulsarClusterRuntimeConfiguration;
 
 public abstract class AbstractPulsarAgentProvider extends AbstractAgentProvider {
 

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
@@ -1,0 +1,263 @@
+package com.datastax.oss.sga.pulsar.runner;
+
+import com.datastax.oss.sga.api.model.StreamingCluster;
+import com.datastax.oss.sga.api.runner.code.Header;
+import com.datastax.oss.sga.api.runner.code.Record;
+import com.datastax.oss.sga.api.runner.topics.TopicConnectionsRuntime;
+import com.datastax.oss.sga.api.runner.topics.TopicConnectionsRuntimeProvider;
+import com.datastax.oss.sga.api.runner.topics.TopicConsumer;
+import com.datastax.oss.sga.api.runner.topics.TopicProducer;
+import com.datastax.oss.sga.pulsar.PulsarClientUtils;
+import com.datastax.oss.sga.pulsar.PulsarClusterRuntime;
+import com.datastax.oss.sga.pulsar.PulsarClusterRuntimeConfiguration;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRuntimeProvider {
+    @Override
+    public boolean supports(String streamingClusterType) {
+        return PulsarClusterRuntime.CLUSTER_TYPE.equals(streamingClusterType);
+    }
+
+    @Override
+    public TopicConnectionsRuntime getImplementation() {
+        return new PulsarTopicConnectionsRuntime();
+    }
+
+    private static class PulsarTopicConnectionsRuntime implements TopicConnectionsRuntime {
+
+        private PulsarClient client;
+
+        @Override
+        @SneakyThrows
+        public void init(StreamingCluster streamingCluster) {
+            client = PulsarClientUtils.buildPulsarClient(streamingCluster);
+        }
+
+        @Override
+        @SneakyThrows
+        public void close() {
+            if (client != null) {
+                client.close();
+            }
+        }
+
+        @Override
+        public TopicConsumer createConsumer(String agentId, StreamingCluster streamingCluster, Map<String, Object> configuration) {
+            Map<String, Object> copy = new HashMap<>(configuration);
+            return new PulsarTopicConsumer(copy);
+        }
+
+        @Override
+        public TopicProducer createProducer(String agentId, StreamingCluster streamingCluster, Map<String, Object> configuration) {
+            Map<String, Object> copy = new HashMap<>(configuration);
+            return new PulsarTopicProducer(copy);
+        }
+
+        private static class PulsarConsumerRecord implements Record {
+            private final Object finalKey;
+            private final Object finalValue;
+            private final Message<GenericRecord> receive;
+
+            public PulsarConsumerRecord(Object finalKey, Object finalValue, Message<GenericRecord> receive) {
+                this.finalKey = finalKey;
+                this.finalValue = finalValue;
+                this.receive = receive;
+            }
+
+            @Override
+            public Object key() {
+                return finalKey;
+            }
+
+            @Override
+            public Object value() {
+                return finalValue;
+            }
+
+            @Override
+            public String origin() {
+                return receive.getTopicName();
+            }
+
+            @Override
+            public Long timestamp() {
+                return receive.getPublishTime();
+            }
+
+            @Override
+            public Collection<Header> headers() {
+                return receive.getProperties().entrySet().stream()
+                        .map(e -> new Header() {
+                            @Override
+                            public String key() {
+                                return e.getKey();
+                            }
+
+                            @Override
+                            public String value() {
+                                return e.getValue();
+                            }
+                        })
+                        .collect(Collectors.toList());
+            }
+        }
+
+        private class PulsarTopicConsumer implements TopicConsumer {
+
+            private final Map<String, Object> configuration;
+            Consumer<GenericRecord> consumer;
+
+            List<MessageId> receivedMessages;
+
+            public PulsarTopicConsumer(Map<String, Object> configuration) {
+                this.configuration = configuration;
+                receivedMessages = new ArrayList<>();
+            }
+
+
+            @Override
+            public void start() throws Exception {
+                String topic = (String) configuration.remove("topic");
+                consumer = client
+                        .newConsumer(Schema.AUTO_CONSUME())
+                        .loadConf(configuration)
+                        .topic(topic)
+                        .subscriptionType(SubscriptionType.Failover)
+                        .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                        .ackTimeout(60000, java.util.concurrent.TimeUnit.MILLISECONDS)
+                        .subscribe();
+
+            }
+
+            @Override
+            public void close() throws Exception {
+                if (consumer != null) {
+                    consumer.close();
+                }
+            }
+
+            @Override
+            public List<Record> read() throws Exception {
+                Message<GenericRecord> receive = consumer.receive(1, TimeUnit.SECONDS);
+                if (receive == null) {
+                    return List.of();
+                }
+                receivedMessages.add(receive.getMessageId());
+
+                Object key = receive.getKey();
+                Object value = receive.getValue().getNativeObject();
+                if (value instanceof KeyValue<?,?> kv) {
+                    key = kv.getKey();
+                    value = kv.getValue();
+                }
+
+                final Object finalKey = key;
+                final Object finalValue = value;
+                log.info("Received message: {}", receive);
+                return List.of(new PulsarConsumerRecord(finalKey, finalValue, receive));
+            }
+
+            @Override
+            public void commit() throws Exception {
+                for (MessageId messageId : receivedMessages) {
+                    consumer.acknowledge(messageId);
+                }
+                receivedMessages.clear();
+            }
+        }
+
+        private class PulsarTopicProducer  <K> implements TopicProducer {
+
+            private final Map<String, Object> configuration;
+            Producer<K> producer;
+            Schema<K> schema;
+
+            public PulsarTopicProducer(Map<String, Object> configuration) {
+                this.configuration = configuration;
+            }
+
+            @Override
+            @SneakyThrows
+            public void start() {
+                // TODO: handle schema
+                String topic = (String) configuration.remove("topic");
+                schema = (Schema<K>) configuration.remove("schema");
+                if (schema == null) {
+                    schema = (Schema) Schema.BYTES;
+                }
+                producer = client.newProducer(schema)
+                        .topic(topic)
+                        .loadConf(configuration)
+                        .create();
+            }
+
+            @Override
+            @SneakyThrows
+            public void close() {
+                if (producer != null) {
+                    producer.close();
+                }
+            }
+
+            @Override
+            public void write(List<Record> records) {
+                List<CompletableFuture<?>> handles = new ArrayList<>();
+                for (Record r : records) {
+                    log.info("Writing message {}", r);
+                    // TODO: handle KV
+                    handles.add(producer.newMessage()
+                            .key(r.key() != null ? r.key().toString() : null)
+                            .value(convertValue(r))
+                            .properties(r
+                                    .headers()
+                                    .stream()
+                                    .collect(Collectors.toMap(Header::key, h -> {
+                                        return h.value() != null ? h.value().toString() : null;
+                                    })))
+                            .sendAsync());
+                }
+                CompletableFuture.allOf(handles.toArray(new CompletableFuture[0])).join();
+            }
+
+            private K convertValue(Record r) {
+                Object value = r.value();
+                if (value == null) {
+                    return null;
+                }
+                switch (schema.getSchemaInfo().getType()) {
+                    case BYTES:
+                        if (value instanceof byte[]) {
+                            return (K) value;
+                        }
+                        return (K) value.toString().getBytes(StandardCharsets.UTF_8);
+                    case STRING:
+                        return (K) value.toString();
+                    default:
+                        throw new IllegalArgumentException("Unsupported output schema type " + schema);
+                }
+            }
+        }
+    }
+}

--- a/pulsar/src/main/resources/META-INF/services/com.datastax.oss.sga.api.runner.topics.TopicConnectionsRuntimeProvider
+++ b/pulsar/src/main/resources/META-INF/services/com.datastax.oss.sga.api.runner.topics.TopicConnectionsRuntimeProvider
@@ -1,0 +1,1 @@
+com.datastax.oss.sga.pulsar.runner.PulsarTopicConnectionsRuntimeProvider

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -49,6 +49,13 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>sga-pulsar</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- main implementation for the AI Agents -->
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -106,6 +113,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>pulsar</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/runtime/src/test/java/com/datastax/oss/sga/pulsar/PulsarRunnerDockerTest.java
+++ b/runtime/src/test/java/com/datastax/oss/sga/pulsar/PulsarRunnerDockerTest.java
@@ -1,0 +1,194 @@
+package com.datastax.oss.sga.pulsar;
+
+import com.datastax.oss.sga.api.model.Application;
+import com.datastax.oss.sga.api.model.Connection;
+import com.datastax.oss.sga.api.model.Module;
+import com.datastax.oss.sga.api.model.TopicDefinition;
+import com.datastax.oss.sga.api.runtime.ClusterRuntimeRegistry;
+import com.datastax.oss.sga.api.runtime.ExecutionPlan;
+import com.datastax.oss.sga.api.runtime.PluginsRegistry;
+import com.datastax.oss.sga.impl.deploy.ApplicationDeployer;
+import com.datastax.oss.sga.impl.k8s.tests.KubeTestServer;
+import com.datastax.oss.sga.impl.parser.ModelBuilder;
+import com.datastax.oss.sga.runtime.agent.AgentSpec;
+import com.datastax.oss.sga.runtime.agent.PodJavaRuntime;
+import com.datastax.oss.sga.runtime.agent.RuntimePodConfiguration;
+import com.datastax.oss.sga.runtime.impl.k8s.PodAgentConfiguration;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+class PulsarRunnerDockerTest {
+
+    private static final String IMAGE = "datastax/lunastreaming-all:2.10_4.9";
+
+    private static PulsarContainer pulsarContainer;
+
+    @RegisterExtension
+    static final KubeTestServer kubeServer = new KubeTestServer();
+
+    private static PulsarAdmin admin;
+
+
+    @Test
+    public void testRunAITools() throws Exception {
+        kubeServer.spyAgentCustomResources("tenant", "step1");
+
+        Application applicationInstance = ModelBuilder
+                .buildApplicationInstance(Map.of("instance.yaml",
+                        buildInstanceYaml(),
+                        "module.yaml", """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                  - name: "output-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - name: "drop-description"
+                                    id: "step1"
+                                    type: "drop-fields"
+                                    input: "input-topic"
+                                    output: "output-topic"
+                                    configuration:
+                                      fields:
+                                        - "description"
+                                """));
+
+        ApplicationDeployer deployer = ApplicationDeployer
+                .builder()
+                .registry(new ClusterRuntimeRegistry())
+                .pluginsRegistry(new PluginsRegistry())
+                .build();
+
+        Module module = applicationInstance.getModule("module-1");
+
+        ExecutionPlan implementation = deployer.createImplementation(applicationInstance);
+        assertTrue(implementation.getConnectionImplementation(module,
+                new Connection(TopicDefinition.fromName("input-topic"))) instanceof PulsarTopic);
+
+        List<PodAgentConfiguration> customResourceDefinitions = (List<PodAgentConfiguration>) deployer.deploy("tenant", implementation);
+        Collection<String> topics = admin.topics().getList("public/default");
+        log.info("Topics {}", topics);
+        assertTrue(topics.contains("persistent://public/default/input-topic"));
+        assertTrue(topics.contains("persistent://public/default/output-topic"));
+
+        log.info("CRDS: {}", customResourceDefinitions);
+
+        assertEquals(1, customResourceDefinitions.size());
+        PodAgentConfiguration podAgentConfiguration = customResourceDefinitions.get(0);
+
+        RuntimePodConfiguration runtimePodConfiguration = new RuntimePodConfiguration(
+                podAgentConfiguration.input(),
+                podAgentConfiguration.output(),
+                new AgentSpec(AgentSpec.ComponentType.valueOf(
+                        podAgentConfiguration.agentConfiguration().componentType()),
+                        podAgentConfiguration.agentConfiguration().agentId(),
+                        "application",
+                        podAgentConfiguration.agentConfiguration().agentType(),
+                        podAgentConfiguration.agentConfiguration().configuration()),
+                applicationInstance.getInstance().streamingCluster()
+        );
+
+        try (PulsarClient client = PulsarClientUtils.buildPulsarClient(implementation.getApplication().getInstance().streamingCluster());
+             Producer<byte[]> producer = client.newProducer().topic("input-topic").create();
+             org.apache.pulsar.client.api.Consumer<byte[]> consumer = client.newConsumer().topic("output-topic").subscriptionName("test").subscribe();
+             ) {
+
+            // produce one message to the input-topic
+            producer
+                    .newMessage()
+                    .value("{\"name\": \"some name\", \"description\": \"some description\"}".getBytes(StandardCharsets.UTF_8))
+                    .key("key")
+                    .properties(Map.of("header-key", "header-value"))
+                    .send();
+            producer.flush();
+
+            PodJavaRuntime.run(runtimePodConfiguration, 5);
+
+            // receive one message from the output-topic (written by the PodJavaRuntime)
+            Message<byte[]> record = consumer.receive();
+            assertEquals("{\"name\":\"some name\"}", new String(record.getValue(), StandardCharsets.UTF_8));
+            assertEquals("header-value", record.getProperties().get("header-key"));
+        }
+
+    }
+
+    private static String buildInstanceYaml() {
+        return """
+                instance:
+                  computeCluster:
+                    type: "kubernetes"
+                  streamingCluster:
+                    type: "pulsar"
+                    configuration:                                      
+                      admin: 
+                        serviceUrl: "%s"
+                      service: 
+                        serviceUrl: "%s"
+                      defaultTenant: "public"
+                      defaultNamespace: "default"
+                """.formatted("http://localhost:" + pulsarContainer.getMappedPort(8080),
+                "pulsar://localhost:" + pulsarContainer.getMappedPort(6650));
+    }
+
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        pulsarContainer = new PulsarContainer(DockerImageName.parse(IMAGE)
+                .asCompatibleSubstituteFor("apachepulsar/pulsar"))
+                .withFunctionsWorker()
+                .withStartupTimeout(Duration.ofSeconds(120)) // Mac M1 is slow with Intel docker images
+                .withLogConsumer(new Consumer<OutputFrame>() {
+                    @Override
+                    public void accept(OutputFrame outputFrame) {
+                        log.info("pulsar> {}", outputFrame.getUtf8String().trim());
+                    }
+                });
+        // start Pulsar and wait for it to be ready to accept requests
+        pulsarContainer.start();
+        admin =
+                PulsarAdmin.builder()
+                        .serviceHttpUrl(
+                                "http://localhost:" + pulsarContainer.getMappedPort(8080))
+                        .build();
+
+        try {
+            admin.namespaces().createNamespace("public/default");
+        } catch (PulsarAdminException.ConflictException exists) {
+            // ignore
+        }
+    }
+
+    @AfterAll
+    public static void teardown() {
+        if (admin != null) {
+            admin.close();
+        }
+        if (pulsarContainer != null) {
+            pulsarContainer.close();
+        }
+    }
+}


### PR DESCRIPTION
This patch adds a minimal implementation for supporting Pulsar Topic while running on the K8S runtime.
This implementation is "minimal" because it is missing full support for Schema management.
Using Pulsar Topic + Pulsar IO allows you to exploit the most powerful features of Pulsar.
With this patch we are using Pulsar as Kafka: Failover subscription + very little support for Schema.

Summary:
- provide a basic implementation of TopicConnectionsProvider for Pulsar
- add integration tests using the AI ToolKit
- the Consumer uses AUTO_CONSUME, so it is very likely that this work work well enough both with schema-less topics and with topic with schema (primitive, AVRO and also KeyValue)
- this stuff works basically only with JSON and without setting a Schema on the Pulsar Topic on the Output Topic
