### PR TITLE
Implement Language Detector

### DIFF
--- a/agents/tika/pom.xml
+++ b/agents/tika/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
+      <artifactId>tika-langdetect-tika</artifactId>
+      <version>2.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
       <version>2.8.0</version>
       <type>pom</type>

--- a/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/LanguageDetectorAgent.java
+++ b/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/LanguageDetectorAgent.java
@@ -1,0 +1,54 @@
+package com.dastastax.oss.sga.agents.tika;
+
+import com.datastax.oss.sga.api.runner.code.AgentContext;
+import com.datastax.oss.sga.api.runner.code.Record;
+import com.datastax.oss.sga.api.runner.code.SimpleRecord;
+import com.datastax.oss.sga.api.runner.code.SingleRecordAgentFunction;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tika.langdetect.tika.LanguageIdentifier;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class LanguageDetectorAgent extends SingleRecordAgentFunction {
+
+    private String field = "language";
+
+    @Override
+    public void init(Map<String, Object> configuration) throws Exception {
+        if (configuration.containsKey("field")) {
+            field = (String) configuration.get("field");
+        }
+    }
+
+    @Override
+    public void setContext(AgentContext context) throws Exception {
+    }
+    @Override
+    public void start() throws Exception {
+
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+
+    @Override
+    public List<Record> processRecord(Record record) throws Exception {
+        if (record == null) {
+            return List.of();
+        }
+        String inputText = Utils.toText(record.value());
+
+        LanguageIdentifier identifier = new LanguageIdentifier(inputText);
+        String language = identifier.getLanguage();
+
+        Record result = SimpleRecord
+                .copyFrom(record)
+                .headers(Utils.addHeader(record.headers(), SimpleRecord.SimpleHeader.of(field, language)))
+                .build();
+
+        return List.of(result);
+    }
+}

--- a/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/TikaAgentsCodeProvider.java
+++ b/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/TikaAgentsCodeProvider.java
@@ -9,7 +9,8 @@ import java.util.function.Supplier;
 public class TikaAgentsCodeProvider implements AgentCodeProvider {
 
     private static Map<String, Supplier<SingleRecordAgentFunction>> FACTORIES = Map.of(
-            "text-extractor", () -> new TikaTextExtractorAgent()
+            "text-extractor", () -> new TikaTextExtractorAgent(),
+            "language-detector", () -> new LanguageDetectorAgent()
     );
 
     @Override

--- a/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/TikaTextExtractorAgent.java
+++ b/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/TikaTextExtractorAgent.java
@@ -48,12 +48,7 @@ public class TikaTextExtractorAgent extends SingleRecordAgentFunction {
         }
         AutoDetectParser parser = new AutoDetectParser();
         Object value = record.value();
-        final InputStream stream;
-        if (value instanceof byte[] array) {
-            stream = new ByteArrayInputStream(array);
-        } else {
-            stream = new ByteArrayInputStream(value.toString().getBytes(StandardCharsets.UTF_8));
-        }
+        final InputStream stream = Utils.toStream(value);
         Metadata metadata = new Metadata();
         ParseContext parseContext = new ParseContext();
         Reader reader = new ParsingReader(parser, stream, metadata, parseContext);

--- a/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/Utils.java
+++ b/agents/tika/src/main/java/com/dastastax/oss/sga/agents/tika/Utils.java
@@ -1,0 +1,43 @@
+package com.dastastax.oss.sga.agents.tika;
+
+import com.datastax.oss.sga.api.runner.code.Header;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class Utils {
+    public static InputStream toStream(Object value) {
+        final InputStream stream;
+        if (value instanceof byte[] array) {
+            stream = new ByteArrayInputStream(array);
+        } else {
+            stream = new ByteArrayInputStream(value.toString().getBytes(StandardCharsets.UTF_8));
+        }
+        return stream;
+    }
+
+    public static String toText(Object value) {
+
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof byte[] array) {
+            return new String(array, StandardCharsets.UTF_8);
+        } else {
+            return value.toString();
+        }
+    }
+
+    public static List<Header> addHeader(Collection<Header> headers, Header newHeader) {
+        if (headers == null || headers.isEmpty()) {
+            return List.of(newHeader);
+        }
+        List<Header> result = new ArrayList<>(headers);
+        result.add(newHeader);
+        return result;
+    }
+}

--- a/agents/tika/src/test/java/com/datastax/oss/sga/agents/tika/LanguageDetectorTest.java
+++ b/agents/tika/src/test/java/com/datastax/oss/sga/agents/tika/LanguageDetectorTest.java
@@ -1,0 +1,49 @@
+package com.datastax.oss.sga.agents.tika;
+
+import com.dastastax.oss.sga.agents.tika.TikaAgentsCodeProvider;
+import com.datastax.oss.sga.api.runner.code.Record;
+import com.datastax.oss.sga.api.runner.code.SimpleRecord;
+import com.datastax.oss.sga.api.runner.code.SingleRecordAgentFunction;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+public class LanguageDetectorTest {
+
+    @Test
+    public void textDetect() throws Exception {
+        TikaAgentsCodeProvider provider = new TikaAgentsCodeProvider();
+        SingleRecordAgentFunction instance = provider.createInstance("language-detector");
+        instance.init(Map.of("field", "detected-language"));
+
+
+        assertEquals("en", detectLanguage(instance, "This is a English"));
+        assertEquals("it", detectLanguage(instance, "Questo é italiano"));
+        assertEquals("fr", detectLanguage(instance, "Parlez-vous français?"));
+
+    }
+
+    @NotNull
+    private static String detectLanguage(SingleRecordAgentFunction instance, String text) throws Exception {
+        Record fromSource = SimpleRecord
+                .builder()
+                .key("filename.txt")
+                .value(text.getBytes(StandardCharsets.UTF_8))
+                .origin("origin")
+                .timestamp(System.currentTimeMillis())
+                .build();
+
+        Record result = instance.processRecord(fromSource).get(0);
+        log.info("Result: {}", result);
+        return result.getHeader("detected-language").value().toString();
+    }
+
+}

--- a/api/src/main/java/com/datastax/oss/sga/api/runner/code/Record.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/code/Record.java
@@ -7,4 +7,10 @@ public interface Record {
     String origin();
     Long timestamp();
     Collection<Header> headers();
+
+    default Header getHeader(String key) {
+        return headers()
+                .stream()
+                .filter(h -> h.key().equals(key)).findFirst().orElse(null);
+    }
 }

--- a/api/src/main/java/com/datastax/oss/sga/api/runner/code/SimpleRecord.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/code/SimpleRecord.java
@@ -1,5 +1,6 @@
 package com.datastax.oss.sga.api.runner.code;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -43,5 +44,41 @@ public final class SimpleRecord implements Record {
     @Override
     public Collection<Header> headers() {
         return headers;
+    }
+
+    /**
+     * Copy all fields from {@link Record} to new {@link SimpleRecordBuilder}.
+     * @param record
+     * @return
+     */
+    public static SimpleRecordBuilder copyFrom(Record record) {
+        return builder()
+                .key(record.key())
+                .value(record.value())
+                .origin(record.origin())
+                .headers(record.headers())
+                .timestamp(record.timestamp());
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class SimpleHeader implements Header {
+
+        public static SimpleHeader of(String key, String value) {
+            return new SimpleHeader(key, value);
+        }
+
+        final String key;
+        final String value;
+
+        @Override
+        public String key() {
+            return key;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
     }
 }


### PR DESCRIPTION
Summary:
- implement a new Tika Based Language detector
- the agent adds an header that contains the classification for the language (see here https://www.javatpoint.com/tika-language-detection#:~:text=Tika%20can%20identify%20language%20of,matching%20ISO%20639%20language%20code.)


Once you have set the language in the header then you can use the "drop" agent to drop messages that doesn't appear to be usable for your application (for instance non-English documents) 