### PR TITLE
Add some default header deserializers

### DIFF
--- a/runtime/runtime-impl/src/main/python/examples/example.yaml
+++ b/runtime/runtime-impl/src/main/python/examples/example.yaml
@@ -2,4 +2,4 @@ streamingCluster:
   type: kafka
 agent:
   configuration:
-     className: examples.example.Example
+    className: examples.example.Example

--- a/runtime/runtime-impl/src/main/python/sga_runtime/kafka_serialization.py
+++ b/runtime/runtime-impl/src/main/python/sga_runtime/kafka_serialization.py
@@ -1,0 +1,82 @@
+import struct as _struct
+
+from confluent_kafka.serialization import Serializer, SerializationError, StringSerializer, DoubleSerializer, \
+    IntegerSerializer
+
+
+class BooleanSerializer(Serializer):
+    """
+    Serializes bool to boolean bytes.
+
+    See Also:
+        `BooleanSerializer Javadoc <https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/serialization/BooleanSerializer.java>`_
+    """  # noqa: E501
+
+    def __call__(self, obj, ctx=None):
+        """
+        Serializes bool as boolean bytes.
+
+        Args:
+            obj (object): object to be serialized
+
+            ctx (SerializationContext): Metadata pertaining to the serialization
+                operation
+
+        Note:
+            None objects are represented as Kafka Null.
+
+        Raises:
+            SerializerError if an error occurs during serialization
+
+        Returns:
+            boolean bytes if obj is not None, else None
+        """
+
+        if obj is None:
+            return None
+
+        return b'\x01' if obj else b'\x00'
+
+
+class LongSerializer(Serializer):
+    """
+    Serializes int to int32 bytes.
+
+    See Also:
+        `LongSerializer Javadoc <https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/serialization/LongSerializer.java>`_
+    """  # noqa: E501
+
+    def __call__(self, obj, ctx=None):
+        """
+        Serializes int as int64 bytes.
+
+        Args:
+            obj (object): object to be serialized
+
+            ctx (SerializationContext): Metadata pertaining to the serialization
+                operation
+
+        Note:
+            None objects are represented as Kafka Null.
+
+        Raises:
+            SerializerError if an error occurs during serialization
+
+        Returns:
+            int64 bytes if obj is not None, else None
+        """
+
+        if obj is None:
+            return None
+
+        try:
+            return _struct.pack('>q', obj)
+        except _struct.error as e:
+            raise SerializationError(str(e))
+
+
+STRING_SERIALIZER = StringSerializer()
+DOUBLE_SERIALIZER = DoubleSerializer()
+INTEGER_SERIALIZER = IntegerSerializer()
+LONG_SERIALIZER = LongSerializer()
+BOOLEAN_SERIALIZER = BooleanSerializer()

--- a/runtime/runtime-impl/src/main/python/sga_runtime/record.py
+++ b/runtime/runtime-impl/src/main/python/sga_runtime/record.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+from typing import Any, List, Tuple
+
+
+class AbstractRecord(ABC):
+    @abstractmethod
+    def key(self):
+        pass
+
+    @abstractmethod
+    def value(self):
+        pass
+
+    @abstractmethod
+    def origin(self) -> str:
+        pass
+
+    @abstractmethod
+    def timestamp(self) -> int:
+        pass
+
+    @abstractmethod
+    def headers(self) -> List[Tuple[str, Any]]:
+        pass
+
+
+class Record(AbstractRecord):
+    def __init__(self, value, key=None, origin: str = None, timestamp: int = None,
+                 headers: List[Tuple[str, Any]] = None):
+        self._value = value
+        self._key = key
+        self._origin = origin
+        self._timestamp = timestamp
+        self._headers = headers or []
+
+    def key(self):
+        return self._key
+
+    def value(self):
+        return self._value
+
+    def origin(self) -> str:
+        return self._origin
+
+    def timestamp(self) -> int:
+        return self._timestamp
+
+    def headers(self) -> List[Tuple[str, Any]]:
+        return self._headers
+
+    def __str__(self):
+        return f"Record(value={self._value}, key={self._key}, origin={self._origin}, timestamp={self._timestamp}, " \
+               f"headers={self._headers})"

--- a/runtime/runtime-impl/src/main/python/sga_runtime/topic_connections_registry.py
+++ b/runtime/runtime-impl/src/main/python/sga_runtime/topic_connections_registry.py
@@ -12,5 +12,5 @@ def get_topic_connections_runtime(streaming_cluster):
     streaming_cluster_type = streaming_cluster['type']
 
     if streaming_cluster_type not in TOPIC_CONNECTIONS_RUNTIME:
-        raise ValueError(f'No TopicConnectionsRuntimeProvider found for type {streaming_cluster_type}')
+        raise ValueError(f'No topic connection found for type {streaming_cluster_type}')
     return TOPIC_CONNECTIONS_RUNTIME[streaming_cluster_type]


### PR DESCRIPTION
This PR also introduces an AbstractRecord "interface" and a Record class for user convenience.
So although not strictly required (we are in Python and type checking would happen only at runtime anyway), users should return classes that derive from AbstractRecord or use the Record value object directly.
AbstractRecord and Record have type hints to show warnings in the IDE if the values they receive are detected to be of the wrong type.