### PR TITLE
Refactor: extract the Merging of Agents into an ExecutionPlanOptimizer abstraction

### DIFF
--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/AgentNodeProvider.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/AgentNodeProvider.java
@@ -32,15 +32,4 @@ public interface AgentNodeProvider {
      */
     boolean supports(String type, ComputeClusterRuntime clusterRuntime);
 
-    /**
-     * Returns the ability of an Agent to be merged with the previous version.
-     * @return true if the agents can be merged
-     */
-    default boolean canMerge(AgentNode previousAgent, AgentNode agentImplementation) {
-        return false;
-    }
-
-    default AgentNode mergeAgents(AgentNode previousAgent, AgentNode agentImplementation, ExecutionPlan instance) {
-        throw new UnsupportedOperationException("This provider cannot merge agents");
-    }
 }

--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/ComputeClusterRuntime.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/ComputeClusterRuntime.java
@@ -20,6 +20,7 @@ import com.datastax.oss.sga.api.model.Application;
 import com.datastax.oss.sga.api.model.Module;
 import com.datastax.oss.sga.api.model.Pipeline;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -60,6 +61,8 @@ public interface ComputeClusterRuntime extends AutoCloseable {
 
     void delete(String tenant, ExecutionPlan applicationInstance, StreamingClusterRuntime streamingClusterRuntime,
                 String codeStorageArchiveId);
+
+    List<ExecutionPlanOptimiser> getExecutionPlanOptimisers();
 
     default AgentNodeMetadata computeAgentMetadata(AgentConfiguration agentConfiguration, ExecutionPlan physicalApplicationInstance, StreamingClusterRuntime streamingClusterRuntime) {
         return null;

--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/ExecutionPlanOptimiser.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/ExecutionPlanOptimiser.java
@@ -1,0 +1,14 @@
+package com.datastax.oss.sga.api.runtime;
+
+/**
+ * Optimises the execution plan of a Pipeline.
+ */
+public interface ExecutionPlanOptimiser {
+    /**
+     * Returns the ability of an Agent to be merged with the previous version.
+     * @return true if the agents can be merged
+     */
+    boolean canMerge(AgentNode previousAgent, AgentNode agentImplementation);
+
+    AgentNode mergeAgents(AgentNode previousAgent, AgentNode agentImplementation, ExecutionPlan instance);
+}

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/AbstractComposableAgentProvider.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/AbstractComposableAgentProvider.java
@@ -1,0 +1,33 @@
+package com.datastax.oss.sga.impl.agents;
+
+import com.datastax.oss.sga.api.model.AgentConfiguration;
+import com.datastax.oss.sga.api.runtime.AgentNode;
+import com.datastax.oss.sga.api.runtime.ComponentType;
+import com.datastax.oss.sga.api.runtime.ExecutionPlan;
+import com.datastax.oss.sga.api.runtime.ExecutionPlanOptimiser;
+import com.datastax.oss.sga.impl.common.AbstractAgentProvider;
+import com.datastax.oss.sga.impl.common.DefaultAgentNode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implements support for agents that can be composed into a single Composable Agent.
+ */
+@Slf4j
+public abstract class AbstractComposableAgentProvider extends AbstractAgentProvider {
+
+    public AbstractComposableAgentProvider(Set<String> supportedTypes, List<String> supportedRuntimes) {
+        super(supportedTypes, supportedRuntimes);
+    }
+
+    @Override
+    protected boolean isComposable(AgentConfiguration agentConfiguration) {
+        return true;
+    }
+
+}

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/AbstractCompositeAgentProvider.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/AbstractCompositeAgentProvider.java
@@ -1,4 +1,4 @@
-package com.datastax.oss.sga.runtime.impl.k8s.agents;
+package com.datastax.oss.sga.impl.agents;
 
 import com.datastax.oss.sga.api.model.AgentConfiguration;
 import com.datastax.oss.sga.api.runtime.ComponentType;
@@ -8,8 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 import java.util.Set;
 
-import static com.datastax.oss.sga.runtime.impl.k8s.KubernetesClusterRuntime.CLUSTER_TYPE;
-
 /**
  * Implements support for processors that can be executed in memory into a single pipeline.
  * This is a special processor that executes a pipeline of Agents in memory.
@@ -17,14 +15,14 @@ import static com.datastax.oss.sga.runtime.impl.k8s.KubernetesClusterRuntime.CLU
  * It is created internally by the planner.
  */
 @Slf4j
-public class CompositeAgentProvider extends AbstractAgentProvider {
+public abstract class AbstractCompositeAgentProvider extends AbstractAgentProvider {
 
     public static final String AGENT_TYPE = "composite-agent";
 
     private static final Set<String> SUPPORTED_AGENT_TYPES = Set.of(AGENT_TYPE);
 
-    public CompositeAgentProvider() {
-        super(SUPPORTED_AGENT_TYPES, List.of(CLUSTER_TYPE, "none"));
+    public AbstractCompositeAgentProvider(List<String> clusterRuntimes) {
+        super(SUPPORTED_AGENT_TYPES, clusterRuntimes);
     }
 
     @Override

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/ComposableAgentExecutionPlanOptimiser.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/ComposableAgentExecutionPlanOptimiser.java
@@ -1,10 +1,9 @@
-package com.datastax.oss.sga.runtime.impl.k8s.agents;
+package com.datastax.oss.sga.impl.agents;
 
-import com.datastax.oss.sga.api.model.AgentConfiguration;
 import com.datastax.oss.sga.api.runtime.AgentNode;
 import com.datastax.oss.sga.api.runtime.ComponentType;
 import com.datastax.oss.sga.api.runtime.ExecutionPlan;
-import com.datastax.oss.sga.impl.common.AbstractAgentProvider;
+import com.datastax.oss.sga.api.runtime.ExecutionPlanOptimiser;
 import com.datastax.oss.sga.impl.common.DefaultAgentNode;
 import lombok.extern.slf4j.Slf4j;
 
@@ -12,26 +11,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-/**
- * Implements support for agents that can be composed into a single Composable Agent.
- */
 @Slf4j
-public abstract class AbstractComposableAgentProvider extends AbstractAgentProvider {
-
-    public AbstractComposableAgentProvider(Set<String> supportedTypes, List<String> supportedRuntimes) {
-        super(supportedTypes, supportedRuntimes);
-    }
-
-    @Override
-    protected boolean isComposable(AgentConfiguration agentConfiguration) {
-        return true;
-    }
+public final class ComposableAgentExecutionPlanOptimiser implements ExecutionPlanOptimiser {
 
     @Override
     public boolean canMerge(AgentNode previousAgent, AgentNode agentImplementation) {
-        boolean result =  (previousAgent instanceof DefaultAgentNode agent1
+        boolean result = (previousAgent instanceof DefaultAgentNode agent1
                 && agent1.isComposable()
                 && agentImplementation instanceof DefaultAgentNode agent2
                 && agent2.isComposable());
@@ -46,7 +32,7 @@ public abstract class AbstractComposableAgentProvider extends AbstractAgentProvi
         if (previousAgent instanceof DefaultAgentNode agent1
                 && agentImplementation instanceof DefaultAgentNode agent2) {
 
-            if (agent1.getAgentType().equals(CompositeAgentProvider.AGENT_TYPE)) {
+            if (agent1.getAgentType().equals(AbstractCompositeAgentProvider.AGENT_TYPE)) {
                 // merge "composite-agent" with a Composable Agent
 
                 Map<String, Object> configurationAgent2 = new HashMap<>();
@@ -73,7 +59,7 @@ public abstract class AbstractComposableAgentProvider extends AbstractAgentProvi
 
                 log.info("Discarding topic {}", agent1.getOutputConnection());
                 instance.discardTopic(agent1.getOutputConnection());
-                agent1.overrideConfigurationAfterMerge(CompositeAgentProvider.AGENT_TYPE, newAgent1Configuration, agent2.getOutputConnection());
+                agent1.overrideConfigurationAfterMerge(AbstractCompositeAgentProvider.AGENT_TYPE, newAgent1Configuration, agent2.getOutputConnection());
             } else {
                 List<Map<String, Object>> processors = new ArrayList<>();
                 Map<String, Object> source = new HashMap<>();
@@ -115,7 +101,7 @@ public abstract class AbstractComposableAgentProvider extends AbstractAgentProvi
                     log.info("Discarding topic {}", agent1.getOutputConnection());
                     instance.discardTopic(agent1.getOutputConnection());
                 }
-                agent1.overrideConfigurationAfterMerge(CompositeAgentProvider.AGENT_TYPE, result, agent2.getOutputConnection());
+                agent1.overrideConfigurationAfterMerge(AbstractCompositeAgentProvider.AGENT_TYPE, result, agent2.getOutputConnection());
             }
             log.info("Agent 1 modified: {}", agent1);
             if (agent2.getInputConnection() != null) {

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/ai/GenAIToolKitExecutionPlanOptimizer.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/ai/GenAIToolKitExecutionPlanOptimizer.java
@@ -1,0 +1,85 @@
+package com.datastax.oss.sga.impl.agents.ai;
+
+import com.datastax.oss.sga.api.runtime.AgentNode;
+import com.datastax.oss.sga.api.runtime.ExecutionPlan;
+import com.datastax.oss.sga.api.runtime.ExecutionPlanOptimiser;
+import com.datastax.oss.sga.impl.common.DefaultAgentNode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+public final class GenAIToolKitExecutionPlanOptimizer implements ExecutionPlanOptimiser {
+
+    @Override
+    public boolean canMerge(AgentNode previousAgent, AgentNode agentImplementation) {
+        if (Objects.equals(previousAgent.getAgentType(), GenAIToolKitFunctionAgentProvider.AGENT_TYPE)
+                && Objects.equals(previousAgent.getAgentType(), agentImplementation.getAgentType())
+                && previousAgent instanceof DefaultAgentNode agent1
+                && agentImplementation instanceof DefaultAgentNode agent2) {
+            Map<String, Object> purgedConfiguration1 = new HashMap<>(agent1.getConfiguration());
+            purgedConfiguration1.remove("steps");
+            Map<String, Object> purgedConfiguration2 = new HashMap<>(agent2.getConfiguration());
+            purgedConfiguration2.remove("steps");
+
+            // test query steps with different datasources
+            Object datasource1 = purgedConfiguration1.remove("datasource");
+            Object datasource2 = purgedConfiguration2.remove("datasource");
+
+            if (datasource1 != null && datasource2 != null) {
+                log.info("Comparing datasources {} and {}", datasource1, datasource2);
+                if (!Objects.equals(datasource1, datasource2)) {
+                    log.info("Agents {} and {} cannot be merged (different datasources)",
+                            previousAgent, agentImplementation);
+                    return false;
+                }
+            }
+
+            log.info("Comparing {} and {}", purgedConfiguration1, purgedConfiguration2);
+            return purgedConfiguration1.equals(purgedConfiguration2);
+        }
+        log.info("Agents {} and {} cannot be merged", previousAgent, agentImplementation);
+        return false;
+    }
+
+    @Override
+    public AgentNode mergeAgents(AgentNode previousAgent, AgentNode agentImplementation,
+                                 ExecutionPlan applicationInstance) {
+        if (Objects.equals(previousAgent.getAgentType(), agentImplementation.getAgentType())
+                && previousAgent instanceof DefaultAgentNode agent1
+                && agentImplementation instanceof DefaultAgentNode agent2) {
+
+            log.info("Merging agents");
+            log.info("Agent 1: {}", agent1);
+            log.info("Agent 2: {}", agent2);
+
+            Map<String, Object> configurationWithoutSteps1 = new HashMap<>(agent1.getConfiguration());
+            List<Map<String, Object>> steps1 = (List<Map<String, Object>>) configurationWithoutSteps1.remove("steps");
+            Map<String, Object> configurationWithoutSteps2 = new HashMap<>(agent2.getConfiguration());
+            List<Map<String, Object>> steps2 = (List<Map<String, Object>>) configurationWithoutSteps2.remove("steps");
+
+            List<Map<String, Object>> mergedSteps = new ArrayList<>();
+            mergedSteps.addAll(steps1);
+            mergedSteps.addAll(steps2);
+
+            Map<String, Object> result = new HashMap<>();
+            result.putAll(configurationWithoutSteps1);
+            result.put("steps", mergedSteps);
+
+            log.info("Discarding topic {}", agent1.getInputConnection());
+            applicationInstance.discardTopic(agent1.getOutputConnection());
+
+            agent1.overrideConfigurationAfterMerge(agent1.getAgentType(), result, agent2.getOutputConnection());
+            log.info("Agent 1 modified: {}", agent1);
+
+            log.info("Discarding topic {}", agent2.getInputConnection());
+            applicationInstance.discardTopic(agent2.getInputConnection());
+            return previousAgent;
+        }
+        throw new IllegalStateException();
+    }
+}

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
@@ -9,6 +9,7 @@ import com.datastax.oss.sga.api.runtime.AgentNode;
 import com.datastax.oss.sga.api.runtime.ComponentType;
 import com.datastax.oss.sga.api.runtime.ComputeClusterRuntime;
 import com.datastax.oss.sga.api.runtime.ExecutionPlan;
+import com.datastax.oss.sga.api.runtime.ExecutionPlanOptimiser;
 import com.datastax.oss.sga.impl.common.AbstractAgentProvider;
 import com.datastax.oss.sga.impl.common.DefaultAgentNode;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,8 @@ import java.util.Objects;
 
 @Slf4j
 public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
+
+    public static final String AGENT_TYPE = "ai-tools";
 
     private static final Map<String, StepConfigurationInitializer> STEP_TYPES = Map.of(
 
@@ -239,74 +242,6 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
 
         generateSteps(originalConfiguration, configuration, executionPlan.getApplication(), agentConfiguration);
         return configuration;
-    }
-
-
-    @Override
-    public boolean canMerge(AgentNode previousAgent, AgentNode agentImplementation) {
-        if (Objects.equals(previousAgent.getAgentType(), agentImplementation.getAgentType())
-            && previousAgent instanceof DefaultAgentNode agent1
-            && agentImplementation instanceof DefaultAgentNode agent2) {
-                Map<String, Object> purgedConfiguration1 = new HashMap<>(agent1.getConfiguration());
-                purgedConfiguration1.remove("steps");
-                Map<String, Object> purgedConfiguration2 = new HashMap<>(agent2.getConfiguration());
-                purgedConfiguration2.remove("steps");
-
-                // test query steps with different datasources
-                Object datasource1 = purgedConfiguration1.remove("datasource");
-                Object datasource2 = purgedConfiguration2.remove("datasource");
-
-                if (datasource1 != null && datasource2 != null) {
-                    log.info("Comparing datasources {} and {}", datasource1, datasource2);
-                     if (!Objects.equals(datasource1, datasource2)) {
-                         log.info("Agents {} and {} cannot be merged (different datasources)",
-                                 previousAgent, agentImplementation);
-                         return false;
-                     }
-                }
-
-                log.info("Comparing {} and {}", purgedConfiguration1, purgedConfiguration2);
-                return purgedConfiguration1.equals(purgedConfiguration2);
-        }
-        log.info("Agents {} and {} cannot be merged", previousAgent, agentImplementation);
-        return false;
-    }
-
-    @Override
-    public AgentNode mergeAgents(AgentNode previousAgent, AgentNode agentImplementation,
-                                 ExecutionPlan applicationInstance) {
-        if (Objects.equals(previousAgent.getAgentType(), agentImplementation.getAgentType())
-                && previousAgent instanceof DefaultAgentNode agent1
-                && agentImplementation instanceof DefaultAgentNode agent2) {
-
-            log.info("Merging agents");
-            log.info("Agent 1: {}", agent1);
-            log.info("Agent 2: {}", agent2);
-
-            Map<String, Object> configurationWithoutSteps1 = new HashMap<>(agent1.getConfiguration());
-            List<Map<String, Object>> steps1 = (List<Map<String, Object>>) configurationWithoutSteps1.remove("steps");
-            Map<String, Object> configurationWithoutSteps2 = new HashMap<>(agent2.getConfiguration());
-            List<Map<String, Object>> steps2 = (List<Map<String, Object>>) configurationWithoutSteps2.remove("steps");
-
-            List<Map<String, Object>> mergedSteps = new ArrayList<>();
-            mergedSteps.addAll(steps1);
-            mergedSteps.addAll(steps2);
-
-            Map<String, Object> result = new HashMap<>();
-            result.putAll(configurationWithoutSteps1);
-            result.put("steps", mergedSteps);
-
-            log.info("Discarding topic {}", agent1.getInputConnection());
-            applicationInstance.discardTopic(agent1.getOutputConnection());
-
-            agent1.overrideConfigurationAfterMerge(agent1.getAgentType(), result, agent2.getOutputConnection());
-            log.info("Agent 1 modified: {}", agent1);
-
-            log.info("Discarding topic {}", agent2.getInputConnection());
-            applicationInstance.discardTopic(agent2.getInputConnection());
-            return previousAgent;
-        }
-        throw new IllegalStateException();
     }
 
     protected static <T> T requiredField(Map<String, Object> step, AgentConfiguration agentConfiguration, Map<String, Object> originalConfiguration, String name) {

--- a/core/src/main/java/com/datastax/oss/sga/impl/noop/NoOpComputeClusterRuntimeProvider.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/noop/NoOpComputeClusterRuntimeProvider.java
@@ -2,13 +2,22 @@ package com.datastax.oss.sga.impl.noop;
 
 import com.datastax.oss.sga.api.runtime.ComputeClusterRuntime;
 import com.datastax.oss.sga.api.runtime.ComputeClusterRuntimeProvider;
+import com.datastax.oss.sga.api.runtime.ExecutionPlanOptimiser;
+import com.datastax.oss.sga.impl.agents.AbstractCompositeAgentProvider;
+import com.datastax.oss.sga.impl.agents.ComposableAgentExecutionPlanOptimiser;
+import com.datastax.oss.sga.impl.agents.ai.GenAIToolKitExecutionPlanOptimizer;
 import com.datastax.oss.sga.impl.common.BasicClusterRuntime;
+
+import java.util.List;
 import java.util.Map;
 
 /**
  * This is a dummy implementation of a ClusterRuntimeProvider useful mostly for unit tests.
  */
 public class NoOpComputeClusterRuntimeProvider implements ComputeClusterRuntimeProvider {
+
+    public static final String CLUSTER_TYPE = "none";
+
     @Override
     public boolean supports(String type) {
         return "none".equals(type);
@@ -20,12 +29,23 @@ public class NoOpComputeClusterRuntimeProvider implements ComputeClusterRuntimeP
     }
 
     public static class NoOpClusterRuntime extends BasicClusterRuntime {
+
+        static final List<ExecutionPlanOptimiser> OPTIMISERS = List.of(
+                new GenAIToolKitExecutionPlanOptimizer(),
+                new ComposableAgentExecutionPlanOptimiser());
+
         @Override
         public String getClusterType() {
-            return "none";
+            return CLUSTER_TYPE;
         }
 
         @Override
         public void initialize(Map<String, Object> configuration) {}
+
+        @Override
+        public List<ExecutionPlanOptimiser> getExecutionPlanOptimisers() {
+            return OPTIMISERS;
+        }
     }
+
 }

--- a/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/KubernetesCompositeAgentProvider.java
+++ b/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/KubernetesCompositeAgentProvider.java
@@ -1,0 +1,13 @@
+package com.datastax.oss.sga.runtime.impl.k8s.agents;
+
+import com.datastax.oss.sga.impl.agents.AbstractCompositeAgentProvider;
+import com.datastax.oss.sga.impl.noop.NoOpComputeClusterRuntimeProvider;
+import com.datastax.oss.sga.runtime.impl.k8s.KubernetesClusterRuntime;
+
+import java.util.List;
+
+public class KubernetesCompositeAgentProvider extends AbstractCompositeAgentProvider {
+    public KubernetesCompositeAgentProvider() {
+        super(List.of(KubernetesClusterRuntime.CLUSTER_TYPE, NoOpComputeClusterRuntimeProvider.CLUSTER_TYPE));
+    }
+}

--- a/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/S3SourceAgentProvider.java
+++ b/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/S3SourceAgentProvider.java
@@ -3,7 +3,8 @@ package com.datastax.oss.sga.runtime.impl.k8s.agents;
 import static com.datastax.oss.sga.runtime.impl.k8s.KubernetesClusterRuntime.CLUSTER_TYPE;
 import com.datastax.oss.sga.api.model.AgentConfiguration;
 import com.datastax.oss.sga.api.runtime.ComponentType;
-import com.datastax.oss.sga.impl.common.AbstractAgentProvider;
+import com.datastax.oss.sga.impl.agents.AbstractComposableAgentProvider;
+
 import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;

--- a/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/TextProcessingAgentsProvider.java
+++ b/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/TextProcessingAgentsProvider.java
@@ -2,6 +2,7 @@ package com.datastax.oss.sga.runtime.impl.k8s.agents;
 
 import com.datastax.oss.sga.api.model.AgentConfiguration;
 import com.datastax.oss.sga.api.runtime.ComponentType;
+import com.datastax.oss.sga.impl.agents.AbstractComposableAgentProvider;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;

--- a/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/ai/KubernetesGenAIToolKitFunctionAgentProvider.java
+++ b/k8s-runtime/k8s-runtime-core/src/main/java/com/datastax/oss/sga/runtime/impl/k8s/agents/ai/KubernetesGenAIToolKitFunctionAgentProvider.java
@@ -6,7 +6,7 @@ import com.datastax.oss.sga.runtime.impl.k8s.KubernetesClusterRuntime;
 public class KubernetesGenAIToolKitFunctionAgentProvider extends GenAIToolKitFunctionAgentProvider {
 
     public KubernetesGenAIToolKitFunctionAgentProvider() {
-        super(KubernetesClusterRuntime.CLUSTER_TYPE, "ai-tools");
+        super(KubernetesClusterRuntime.CLUSTER_TYPE, GenAIToolKitFunctionAgentProvider.AGENT_TYPE);
     }
 
 }

--- a/k8s-runtime/k8s-runtime-core/src/main/resources/META-INF/services/com.datastax.oss.sga.api.runtime.AgentNodeProvider
+++ b/k8s-runtime/k8s-runtime-core/src/main/resources/META-INF/services/com.datastax.oss.sga.api.runtime.AgentNodeProvider
@@ -2,4 +2,4 @@ com.datastax.oss.sga.runtime.impl.k8s.agents.python.PythonCodeAgentProvider
 com.datastax.oss.sga.runtime.impl.k8s.agents.ai.KubernetesGenAIToolKitFunctionAgentProvider
 com.datastax.oss.sga.runtime.impl.k8s.agents.S3SourceAgentProvider
 com.datastax.oss.sga.runtime.impl.k8s.agents.TextProcessingAgentsProvider
-com.datastax.oss.sga.runtime.impl.k8s.agents.CompositeAgentProvider
+com.datastax.oss.sga.runtime.impl.k8s.agents.KubernetesCompositeAgentProvider

--- a/k8s-runtime/k8s-runtime-core/src/test/java/com/datastax/oss/testagents/TestGenericComposableSinkAgentProvider.java
+++ b/k8s-runtime/k8s-runtime-core/src/test/java/com/datastax/oss/testagents/TestGenericComposableSinkAgentProvider.java
@@ -1,19 +1,11 @@
 package com.datastax.oss.testagents;
 
 import com.datastax.oss.sga.api.model.AgentConfiguration;
-import com.datastax.oss.sga.api.model.Module;
-import com.datastax.oss.sga.api.model.Pipeline;
 import com.datastax.oss.sga.api.runtime.ComponentType;
-import com.datastax.oss.sga.api.runtime.ComputeClusterRuntime;
-import com.datastax.oss.sga.api.runtime.Connection;
-import com.datastax.oss.sga.api.runtime.ExecutionPlan;
-import com.datastax.oss.sga.api.runtime.Topic;
-import com.datastax.oss.sga.impl.common.AbstractAgentProvider;
 import com.datastax.oss.sga.runtime.impl.k8s.KubernetesClusterRuntime;
-import com.datastax.oss.sga.runtime.impl.k8s.agents.AbstractComposableAgentProvider;
+import com.datastax.oss.sga.impl.agents.AbstractComposableAgentProvider;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class TestGenericComposableSinkAgentProvider extends AbstractComposableAgentProvider {

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarClusterRuntime.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarClusterRuntime.java
@@ -3,7 +3,9 @@ package com.datastax.oss.sga.pulsar;
 import com.datastax.oss.sga.api.model.Application;
 import com.datastax.oss.sga.api.runtime.AgentNode;
 import com.datastax.oss.sga.api.runtime.ExecutionPlan;
+import com.datastax.oss.sga.api.runtime.ExecutionPlanOptimiser;
 import com.datastax.oss.sga.api.runtime.StreamingClusterRuntime;
+import com.datastax.oss.sga.impl.agents.ai.GenAIToolKitExecutionPlanOptimizer;
 import com.datastax.oss.sga.impl.common.BasicClusterRuntime;
 import com.datastax.oss.sga.impl.common.DefaultAgentNode;
 import com.datastax.oss.sga.pulsar.agents.PulsarAgentNodeMetadata;
@@ -25,6 +27,9 @@ public class PulsarClusterRuntime extends BasicClusterRuntime {
     static final ObjectMapper mapper = new ObjectMapper();
 
     public static final String CLUSTER_TYPE = "pulsar";
+
+    static final List<ExecutionPlanOptimiser> OPTIMISERS = List.of(
+            new GenAIToolKitExecutionPlanOptimizer());
 
     @Override
     public String getClusterType() {
@@ -204,5 +209,10 @@ public class PulsarClusterRuntime extends BasicClusterRuntime {
             }
         }
         throw new IllegalArgumentException("Unsupported Agent type " + agent.getClass().getName());
+    }
+
+    @Override
+    public List<ExecutionPlanOptimiser> getExecutionPlanOptimisers() {
+        return OPTIMISERS;
     }
 }

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/ai/PulsarGenAIToolKitFunctionAgentProvider.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/agents/ai/PulsarGenAIToolKitFunctionAgentProvider.java
@@ -13,7 +13,7 @@ import com.datastax.oss.sga.pulsar.agents.AbstractPulsarAgentProvider;
 public class PulsarGenAIToolKitFunctionAgentProvider extends GenAIToolKitFunctionAgentProvider {
 
     public PulsarGenAIToolKitFunctionAgentProvider() {
-        super(PulsarClusterRuntime.CLUSTER_TYPE, "ai-tools");
+        super(PulsarClusterRuntime.CLUSTER_TYPE, GenAIToolKitFunctionAgentProvider.AGENT_TYPE);
     }
 
     @Override


### PR DESCRIPTION
This is a clean up patch to extract the logic of "mergeAgents" to a dedicated concept and move it to the ClusterRuntime implementation.
Before this change it was the AgentNodeProvider that had the ability to "merge" agents into more optimised agents that can run multiple processing steps at a time.

Currently we have two "optimisers":
- one general purpose optimiser that is able to merges agents (that report isComposable=true), and this creates a single "composite-agent", that can include one source, N processors and one sink
- one special optimiser that is able to merge all the agents that are part of the GenAI ToolKit, that formerly was a Pulsar Function (child of the DataStax Pulsar Transformations function)

