### PR TITLE
Allow to explicly set a topic between two agents

### DIFF
--- a/api/src/main/java/com/datastax/oss/sga/api/model/TopicDefinition.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/model/TopicDefinition.java
@@ -37,12 +37,13 @@ public class TopicDefinition  {
     }
 
     public static TopicDefinition fromName(String name) {
-        return new TopicDefinition(name, CREATE_MODE_NONE, 0, null, null, Map.of(), Map.of());
+        return new TopicDefinition(name, CREATE_MODE_NONE,false, 0, null, null, Map.of(), Map.of());
     }
 
 
     public TopicDefinition(String name,
                            String creationMode,
+                           boolean implicit,
                            int partitions,
                            SchemaDefinition keySchema,
                            SchemaDefinition valueSchema,
@@ -55,6 +56,7 @@ public class TopicDefinition  {
         } else {
             this.creationMode = creationMode;
         }
+        this.implicit = implicit;
         this.partitions = partitions;
         this.keySchema = keySchema;
         this.valueSchema = valueSchema;
@@ -73,6 +75,10 @@ public class TopicDefinition  {
     private SchemaDefinition keySchema;
     private SchemaDefinition valueSchema;
     private int partitions;
+    /**
+     * If true, the topic is not declared in the application, but is expected to exist.
+     */
+    private boolean implicit;
 
     private void validateCreationMode() {
         switch (creationMode) {

--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/ExecutionPlan.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/ExecutionPlan.java
@@ -15,12 +15,15 @@
  */
 package com.datastax.oss.sga.api.runtime;
 
+import com.datastax.oss.sga.api.model.AgentConfiguration;
 import com.datastax.oss.sga.api.model.Application;
 import com.datastax.oss.sga.api.model.Module;
+import com.datastax.oss.sga.api.model.Pipeline;
 import com.datastax.oss.sga.api.model.TopicDefinition;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.imageio.stream.ImageOutputStreamImpl;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/ExecutionPlanOptimiser.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/ExecutionPlanOptimiser.java
@@ -1,5 +1,8 @@
 package com.datastax.oss.sga.api.runtime;
 
+import com.datastax.oss.sga.api.model.Module;
+import com.datastax.oss.sga.api.model.Pipeline;
+
 /**
  * Optimises the execution plan of a Pipeline.
  */
@@ -10,5 +13,5 @@ public interface ExecutionPlanOptimiser {
      */
     boolean canMerge(AgentNode previousAgent, AgentNode agentImplementation);
 
-    AgentNode mergeAgents(AgentNode previousAgent, AgentNode agentImplementation, ExecutionPlan instance);
+    AgentNode mergeAgents(Module module, Pipeline pipeline, AgentNode previousAgent, AgentNode agentImplementation, ExecutionPlan instance);
 }

--- a/api/src/main/java/com/datastax/oss/sga/api/runtime/Topic.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runtime/Topic.java
@@ -2,4 +2,5 @@ package com.datastax.oss.sga.api.runtime;
 
 public interface Topic extends Connection {
     String topicName();
+    boolean implicit();
 }

--- a/cli/src/main/docker/Dockerfile
+++ b/cli/src/main/docker/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install some utilities
+RUN echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
+     && apt-get update \
+     && apt-get -y dist-upgrade \
+     && apt-get -y install --no-install-recommends vim netcat dnsutils less procps iputils-ping \
+                 curl ca-certificates wget apt-transport-https software-properties-common gpg-agent
+
+# Install Python3.11
+RUN apt-get update && add-apt-repository ppa:deadsnakes/ppa \
+     && apt-get -y install --no-install-recommends python3.11-full \
+     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+     && python3 -m ensurepip && python3 -m pip install pipenv
+
+
+# Install Eclipse Temurin Package
+RUN mkdir -p /etc/apt/keyrings \
+     && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
+     && apt-get update \
+     && apt-get -y dist-upgrade \
+     && apt-get -y install temurin-17-jdk \
+     && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
+
+# Cleanup apt
+RUN apt-get -y --purge autoremove \
+     && apt-get autoclean \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /app && chmod g+w /app
+
+ADD maven/Pipfile.lock /app/Pipfile.lock
+
+ENV NLTK_DATA="/app/nltk_data"
+
+# install python runtime deps
+RUN cd /app && pipenv requirements --categories="packages full" > /app/requirements.txt \
+    && python3 -m pip install -r /app/requirements.txt \
+    && python3 -m nltk.downloader -d /app/nltk_data punkt averaged_perceptron_tagger
+
+ENV PYTHONPATH="$PYTHONPATH:/app/sga_runtime"
+
+# Add the runtime code at the end. This optimize docker layers to not depend on artifacts-specific changes.
+ADD maven/lib /app/lib
+ADD maven/entrypoint.sh /app/entrypoint.sh
+ADD maven/sga_runtime /app/sga_runtime
+WORKDIR /app
+
+# The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
+USER 10000
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/ComposableAgentExecutionPlanOptimiser.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/ComposableAgentExecutionPlanOptimiser.java
@@ -1,5 +1,7 @@
 package com.datastax.oss.sga.impl.agents;
 
+import com.datastax.oss.sga.api.model.Module;
+import com.datastax.oss.sga.api.model.Pipeline;
 import com.datastax.oss.sga.api.runtime.AgentNode;
 import com.datastax.oss.sga.api.runtime.ComponentType;
 import com.datastax.oss.sga.api.runtime.ExecutionPlan;
@@ -28,7 +30,7 @@ public final class ComposableAgentExecutionPlanOptimiser implements ExecutionPla
     }
 
     @Override
-    public AgentNode mergeAgents(AgentNode previousAgent, AgentNode agentImplementation, ExecutionPlan instance) {
+    public AgentNode mergeAgents(Module module, Pipeline pipeline, AgentNode previousAgent, AgentNode agentImplementation, ExecutionPlan instance) {
         if (previousAgent instanceof DefaultAgentNode agent1
                 && agentImplementation instanceof DefaultAgentNode agent2) {
 

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/ai/GenAIToolKitExecutionPlanOptimizer.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/ai/GenAIToolKitExecutionPlanOptimizer.java
@@ -1,5 +1,7 @@
 package com.datastax.oss.sga.impl.agents.ai;
 
+import com.datastax.oss.sga.api.model.Module;
+import com.datastax.oss.sga.api.model.Pipeline;
 import com.datastax.oss.sga.api.runtime.AgentNode;
 import com.datastax.oss.sga.api.runtime.ExecutionPlan;
 import com.datastax.oss.sga.api.runtime.ExecutionPlanOptimiser;
@@ -47,7 +49,7 @@ public final class GenAIToolKitExecutionPlanOptimizer implements ExecutionPlanOp
     }
 
     @Override
-    public AgentNode mergeAgents(AgentNode previousAgent, AgentNode agentImplementation,
+    public AgentNode mergeAgents(Module module, Pipeline pipeline, AgentNode previousAgent, AgentNode agentImplementation,
                                  ExecutionPlan applicationInstance) {
         if (Objects.equals(previousAgent.getAgentType(), agentImplementation.getAgentType())
                 && previousAgent instanceof DefaultAgentNode agent1
@@ -75,7 +77,6 @@ public final class GenAIToolKitExecutionPlanOptimizer implements ExecutionPlanOp
             applicationInstance.discardTopic(agent1.getOutputConnection());
 
             agent1.overrideConfigurationAfterMerge(agent1.getAgentType(), result, agent2.getOutputConnection());
-            log.info("Agent 1 modified: {}", agent1);
 
             log.info("Discarding topic {}", agent2.getInputConnection());
             applicationInstance.discardTopic(agent2.getInputConnection());

--- a/core/src/main/java/com/datastax/oss/sga/impl/noop/NoOpStreamingClusterRuntimeProvider.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/noop/NoOpStreamingClusterRuntimeProvider.java
@@ -12,10 +12,15 @@ public class NoOpStreamingClusterRuntimeProvider implements StreamingClusterRunt
         return "noop".equals(type);
     }
 
-    public record SimpleTopic(String name) implements Topic {
+    public record SimpleTopic(String name, boolean implicit) implements Topic {
         @Override
         public String topicName() {
             return name;
+        }
+
+        @Override
+        public boolean implicit() {
+            return this.implicit;
         }
     }
     @Override
@@ -23,7 +28,7 @@ public class NoOpStreamingClusterRuntimeProvider implements StreamingClusterRunt
         return new StreamingClusterRuntime() {
             @Override
             public Topic createTopicImplementation(TopicDefinition topicDefinition, ExecutionPlan applicationInstance) {
-                return new SimpleTopic(topicDefinition.getName());
+                return new SimpleTopic(topicDefinition.getName(), topicDefinition.isImplicit());
             }
         };
     }

--- a/core/src/main/java/com/datastax/oss/sga/impl/parser/ModelBuilder.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/parser/ModelBuilder.java
@@ -258,7 +258,8 @@ public class ModelBuilder {
         if (pipelineConfiguration.getTopics() != null) {
             for (TopicDefinitionModel topicDefinition : pipelineConfiguration.getTopics()) {
                 module.addTopic(new TopicDefinition(topicDefinition.getName(),
-                        topicDefinition.getCreationMode(), topicDefinition.getPartitions(),
+                        topicDefinition.getCreationMode(), false,
+                        topicDefinition.getPartitions(),
                         topicDefinition.getKeySchema(), topicDefinition.getSchema(),
                         topicDefinition.getOptions(), topicDefinition.getConfig()));
             }

--- a/examples/applications/document-qa-chatbot/README.md
+++ b/examples/applications/document-qa-chatbot/README.md
@@ -48,3 +48,11 @@ Since the application opens a gateway, we can use the gateway API to send and co
 ```
 
 
+
+## Debug what you are sending to the LLM
+
+```
+./bin/sga-cli gateway consume chat-bot debug
+```
+
+

--- a/examples/applications/document-qa-chatbot/chatbot.yaml
+++ b/examples/applications/document-qa-chatbot/chatbot.yaml
@@ -5,6 +5,8 @@ topics:
     creation-mode: create-if-not-exists
   - name: "answers-topic"
     creation-mode: create-if-not-exists
+  - name: "log-topic"
+    creation-mode: create-if-not-exists
 errors:
     on-failure: "skip"
 pipeline:
@@ -48,12 +50,14 @@ pipeline:
           content: "{{% value.question}}"
   - name: "cleanup-response"
     type: "drop-fields"
+    output: "log-topic"
     configuration:
       fields:
         - "question_embeddings"
         - "related_documents"
   - name: "keep-only-the-answer"
     type: "compute"
+    input: "log-topic"
     output: "answers-topic"
     configuration:
       fields:

--- a/examples/applications/document-qa-chatbot/gateways.yaml
+++ b/examples/applications/document-qa-chatbot/gateways.yaml
@@ -19,3 +19,7 @@ gateways:
         headers:
           - key: sga-client-session-id
             valueFromParameters: sessionId
+
+  - id: "debug"
+    type: consume
+    topic: "log-topic"

--- a/k8s-runtime/k8s-runtime-core/src/test/java/com/datastax/oss/sga/runtime/impl/k8s/GenAIAgentsTest.java
+++ b/k8s-runtime/k8s-runtime-core/src/test/java/com/datastax/oss/sga/runtime/impl/k8s/GenAIAgentsTest.java
@@ -214,6 +214,126 @@ class GenAIAgentsTest {
 
 
     @Test
+    public void testDontMergeGenAIToolKitAgentsWithExplicitLogTopic() throws Exception {
+        Application applicationInstance = ModelBuilder
+                .buildApplicationInstance(Map.of("instance.yaml",
+                        buildInstanceYaml(),
+                        "configuration.yaml",
+                        """
+                                configuration:  
+                                  resources:
+                                    - name: open-ai
+                                      type: open-ai-configuration
+                                      configuration:
+                                        url: "http://something"                                
+                                        access-key: "xxcxcxc"
+                                        provider: "azure"
+                                  """,
+                        "module.yaml", """
+                                module: "module-1"
+                                id: "pipeline-1"                                
+                                topics:
+                                  - name: "log-topic"
+                                    creation-mode: create-if-not-exists
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                    schema:
+                                      type: avro
+                                      schema: '{"type":"record","namespace":"examples","name":"Product","fields":[{"name":"id","type":"string"},{"name":"name","type":"string"},{"name":"description","type":"string"},{"name":"price","type":"double"},{"name":"category","type":"string"},{"name":"item_vector","type":"bytes"}]}}'
+                                  - name: "output-topic"
+                                    creation-mode: create-if-not-exists                                    
+                                pipeline:
+                                  - name: "compute-embeddings"
+                                    id: "step1"
+                                    type: "compute-ai-embeddings"
+                                    input: "input-topic"
+                                    output: "log-topic"                                    
+                                    configuration:                                      
+                                      model: "text-embedding-ada-002"
+                                      embeddings-field: "value.embeddings"
+                                      text: "{{% value.name }} {{% value.description }}"
+                                  - name: "drop"
+                                    id: "step2"
+                                    type: "drop-fields"
+                                    input: "log-topic"                                    
+                                    output: "output-topic"
+                                    configuration:                                      
+                                      fields: "embeddings"
+                                      part: "value"
+                                """));
+
+        @Cleanup ApplicationDeployer deployer = ApplicationDeployer
+                .builder()
+                .registry(new ClusterRuntimeRegistry())
+                .pluginsRegistry(new PluginsRegistry())
+                .build();
+
+        Module module = applicationInstance.getModule("module-1");
+
+        ExecutionPlan implementation = deployer.createImplementation("app", applicationInstance);
+        log.info("Agents: {}", implementation.getAgents());
+        assertEquals(2, implementation.getAgents().size());
+
+        {
+            AgentNode agentImplementation = implementation.getAgentImplementation(module, "step1");
+            assertNotNull(agentImplementation);
+            DefaultAgentNode step =
+                    (DefaultAgentNode) agentImplementation;
+            Map<String, Object> configuration = step.getConfiguration();
+            log.info("Configuration: {}", configuration);
+            Map<String, Object> openAIConfiguration = (Map<String, Object>) configuration.get("openai");
+            log.info("openAIConfiguration: {}", openAIConfiguration);
+            assertEquals("http://something", openAIConfiguration.get("url"));
+            assertEquals("xxcxcxc", openAIConfiguration.get("access-key"));
+            assertEquals("azure", openAIConfiguration.get("provider"));
+
+
+            List<Map<String, Object>> steps = (List<Map<String, Object>>) configuration.get("steps");
+            assertEquals(1, steps.size());
+            Map<String, Object> step1 = steps.get(0);
+            assertEquals("compute-ai-embeddings", step1.get("type"));
+            assertEquals("text-embedding-ada-002", step1.get("model"));
+            assertEquals("value.embeddings", step1.get("embeddings-field"));
+            assertEquals("{{ value.name }} {{ value.description }}", step1.get("text"));
+        }
+
+        {
+            AgentNode agentImplementation = implementation.getAgentImplementation(module, "step2");
+            assertNotNull(agentImplementation);
+            DefaultAgentNode step =
+                    (DefaultAgentNode) agentImplementation;
+            Map<String, Object> configuration = step.getConfiguration();
+            log.info("Configuration: {}", configuration);
+            Map<String, Object> openAIConfiguration = (Map<String, Object>) configuration.get("openai");
+            log.info("openAIConfiguration: {}", openAIConfiguration);
+            assertEquals("http://something", openAIConfiguration.get("url"));
+            assertEquals("xxcxcxc", openAIConfiguration.get("access-key"));
+            assertEquals("azure", openAIConfiguration.get("provider"));
+
+
+            List<Map<String, Object>> steps = (List<Map<String, Object>>) configuration.get("steps");
+            assertEquals(1, steps.size());
+            Map<String, Object> step2 = steps.get(0);
+            assertEquals("drop-fields", step2.get("type"));
+            assertEquals("embeddings", step2.get("fields"));
+            assertEquals("value", step2.get("part"));
+        }
+
+
+        // verify that the intermediate topic is not created
+        log.info("topics {}", implementation.getTopics().keySet().stream().map(TopicDefinition::getName).toList());
+        assertTrue(implementation.getConnectionImplementation(module,
+                Connection.from(TopicDefinition.fromName("input-topic"))) instanceof NoOpStreamingClusterRuntimeProvider.SimpleTopic);
+        assertTrue(implementation.getConnectionImplementation(module,
+                Connection.from(TopicDefinition.fromName("output-topic"))) instanceof NoOpStreamingClusterRuntimeProvider.SimpleTopic);
+        assertTrue(implementation.getConnectionImplementation(module,
+                Connection.from(TopicDefinition.fromName("log-topic"))) instanceof NoOpStreamingClusterRuntimeProvider.SimpleTopic);
+        assertEquals(3, implementation.getTopics().size());
+
+    }
+
+
+    @Test
     public void testMapAllGenAIToolKitAgents() throws Exception {
         Application applicationInstance = ModelBuilder
                 .buildApplicationInstance(Map.of("instance.yaml",
@@ -502,6 +622,7 @@ class GenAIAgentsTest {
                                         - "value.field1"                                          
                                         - "key.field2"
                                   - name: "casttojson"
+                                    id: casttojson
                                     type: "cast"                                    
                                     output: "output-topic"
                                     configuration:                                      

--- a/kafka/src/main/java/com/dastastax/oss/sga/kafka/runtime/KafkaStreamingClusterRuntime.java
+++ b/kafka/src/main/java/com/dastastax/oss/sga/kafka/runtime/KafkaStreamingClusterRuntime.java
@@ -126,6 +126,7 @@ public class KafkaStreamingClusterRuntime implements StreamingClusterRuntime {
                 topicDefinition.getKeySchema(),
                 topicDefinition.getValueSchema(),
                 creationMode,
+                topicDefinition.isImplicit(),
                 configs,
                 options);
         return kafkaTopic;

--- a/kafka/src/main/java/com/dastastax/oss/sga/kafka/runtime/KafkaTopic.java
+++ b/kafka/src/main/java/com/dastastax/oss/sga/kafka/runtime/KafkaTopic.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public record KafkaTopic(String name, int partitions, int replicationFactor, SchemaDefinition keySchema, SchemaDefinition valueSchema, String createMode,
+                         boolean implicit,
                          Map<String, Object> config, Map<String, Object> options)
         implements Connection, Topic {
     public Map<String,Object> createConsumerConfiguration() {
@@ -52,5 +53,10 @@ public record KafkaTopic(String name, int partitions, int replicationFactor, Sch
     @Override
     public String topicName() {
         return this.name;
+    }
+
+    @Override
+    public boolean implicit() {
+        return this.implicit;
     }
 }

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarStreamingClusterRuntime.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarStreamingClusterRuntime.java
@@ -178,7 +178,8 @@ public class PulsarStreamingClusterRuntime implements StreamingClusterRuntime {
                 topicDefinition.getPartitions(),
                 keySchema,
                 valueSchema,
-                creationMode);
+                creationMode,
+                topicDefinition.isImplicit());
         return pulsarTopic;
     }
 

--- a/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarTopic.java
+++ b/pulsar/src/main/java/com/datastax/oss/sga/pulsar/PulsarTopic.java
@@ -4,11 +4,16 @@ import com.datastax.oss.sga.api.model.SchemaDefinition;
 import com.datastax.oss.sga.api.runtime.Connection;
 import com.datastax.oss.sga.api.runtime.Topic;
 
-public record PulsarTopic(PulsarName name, int partitions,  SchemaDefinition keySchema, SchemaDefinition valueSchema, String createMode)
+public record PulsarTopic(PulsarName name, int partitions,  SchemaDefinition keySchema, SchemaDefinition valueSchema, String createMode, boolean implicit)
         implements Connection, Topic {
 
     @Override
     public String topicName() {
         return name.toPulsarName();
+    }
+
+    @Override
+    public boolean implicit() {
+        return this.implicit;
     }
 }


### PR DESCRIPTION
Summary:
- tag topics that have been created implicitly
- when merging agents, prevent merging agents that are not "consecutive" or that are not linked by an "implicit" topic 