### PR TITLE
Stats: fix stats for TopicSource and TopicSink

### DIFF
--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/AgentRunner.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/AgentRunner.java
@@ -278,6 +278,8 @@ public class AgentRunner
 
             if (source == null) {
                 source = new TopicConsumerSource(consumer, deadLetterProducer);
+                source.setMetadata("topic-source", "topic-source", System.currentTimeMillis());
+                source.init(Map.of());
             }
             agentInfo.watchSource(source);
 
@@ -289,6 +291,8 @@ public class AgentRunner
             }
             if (sink == null) {
                 sink = new TopicProducerSink(producer);
+                sink.setMetadata("topic-sink", "topic-sink", System.currentTimeMillis());
+                sink.init(Map.of());
             }
             agentInfo.watchSink(sink);
 

--- a/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/TopicConsumerSource.java
+++ b/runtime/runtime-impl/src/main/java/com/datastax/oss/sga/runtime/agent/TopicConsumerSource.java
@@ -41,7 +41,7 @@ public class TopicConsumerSource extends AbstractAgentCode implements AgentSourc
     @Override
     public List<Record> read() throws Exception {
         List<Record> result =  consumer.read();
-        processed(result.size(), 0);
+        processed(0, result.size());
         return result;
     }
 


### PR DESCRIPTION
Summary:
- fix started-at, agent-id and agent-type the the system sink/source that represent reading/writing from/to a topic