### PR TITLE
Fix app secrets management on app deletion

### DIFF
--- a/helm/sga/templates/deployer/deployer-configmap.yaml
+++ b/helm/sga/templates/deployer/deployer-configmap.yaml
@@ -22,7 +22,8 @@ metadata:
   labels:
     {{- include "sga.deployerLabels" . | nindent 4 }}
 data:
-  DEPLOYER_AGENT_RESOURCES: {{ .Values.deployer.app.config.agentResources }}
+  DEPLOYER_AGENT_RESOURCES: |
+{{ .Values.deployer.app.config.agentResources | toYaml | indent 4 }}
   DEPLOYER_CLUSTER_RUNTIME: |
 {{ .Values.deployer.app.config.clusterRuntime | toYaml | indent 4 }}
   DEPLOYER_CODE_STORAGE: |

--- a/k8s-deployer/k8s-deployer-core/src/main/java/com/datastax/oss/sga/deployer/k8s/agents/AgentResourcesFactory.java
+++ b/k8s-deployer/k8s-deployer-core/src/main/java/com/datastax/oss/sga/deployer/k8s/agents/AgentResourcesFactory.java
@@ -182,9 +182,9 @@ public class AgentResourcesFactory {
                                                                   final String tenant,
                                                                   final PodAgentConfiguration podAgentConfiguration) {
         final AgentCustomResource agentCR = new AgentCustomResource();
-        final String agentName = "%s-%s".formatted(applicationId, agentId);
+        final String agentName = getAgentCustomResourceName(applicationId, agentId);
         agentCR.setMetadata(new ObjectMetaBuilder()
-                .withName(sanitizeName(agentName))
+                .withName(agentName)
                 .withLabels(getAgentLabels(agentId, applicationId))
                 .build());
         agentCR.setSpec(AgentSpec.builder()
@@ -193,6 +193,11 @@ public class AgentResourcesFactory {
                 .configuration(SerializationUtil.writeAsJson(podAgentConfiguration))
                 .build());
         return agentCR;
+    }
+
+    public static String getAgentCustomResourceName(String applicationId, String agentId) {
+        final String agentName = "%s-%s".formatted(applicationId, agentId);
+        return sanitizeName(agentName);
     }
 
 

--- a/k8s-deployer/k8s-deployer-operator/src/main/java/com/datastax/oss/sga/deployer/k8s/ResolvedDeployerConfiguration.java
+++ b/k8s-deployer/k8s-deployer-operator/src/main/java/com/datastax/oss/sga/deployer/k8s/ResolvedDeployerConfiguration.java
@@ -1,0 +1,28 @@
+package com.datastax.oss.sga.deployer.k8s;
+
+import com.datastax.oss.sga.deployer.k8s.agents.AgentResourceUnitConfiguration;
+import com.datastax.oss.sga.deployer.k8s.util.SerializationUtil;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.smallrye.config.WithDefault;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Map;
+import lombok.Getter;
+
+@ApplicationScoped
+public class ResolvedDeployerConfiguration {
+
+    public ResolvedDeployerConfiguration(DeployerConfiguration configuration) {
+        this.clusterRuntime = SerializationUtil.readYaml(configuration.clusterRuntime(), Map.class);
+        this.codeStorage = SerializationUtil.readYaml(configuration.codeStorage(), Map.class);
+        this.agentResources = SerializationUtil.readYaml(configuration.agentResources(), AgentResourceUnitConfiguration.class);
+    }
+
+    @Getter
+    private Map<String, Object> clusterRuntime;
+
+    @Getter
+    private Map<String, Object> codeStorage;
+
+    @Getter
+    private AgentResourceUnitConfiguration agentResources;
+}

--- a/k8s-deployer/k8s-deployer-operator/src/main/java/com/datastax/oss/sga/deployer/k8s/controllers/apps/AppController.java
+++ b/k8s-deployer/k8s-deployer-operator/src/main/java/com/datastax/oss/sga/deployer/k8s/controllers/apps/AppController.java
@@ -62,9 +62,7 @@ public class AppController extends BaseController<ApplicationCustomResource> imp
                 .get();
         if (currentJob == null || areSpecChanged(application)) {
             createJob(application, delete);
-            if (delete) {
-                application.getStatus().setStatus(ApplicationLifecycleStatus.DELETING);
-            } else {
+            if (!delete) {
                 application.getStatus().setStatus(ApplicationLifecycleStatus.DEPLOYING);
             }
             return true;
@@ -82,14 +80,7 @@ public class AppController extends BaseController<ApplicationCustomResource> imp
 
     @SneakyThrows
     private void createJob(ApplicationCustomResource applicationCustomResource, boolean delete) {
-
-        final Map<String, Object> clusterRuntime;
-        if (configuration.clusterRuntime() == null) {
-            clusterRuntime = Map.of();
-        } else {
-            clusterRuntime = SerializationUtil.readYaml(configuration.clusterRuntime(), Map.class);
-        }
-        final Job job = AppResourcesFactory.generateJob(applicationCustomResource, clusterRuntime, delete);
+        final Job job = AppResourcesFactory.generateJob(applicationCustomResource, configuration.getClusterRuntime(), delete);
         KubeUtil.patchJob(client, job);
     }
 

--- a/k8s-runtime/k8s-runtime-core/src/test/java/com/datastax/oss/sga/runtime/impl/k8s/KubernetesClusterRuntimeDockerTest.java
+++ b/k8s-runtime/k8s-runtime-core/src/test/java/com/datastax/oss/sga/runtime/impl/k8s/KubernetesClusterRuntimeDockerTest.java
@@ -93,6 +93,9 @@ class KubernetesClusterRuntimeDockerTest {
                 + ".servers\":\"PLAINTEXT://localhost:%d\"}}},\"codeStorage\":{\"codeStorageArchiveId\":null}}")
                 .formatted(kafkaContainer.getFirstMappedPort()), agent.getSpec().getConfiguration());
 
+        deployer.delete(tenant, implementation, null);
+        assertEquals(0, agentsCRs.size());
+
 
     }
 

--- a/k8s-storage/src/test/java/com/datastax/oss/sga/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
+++ b/k8s-storage/src/test/java/com/datastax/oss/sga/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
@@ -1,0 +1,83 @@
+package com.datastax.oss.sga.impl.storage.k8s.apps;
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.datastax.oss.sga.api.model.Application;
+import com.datastax.oss.sga.api.model.Secrets;
+import com.datastax.oss.sga.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import com.datastax.oss.sga.impl.k8s.tests.KubeK3sServer;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.Secret;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+class KubernetesApplicationStoreTest {
+
+    @RegisterExtension
+    static final KubeK3sServer k3s = new KubeK3sServer(true);
+
+    @Test
+    void testApp() {
+
+        final KubernetesApplicationStore store = new KubernetesApplicationStore();
+        store.initialize(Map.of("namespaceprefix", "s", "deployer-runtime", Map.of("image", "busybox", "image-pull-policy", "IfNotPresent")));
+
+        store.onTenantCreated("mytenant");
+        assertNotNull(k3s.getClient().namespaces().withName("smytenant").get());
+
+        final Application app = new Application();
+        app.setSecrets(new Secrets(Map.of("mysecret", new com.datastax.oss.sga.api.model.Secret("mysecret", "My secret", Map.of("token", "xxx")))));
+        store.put("mytenant", "myapp", app, "code-1");
+        final ApplicationCustomResource createdCr =
+                k3s.getClient().resources(ApplicationCustomResource.class)
+                        .inNamespace("smytenant")
+                        .withName("myapp")
+                        .get();
+
+        assertEquals("IfNotPresent", createdCr.getSpec().getImagePullPolicy());
+        assertEquals("{\"resources\":{},\"modules\":{},\"instance\":null}", createdCr.getSpec().getApplication());
+        assertEquals("busybox", createdCr.getSpec().getImage());
+        assertEquals("mytenant", createdCr.getSpec().getTenant());
+
+
+        final Secret createdSecret = k3s.getClient().secrets()
+                .inNamespace("smytenant")
+                .withName("myapp")
+                .get();
+
+        final OwnerReference ownerReference = createdSecret.getMetadata().getOwnerReferences().get(0);
+        assertEquals("myapp", ownerReference.getName());
+        assertEquals(createdCr.getKind(), ownerReference.getKind());
+        assertEquals(createdCr.getApiVersion(), ownerReference.getApiVersion());
+        assertEquals(createdCr.getMetadata().getUid(), ownerReference.getUid());
+        assertTrue(ownerReference.getBlockOwnerDeletion());
+        assertTrue(ownerReference.getController());
+        assertEquals("eyJzZWNyZXRzIjp7Im15c2VjcmV0Ijp7ImlkIjoibXlzZWNyZXQiLCJuYW1lIjoiTXkgc2VjcmV0IiwiZGF0YSI6eyJ0b2tlbiI6Inh4eCJ9fX19", createdSecret.getData().get("secrets"));
+
+        assertEquals(1, store.list("mytenant").size());
+
+        assertNotNull(store.get("mytenant", "myapp"));
+        store.delete("mytenant", "myapp");
+
+        assertNull(k3s.getClient().resources(ApplicationCustomResource.class)
+                .inNamespace("smytenant")
+                .withName("myapp")
+                .get());
+
+        // actually in the real deployment, the operator will intercept the app custom resource deletion until the cleanup job is finished
+        assertNotNull(k3s.getClient().secrets()
+                .inNamespace("smytenant")
+                .withName("myapp")
+                .get());
+
+        Awaitility.await().untilAsserted(() -> {
+            assertNull(k3s.getClient().secrets()
+                    .inNamespace("smytenant")
+                    .withName("myapp")
+                    .get());
+        });
+        store.onTenantDeleted("mytenant");
+        assertTrue(k3s.getClient().namespaces().withName("smytenant").get().isMarkedForDeletion());
+    }
+}


### PR DESCRIPTION
Currently there's a bug in the app deletion. The lifecycle should looks like:
1. Delete the app custom resource
2. Operator intercepts the CR deletion (using the finalizer)
3. Operator runs the cleanup job
4. Once the cleanup job finished, the app custom resource is being deleted
5. The app secret is deleted as it's bound to the app custom resource


But at the moment when the app CR is deleted, also the secret is deleted. This cause the cleanup job to fails 