### PR TITLE
Add compute-embeddings to the Text Processing Pipeline

### DIFF
--- a/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TextNormaliserAgent.java
+++ b/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TextNormaliserAgent.java
@@ -50,7 +50,7 @@ public class TextNormaliserAgent extends SingleRecordAgentProcessor {
             stream = stream.trim();
         }
         return List.of(SimpleRecord
-                .builder()
+                .copyFrom(record)
                 .value(stream)
                 .build());
 

--- a/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TikaTextExtractorAgent.java
+++ b/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TikaTextExtractorAgent.java
@@ -57,12 +57,8 @@ public class TikaTextExtractorAgent extends SingleRecordAgentProcessor {
                     .collect(Collectors.toMap(Function.identity(), metadata::get)), valueAsString);
             reader.transferTo(valueAsString);
             return List.of(SimpleRecord
-                    .builder()
-                    .key(record.key())
+                    .copyFrom(record)
                     .value(valueAsString.toString())
-                    .origin(record.origin())
-                    .timestamp(record.timestamp())
-                    .headers(record.headers())
                     .build());
         } finally {
             reader.close();

--- a/examples/applications/text-processing/configuration.yaml
+++ b/examples/applications/text-processing/configuration.yaml
@@ -1,1 +1,8 @@
 configuration:
+  resources:
+  - type: "open-ai-configuration"
+    name: "OpenAI Azure configuration"
+    configuration:
+      url: "{{ secrets.open-ai.url }}"
+      access-key: "{{ secrets.open-ai.access-key }}"
+      provider: "azure"

--- a/examples/applications/text-processing/pipeline.yaml
+++ b/examples/applications/text-processing/pipeline.yaml
@@ -34,9 +34,21 @@ pipeline:
       length_function: "cl100k_base"
   - name: "Convert to structured data"
     type: "document-to-json"
-    output: "output-topic"
     configuration:
         text-field: text
         copy-properties: true
-
-
+  - name: "prepare-structure"
+    type: "compute"
+    configuration:
+      fields:
+         - name: "value.filename"
+           expression: "properties.name"
+           type: STRING
+  - name: "compute-embeddings"
+    id: "step1"
+    type: "compute-ai-embeddings"
+    output: "output-topic"
+    configuration:
+      model: "text-embedding-ada-002" # This needs to match the name of the model deployment, not the base model
+      embeddings-field: "value.item-vector"
+      text: "{{% value.text }}"


### PR DESCRIPTION
Summary:
- fix a couple of glitches in the Text Extraxtion agents (some properties were not copied)
- enhance the text processing example pipeline with a "compute" and a "compute-ai-embeddings" agents