### PR TITLE
Report more details about agents at runtime

### DIFF
--- a/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/DocumentToJsonAgent.java
+++ b/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/DocumentToJsonAgent.java
@@ -34,27 +34,9 @@ public class DocumentToJsonAgent extends SingleRecordAgentProcessor {
     private boolean copyProperties;
 
     @Override
-    public String agentType() {
-        return "document-to-json";
-    }
-
-    @Override
     public void init(Map<String, Object> configuration) throws Exception {
         this.textField = configuration.getOrDefault("text-field", "text").toString();
         this.copyProperties = Boolean.parseBoolean(configuration.getOrDefault("copy-properties", "true").toString());
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-    }
-    @Override
-    public void start() throws Exception {
-
-    }
-
-    @Override
-    public void close() throws Exception {
-
     }
 
     @Override

--- a/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/LanguageDetectorAgent.java
+++ b/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/LanguageDetectorAgent.java
@@ -31,11 +31,6 @@ public class LanguageDetectorAgent extends SingleRecordAgentProcessor {
     private List<String> allowedLanguages;
 
     @Override
-    public String agentType() {
-        return "language-detector";
-    }
-
-    @Override
     public void init(Map<String, Object> configuration) throws Exception {
         if (configuration.containsKey("property")) {
             property = (String) configuration.get("property");
@@ -46,19 +41,6 @@ public class LanguageDetectorAgent extends SingleRecordAgentProcessor {
             allowedLanguages = List.of();
         }
         log.info("Configuring Language Detectors with field {} and allowed languages {}", property, allowedLanguages);
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-    }
-    @Override
-    public void start() throws Exception {
-
-    }
-
-    @Override
-    public void close() throws Exception {
-
     }
 
     @Override

--- a/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TextNormaliserAgent.java
+++ b/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TextNormaliserAgent.java
@@ -32,27 +32,9 @@ public class TextNormaliserAgent extends SingleRecordAgentProcessor {
     private boolean trimSpaces = true;
 
     @Override
-    public String agentType() {
-        return "text-normaliser";
-    }
-
-    @Override
     public void init(Map<String, Object> configuration) throws Exception {
         makeLowercase = Boolean.parseBoolean(configuration.getOrDefault("make-lowercase", "true").toString());
         trimSpaces = Boolean.parseBoolean(configuration.getOrDefault("trim-spaces", "true").toString());
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-    }
-    @Override
-    public void start() throws Exception {
-
-    }
-
-    @Override
-    public void close() throws Exception {
-
     }
 
     @Override

--- a/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TextSplitterAgent.java
+++ b/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TextSplitterAgent.java
@@ -42,11 +42,6 @@ public class TextSplitterAgent extends SingleRecordAgentProcessor {
     private LengthFunction lengthFunction;
 
     @Override
-    public String agentType() {
-        return "text-splitter";
-    }
-
-    @Override
     public void init(Map<String, Object> configuration) throws Exception {
         initTextSplitter(configuration);
     }
@@ -78,19 +73,6 @@ public class TextSplitterAgent extends SingleRecordAgentProcessor {
         }
         this.textSplitter = newTextSplitter;
         this.lengthFunction = newLengthFunction;
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-    }
-    @Override
-    public void start() throws Exception {
-
-    }
-
-    @Override
-    public void close() throws Exception {
-
     }
 
     @Override

--- a/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TikaTextExtractorAgent.java
+++ b/agents/text-processing/src/main/java/com/dastastax/oss/sga/agents/tika/TikaTextExtractorAgent.java
@@ -15,7 +15,6 @@
  */
 package com.dastastax.oss.sga.agents.tika;
 
-import com.datastax.oss.sga.api.runner.code.AgentContext;
 import com.datastax.oss.sga.api.runner.code.Record;
 import com.datastax.oss.sga.api.runner.code.SimpleRecord;
 import com.datastax.oss.sga.api.runner.code.SingleRecordAgentProcessor;
@@ -29,35 +28,12 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Slf4j
 public class TikaTextExtractorAgent extends SingleRecordAgentProcessor {
-
-    @Override
-    public String agentType() {
-        return "text-extractor";
-    }
-
-    @Override
-    public void init(Map<String, Object> configuration) throws Exception {
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-    }
-    @Override
-    public void start() throws Exception {
-
-    }
-
-    @Override
-    public void close() throws Exception {
-
-    }
 
     @Override
     public List<Record> processRecord(Record record) throws Exception {

--- a/ai-agents/src/main/java/com/datastax/oss/sga/ai/agents/GenAIToolKitAgent.java
+++ b/ai-agents/src/main/java/com/datastax/oss/sga/ai/agents/GenAIToolKitAgent.java
@@ -62,11 +62,6 @@ public class GenAIToolKitAgent extends SingleRecordAgentProcessor {
     private ServiceProvider serviceProvider;
 
     @Override
-    public String agentType() {
-        return "ai-tools";
-    }
-
-    @Override
     public List<Record> processRecord(Record record) throws Exception {
         log.info("Processing {}", record);
         TransformContext context = recordToTransformContext(record);

--- a/api/src/main/java/com/datastax/oss/sga/api/runner/code/AbstractAgentCode.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/code/AbstractAgentCode.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.sga.api.runner.code;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Base class for AgentCode implementations.
+ * It provides default implementations for the Agent identity and AgentInfo methods.
+ */
+public abstract class AbstractAgentCode implements AgentCode {
+    private final AtomicLong totalIn = new AtomicLong();
+    private final AtomicLong totalOut = new AtomicLong();
+    private String agentId;
+    private String agentType;
+    private long startedAt;
+    private long lastProcessedAt;
+
+    @Override
+    public final String agentId() {
+        return agentId;
+    }
+
+    @Override
+    public final String agentType() {
+        return agentType;
+    }
+
+    public final long startedAt() {
+        return startedAt;
+    }
+
+    @Override
+    public final void setMetadata(String id, String agentType, long startedAt) throws Exception {
+        this.agentId = id;
+        this.agentType = agentType;
+        this.startedAt = startedAt;
+    }
+
+    public void processed(long countIn, long countOut) {
+        lastProcessedAt = System.currentTimeMillis();
+        totalIn.addAndGet(countIn);
+        totalOut.addAndGet(countOut);
+    }
+
+    /**
+     * Override this method to provide additional information about the agent.
+     * @return a map of additional information
+     */
+    protected Map<String, Object> buildAdditionalInfo() {
+        return Map.of();
+    }
+
+    @Override
+    public final AgentInfo getInfo() {
+        return new AgentInfo(agentId(), agentType(), buildAdditionalInfo(), totalIn.get(), totalOut.get(), startedAt(), lastProcessedAt);
+    }
+
+}

--- a/api/src/main/java/com/datastax/oss/sga/api/runner/code/AgentCode.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/code/AgentCode.java
@@ -22,12 +22,16 @@ import java.util.Map;
  */
 public interface AgentCode {
 
+    String agentId();
+
     /**
      * Get the type of the agent.
      * @return the type of the agent
      */
     String agentType();
 
+    default void setMetadata(String id, String agentType, long startedAt) throws Exception {
+    }
     default void init(Map<String, Object> configuration) throws Exception {
     }
 
@@ -37,7 +41,5 @@ public interface AgentCode {
     default void start() throws Exception {}
     default void close() throws Exception {}
 
-    default AgentInfo getInfo() {
-        return new AgentInfo(agentType(), Map.of(), null, null);
-    }
+    AgentInfo getInfo();
 }

--- a/api/src/main/java/com/datastax/oss/sga/api/runner/code/AgentInfo.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/code/AgentInfo.java
@@ -27,11 +27,18 @@ import java.util.Map;
 @NoArgsConstructor
 public class AgentInfo {
 
+    @JsonProperty("agent-id")
+    private String agentId;
+    @JsonProperty("agent-type")
     private String agentType;
     private Map<String, Object> info;
     @JsonProperty("total-in")
     private Long totalIn;
     @JsonProperty("total-out")
     private Long totalOut;
+    @JsonProperty("started-at")
+    private Long startedAt;
+    @JsonProperty("last-processed-at")
+    private Long lastProcessedAt;
 
 }

--- a/api/src/main/java/com/datastax/oss/sga/api/runner/code/SingleRecordAgentProcessor.java
+++ b/api/src/main/java/com/datastax/oss/sga/api/runner/code/SingleRecordAgentProcessor.java
@@ -21,10 +21,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-public abstract class SingleRecordAgentProcessor implements AgentProcessor {
+public abstract class SingleRecordAgentProcessor extends AbstractAgentCode implements AgentProcessor {
 
-    private final AtomicLong totalIn = new AtomicLong();
-    private final AtomicLong totalOut = new AtomicLong();
     private final AtomicLong errors = new AtomicLong();
 
     public abstract List<Record> processRecord(Record record) throws Exception;
@@ -33,10 +31,9 @@ public abstract class SingleRecordAgentProcessor implements AgentProcessor {
     public final List<SourceRecordAndResult> process(List<Record> records) {
         List<SourceRecordAndResult> result = new ArrayList<>();
         for (Record record : records) {
-            totalIn.incrementAndGet();
             try {
                 List<Record> process = processRecord(record);
-                totalOut.addAndGet(process.size());
+                processed(1, process.size());
                 if (!process.isEmpty()) {
                     result.add(new SourceRecordAndResult(record, process, null));
                 }
@@ -49,9 +46,7 @@ public abstract class SingleRecordAgentProcessor implements AgentProcessor {
     }
 
     @Override
-    public AgentInfo getInfo() {
-        return new AgentInfo(agentType(),
-                Map.of("errors", errors.get()),
-                totalIn.get(), totalOut.get());
+    protected Map<String, Object> buildAdditionalInfo() {
+        return Map.of("errors", errors.get());
     }
 }

--- a/core/src/main/java/com/datastax/oss/sga/impl/agents/ComposableAgentExecutionPlanOptimiser.java
+++ b/core/src/main/java/com/datastax/oss/sga/impl/agents/ComposableAgentExecutionPlanOptimiser.java
@@ -38,9 +38,11 @@ public final class ComposableAgentExecutionPlanOptimiser implements ExecutionPla
                 && agent1.isComposable()
                 && agentImplementation instanceof DefaultAgentNode agent2
                 && agent2.isComposable());
-        log.info("canMerge {}", previousAgent);
-        log.info("canMerge {}", agentImplementation);
-        log.info("canMerge RESULT: {}", result);
+        if (log.isDebugEnabled()) {
+            log.debug("canMerge {}", previousAgent);
+            log.debug("canMerge {}", agentImplementation);
+            log.debug("canMerge RESULT: {}", result);
+        }
         return result;
     }
 
@@ -55,6 +57,7 @@ public final class ComposableAgentExecutionPlanOptimiser implements ExecutionPla
                 Map<String, Object> configurationAgent2 = new HashMap<>();
                 configurationAgent2.put("agentType", agent2.getAgentType());
                 configurationAgent2.put("configuration", agent2.getConfiguration());
+                configurationAgent2.put("agentId", agent2.getId());
 
                 Map<String, Object> newAgent1Configuration = new HashMap<>(agent1.getConfiguration());
                 if (agent2.getComponentType() == ComponentType.FUNCTION) {
@@ -86,6 +89,7 @@ public final class ComposableAgentExecutionPlanOptimiser implements ExecutionPla
                 Map<String, Object> configurationAgent1 = new HashMap<>();
                 configurationAgent1.put("agentType", agent1.getAgentType());
                 configurationAgent1.put("configuration", agent1.getConfiguration());
+                configurationAgent1.put("agentId", agent1.getId());
                 if (agent1.getComponentType() == ComponentType.SOURCE) {
                     source.putAll(configurationAgent1);
                 } else if (agent1.getComponentType() == ComponentType.SINK) {
@@ -99,6 +103,7 @@ public final class ComposableAgentExecutionPlanOptimiser implements ExecutionPla
                 Map<String, Object> configurationAgent2 = new HashMap<>();
                 configurationAgent2.put("agentType", agent2.getAgentType());
                 configurationAgent2.put("configuration", agent2.getConfiguration());
+                configurationAgent2.put("agentId", agent2.getId());
                 if (agent2.getComponentType() == ComponentType.SOURCE) {
                     source.putAll(configurationAgent2);
                 } else if (agent2.getComponentType() == ComponentType.SINK) {

--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/AgentRunner.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/AgentRunner.java
@@ -457,11 +457,14 @@ public class AgentRunner
 
     private static AgentCode initAgent(RuntimePodConfiguration configuration) throws Exception {
         log.info("Bootstrapping agent with configuration {}", configuration.agent());
-        return initAgent(configuration.agent().agentType(), configuration.agent().configuration());
+        return initAgent(configuration.agent().agentId(), configuration.agent().agentType(),
+                System.currentTimeMillis(),
+                configuration.agent().configuration());
     }
 
-    public static AgentCode initAgent(String agentType, Map<String, Object> configuration) throws Exception {
+    public static AgentCode initAgent(String agentId, String agentType, long startedAt, Map<String, Object> configuration) throws Exception {
         AgentCode agentCode = AGENT_CODE_REGISTRY.getAgentCode(agentType);
+        agentCode.setMetadata(agentId, agentType, startedAt);
         agentCode.init(configuration);
         return agentCode;
     }

--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/TopicConsumerSource.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/TopicConsumerSource.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.sga.runtime.agent;
 
+import com.datastax.oss.sga.api.runner.code.AbstractAgentCode;
 import com.datastax.oss.sga.api.runner.code.AgentInfo;
 import com.datastax.oss.sga.api.runner.code.AgentSource;
 import com.datastax.oss.sga.api.runner.code.Record;
@@ -26,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class TopicConsumerSource implements AgentSource {
+public class TopicConsumerSource extends AbstractAgentCode implements AgentSource {
 
     private final TopicConsumer consumer;
     private final TopicProducer deadLetterQueueProducer;
@@ -38,18 +39,10 @@ public class TopicConsumerSource implements AgentSource {
     }
 
     @Override
-    public String agentType() {
-        return "topic-source";
-    }
-
-    @Override
-    public void init(Map<String, Object> configuration) throws Exception {
-        // the consumer is already initialized
-    }
-
-    @Override
     public List<Record> read() throws Exception {
-        return consumer.read();
+        List<Record> result =  consumer.read();
+        processed(result.size(), 0);
+        return result;
     }
 
     @Override
@@ -86,7 +79,7 @@ public class TopicConsumerSource implements AgentSource {
     }
 
     @Override
-    public AgentInfo getInfo() {
-        return new AgentInfo(agentType(), Map.of("consumer", consumer.getInfo()), null, consumer.getTotalOut());
+    protected Map<String, Object> buildAdditionalInfo() {
+        return Map.of("consumer", consumer.getInfo());
     }
 }

--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/TopicProducerSink.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/TopicProducerSink.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.sga.runtime.agent;
 
+import com.datastax.oss.sga.api.runner.code.AbstractAgentCode;
 import com.datastax.oss.sga.api.runner.code.AgentInfo;
 import com.datastax.oss.sga.api.runner.code.AgentSink;
 import com.datastax.oss.sga.api.runner.code.Record;
@@ -23,15 +24,10 @@ import com.datastax.oss.sga.api.runner.topics.TopicProducer;
 import java.util.List;
 import java.util.Map;
 
-public class TopicProducerSink implements AgentSink {
+public class TopicProducerSink extends AbstractAgentCode implements AgentSink {
 
     private final TopicProducer producer;
     private CommitCallback callback;
-
-    @Override
-    public String agentType() {
-        return "topic-sink";
-    }
 
     public TopicProducerSink(TopicProducer producer) {
         this.producer = producer;
@@ -59,6 +55,7 @@ public class TopicProducerSink implements AgentSink {
 
     @Override
     public void write(List<Record> records) throws Exception {
+        processed(records.size(), 0);
         producer.write(records);
         callback.commit(records);
     }
@@ -71,7 +68,7 @@ public class TopicProducerSink implements AgentSink {
     }
 
     @Override
-    public AgentInfo getInfo() {
-        return new AgentInfo(agentType(), Map.of("producer", producer.getInfo()), producer.getTotalIn(), null);
+    protected Map<String, Object> buildAdditionalInfo() {
+        return Map.of("producer", producer.getInfo());
     }
 }

--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/python/PythonCodeAgentProvider.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/python/PythonCodeAgentProvider.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.sga.runtime.agent.python;
 
+import com.datastax.oss.sga.api.runner.code.AbstractAgentCode;
 import com.datastax.oss.sga.api.runner.code.AgentCode;
 import com.datastax.oss.sga.api.runner.code.AgentCodeProvider;
 import lombok.AllArgsConstructor;
@@ -34,17 +35,11 @@ public class PythonCodeAgentProvider implements AgentCodeProvider {
 
     @Override
     public AgentCode createInstance(String agentType) {
-        return new PythonAgentPlaceHolder(agentType);
+        return new PythonAgentPlaceHolder();
     }
 
     @AllArgsConstructor
-    private static class PythonAgentPlaceHolder implements AgentCode {
-
-        private final String agentType;
-        @Override
-        public String agentType() {
-            return agentType;
-        }
+    private static class PythonAgentPlaceHolder extends AbstractAgentCode implements AgentCode {
     }
 
     public static boolean isPythonCodeAgent(AgentCode agentCode) {

--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/simple/IdentityAgentProvider.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/simple/IdentityAgentProvider.java
@@ -36,11 +36,6 @@ public class IdentityAgentProvider implements AgentCodeProvider {
     public static class IdentityAgentCode extends SingleRecordAgentProcessor {
 
         @Override
-        public String agentType() {
-            return "identity";
-        }
-
-        @Override
         public List<Record> processRecord(Record record) throws Exception {
             return List.of(record);
         }

--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/simple/NoOpAgentProvider.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/simple/NoOpAgentProvider.java
@@ -36,11 +36,6 @@ public class NoOpAgentProvider implements AgentCodeProvider {
     private static class NoOpAgentCode extends SingleRecordAgentProcessor {
 
         @Override
-        public String agentType() {
-            return "noop";
-        }
-
-        @Override
         public List<Record> processRecord(Record record) throws Exception {
             return List.of();
         }

--- a/runtime/runtime-impl/src/test/java/com/datastax/oss/sga/kafka/FailingProcessorAgentCodeProvider.java
+++ b/runtime/runtime-impl/src/test/java/com/datastax/oss/sga/kafka/FailingProcessorAgentCodeProvider.java
@@ -36,11 +36,6 @@ public class FailingProcessorAgentCodeProvider implements AgentCodeProvider {
     public AgentCode createInstance(String agentType) {
         return new SingleRecordAgentProcessor() {
 
-            @Override
-            public String agentType() {
-                return agentType;
-            }
-
             String failOnContent;
             @Override
             public void init(Map<String, Object> configuration) throws Exception {

--- a/runtime/runtime-impl/src/test/java/com/datastax/oss/sga/runtime/agent/AgentRecordTrackerTest.java
+++ b/runtime/runtime-impl/src/test/java/com/datastax/oss/sga/runtime/agent/AgentRecordTrackerTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.sga.runtime.agent;
 
+import com.datastax.oss.sga.api.runner.code.AbstractAgentCode;
 import com.datastax.oss.sga.api.runner.code.AgentContext;
 import com.datastax.oss.sga.api.runner.code.AgentProcessor;
 import com.datastax.oss.sga.api.runner.code.AgentSource;
@@ -32,41 +33,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AgentRecordTrackerTest {
 
-    private static record MyRecord (Object key, Object value, String origin, Long timestamp, Collection<Header> headers) implements Record {
+    private record MyRecord (Object key, Object value, String origin, Long timestamp, Collection<Header> headers) implements Record {
     }
 
-    private static class MySource implements AgentSource {
-
-        @Override
-        public String agentType() {
-            return "my-source";
-        }
+    private static class MySource extends AbstractAgentCode implements AgentSource {
 
         List<Record> committed = new ArrayList<>();
 
         @Override
         public void commit(List<Record> records) throws Exception {
             committed.addAll(records);
-        }
-
-        @Override
-        public void init(Map<String, Object> configuration) throws Exception {
-
-        }
-
-        @Override
-        public void setContext(AgentContext context) throws Exception {
-
-        }
-
-        @Override
-        public void start() throws Exception {
-
-        }
-
-        @Override
-        public void close() throws Exception {
-
         }
 
         @Override

--- a/runtime/runtime-impl/src/test/java/com/datastax/oss/sga/runtime/agent/AgentRunnerTest.java
+++ b/runtime/runtime-impl/src/test/java/com/datastax/oss/sga/runtime/agent/AgentRunnerTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.sga.runtime.agent;
 
+import com.datastax.oss.sga.api.runner.code.AbstractAgentCode;
 import com.datastax.oss.sga.api.runner.code.AgentContext;
 import com.datastax.oss.sga.api.runner.code.AgentProcessor;
 import com.datastax.oss.sga.api.runner.code.AgentSink;
@@ -140,12 +141,7 @@ class AgentRunnerTest {
         source.expectUncommitted(0);
     }
 
-    private static class SimpleSink implements AgentSink {
-
-        @Override
-        public String agentType() {
-            return "test";
-        }
+    private static class SimpleSink extends AbstractAgentCode implements AgentSink {
 
         CommitCallback callback;
 
@@ -160,12 +156,8 @@ class AgentRunnerTest {
         }
     }
 
-    private static class SimpleSource implements AgentSource {
+    private static class SimpleSource extends AbstractAgentCode implements AgentSource {
 
-        @Override
-        public String agentType() {
-            return "test";
-        }
 
         final List<Record> records;
         final List<Record> uncommitted = new ArrayList<>();
@@ -209,11 +201,6 @@ class AgentRunnerTest {
     }
 
     private static class SimpleAgentProcessor extends SingleRecordAgentProcessor {
-
-        @Override
-        public String agentType() {
-            return "test";
-        }
 
         private final Set<String> failOnContent;
         private int executionCount;


### PR DESCRIPTION
Summary:
- report agent-id on all the agents in the "status" section
- add  "last-processed-at"  and "started-at" for each agent

Note:
please note that the  "composite-agent" is actually a sequence of agents that are executed in the same process but totalIn/totalOut can be different in the middle of the in-memory pipeline, see the "text-splitter" agent