### PR TITLE
Gateway: prevent to lose messages while reading from Kafka

### DIFF
--- a/kafka/src/main/java/com/dastastax/oss/sga/kafka/runner/KafkaReaderWrapper.java
+++ b/kafka/src/main/java/com/dastastax/oss/sga/kafka/runner/KafkaReaderWrapper.java
@@ -76,6 +76,16 @@ class KafkaReaderWrapper implements TopicReader {
                 }
             }
         }
+
+        // this MAY look like debug code, but it's not.
+        // the "seek" operations are "lazy"
+        // so we need to call "position" to actually trigger the seek
+        // otherwise if a producer writes to the topic, we may lose the first message
+        for (TopicPartition topicPartition : partitions) {
+            long position = consumer.position(topicPartition);
+            log.info("Current position for partition {} is {}", topicPartition, position);
+        }
+
     }
 
     @SneakyThrows


### PR DESCRIPTION
Summary:

The Kafka Consumer API "seek" is "lazy", so it is possible that if a producer sends a message before calling consumer.poll() and you are "seeking to end"  the you miss the message.

The fix is to call the operation suggested in the Javadocs (consumer.position) to force the seek() and ensure that we don't lose data.