### PR TITLE
Helm: add a client pod with pre-configured SGAI cli tools

### DIFF
--- a/bin/sga-cli
+++ b/bin/sga-cli
@@ -36,6 +36,12 @@ if [ ! -d cli/target/cli ]; then
   ./mvnw clean install -DskipTests -pl cli -am
 fi
 popd > /dev/null
-"$ROOT_DIR/cli/target/cli/bin/sga" "$@"
+SGA_CLI_CONFIG=${SGA_CLI_CONFIG:-""}
+if [ -n "$SGA_CLI_CONFIG" ]; then
+  echo "Using CLI config file from ENV variable SGA_CLI_CONFIG: $SGA_CLI_CONFIG"
+  SGA_CLI_CONFIG="--conf $SGA_CLI_CONFIG"
+fi
+
+"$ROOT_DIR/cli/target/cli/bin/sga" $SGA_CLI_CONFIG "$@"
 
 

--- a/cli/src/main/docker/Dockerfile
+++ b/cli/src/main/docker/Dockerfile
@@ -48,5 +48,8 @@ RUN mkdir /app && chmod g+w /app
 ADD maven /app
 WORKDIR /app
 
+RUN chown -R 10000:10000 /app/conf
+RUN echo "export PATH=$PATH:/app/bin" >> /.bashrc
+
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
 USER 10000

--- a/dev/clear-minikube.sh
+++ b/dev/clear-minikube.sh
@@ -24,4 +24,5 @@ docker image rm -f datastax/sga-runtime:latest-dev
 docker image rm -f datastax/sga-deployer:latest-dev
 docker image rm -f datastax/sga-control-plane:latest-dev
 docker image rm -f datastax/sga-api-gateway:latest-dev
+docker image rm -f datastax/sga-cli:latest-dev
 

--- a/dev/deploy-minikube.sh
+++ b/dev/deploy-minikube.sh
@@ -20,3 +20,4 @@ minikube image load --overwrite datastax/sga-deployer:latest-dev
 minikube image load --overwrite datastax/sga-control-plane:latest-dev
 minikube image load --overwrite datastax/sga-runtime:latest-dev
 minikube image load --overwrite datastax/sga-api-gateway:latest-dev
+minikube image load --overwrite datastax/sga-cli:latest-dev

--- a/dev/start-standalone.sh
+++ b/dev/start-standalone.sh
@@ -46,6 +46,7 @@ if [ "true" == "$(use_minikube_load)" ]; then
   minikube image load --overwrite datastax/sga-control-plane:latest-dev
   minikube image load --overwrite datastax/sga-runtime:latest-dev
   minikube image load --overwrite datastax/sga-api-gateway:latest-dev
+  minikube image load --overwrite datastax/sga-cli:latest-dev
 else
   eval $(minikube docker-env)
   if [ "$SKIP_BUILD" == "false" ]; then

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -41,6 +41,8 @@ elif [ "$only_image" == "operator" ]; then
   build_docker_image k8s-deployer/k8s-deployer-operator
 elif [ "$only_image" == "runtime" ]; then
   build_docker_image runtime/runtime-impl
+elif [ "$only_image" == "cli" ]; then
+  build_docker_image cli
 elif [ "$only_image" == "api-gateway" ]; then
   build_docker_image api-gateway
 else

--- a/helm/examples/deploy-application-job.yaml
+++ b/helm/examples/deploy-application-job.yaml
@@ -18,7 +18,7 @@ spec:
           - bash
           - -c
           - |
-            cat - > /tmp/cli.yaml << EOL
+            cat - > /app/conf/cli.yaml << EOL
             webServiceUrl: http://sga-control-plane.default.svc.cluster.local:8090
             apiGatewayUrl: ws://sga-api-gateway.default.svc.cluster.local:8091
             tenant: default
@@ -32,8 +32,7 @@ spec:
                data:
                 client-id: xxxx
             EOL
-            cat /tmp/cli.yaml
-            /app/bin/sga --conf /tmp/cli.yaml tenants list
+            /app/bin/sga tenants list
             curl --fail --output-dir /tmp -O -L https://github.com/eolivelli/sgai-examples/raw/main/examples.tar.gz
             cd /tmp
             tar zxf /tmp/examples.tar.gz
@@ -41,7 +40,7 @@ spec:
             INSTANCE=instances/kafka-kubernetes.yaml
             SECRETS=/tmp/secrets.yaml
             APPNAME=app1
-            /app/bin/sga --conf /tmp/cli.yaml apps deploy -app $APPLICATION -s /tmp/secrets.yaml --instance $INSTANCE app1
-            /app/bin/sga --conf /tmp/cli.yaml apps get app1 -o yaml
+            /app/bin/sga apps deploy -app $APPLICATION -s /tmp/secrets.yaml --instance $INSTANCE app1
+            /app/bin/sga apps get app1 -o yaml
       restartPolicy: Never
   backoffLimit: 0

--- a/helm/examples/local.yaml
+++ b/helm/examples/local.yaml
@@ -29,6 +29,13 @@ deployer:
         access-key: minioadmin
         secret-key: minioadmin
 
+client:
+  replicaCount: 1
+  image:
+    repository: datastax/sga-cli
+    pullPolicy: Never
+    tag: "latest-dev"
+
 apiGateway:
   image:
     pullPolicy: Never

--- a/helm/sga/templates/_helpers.tpl
+++ b/helm/sga/templates/_helpers.tpl
@@ -159,6 +159,83 @@ Create the name of the role binding to use
 {{- end }}
 
 
+{{/*
+    CLIENT
+*/}}
+
+{{- define "sga.clientName" -}}
+{{- default .Chart.Name .Values.client.nameOverride | trunc 63 | trimSuffix "-" }}-client
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sga.clientFullname" -}}
+{{- if .Values.client.fullnameOverride }}
+{{- .Values.client.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.client.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}-client
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}-client
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sga.clientLabels" -}}
+helm.sh/chart: {{ include "sga.chart" . }}
+{{ include "sga.clientSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+
+{{- define "sga.clientSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "sga.clientName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sga.clientServiceAccountName" -}}
+{{- if .Values.client.serviceAccount.create }}
+{{- default (include "sga.clientFullname" .) .Values.client.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.client.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the role to use
+*/}}
+{{- define "sga.clientRoleName" -}}
+{{- if .Values.client.serviceAccount.create }}
+{{- default (include "sga.clientFullname" .) .Values.client.serviceAccount.role.name }}
+{{- else }}
+{{- default "default" .Values.client.serviceAccount.role.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the role binding to use
+*/}}
+{{- define "sga.clientRoleBindingName" -}}
+{{- if .Values.client.serviceAccount.create }}
+{{- default (include "sga.clientFullname" .) .Values.client.serviceAccount.roleBinding.name }}
+{{- else }}
+{{- default "default" .Values.client.serviceAccount.roleBinding.name }}
+{{- end }}
+{{- end }}
+
 
 {{/*
     API GATEWAY

--- a/helm/sga/templates/client/client-configmap.yaml
+++ b/helm/sga/templates/client/client-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sga.clientFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sga.clientLabels" . | nindent 4 }}
+data:
+{{- range $key, $val := $.Values.client.app.config }}
+  {{ $key | replace "-" "" | replace "\"" "." | snakecase | upper | replace "." "_"  }}: {{ $val | toString | replace "\"" "" | trim | quote }}
+{{- end }}

--- a/helm/sga/templates/client/client-deployment.yaml
+++ b/helm/sga/templates/client/client-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sga.clientFullname" . }}
+  labels:
+    {{- include "sga.clientLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.client.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sga.clientSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.client.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "sga.clientSelectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.client.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sga.clientServiceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.client.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.client.securityContext | nindent 12 }}
+          image: "{{ .Values.client.image.repository }}:{{ .Values.client.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.client.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.client.resources | nindent 12 }}
+          command: [ "sh", "-c" ]
+          args:
+            - > 
+                echo "webServiceUrl: $WEB_SERVICE_URL" > /app/conf/cli.yaml &&
+                echo "apiGatewayUrl: $API_GATEWAY_URL" >> /app/conf/cli.yaml &&
+                echo "tenant: $DEFAULT_TENANT" >> /app/conf/cli.yaml &&                
+                env &
+                sleep infinity
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - configMapRef:
+                name: {{ include "sga.clientFullname" . }}
+      {{- with .Values.client.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.client.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.client.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/sga/templates/client/client-serviceaccount.yaml
+++ b/helm/sga/templates/client/client-serviceaccount.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.client.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sga.clientServiceAccountName" . }}
+  labels:
+    {{- include "sga.clientLabels" . | nindent 4 }}
+  {{- with .Values.client.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sga.clientRoleName" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sga.clientRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "sga.clientRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sga.clientServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "sga.clientRoleName" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - pods
+      - pods/log
+    verbs:
+      - "*"
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - "*"
+  - apiGroups:
+      - sga.oss.datastax.com
+    resources:
+      - agents
+      - agents/status
+      - applications
+      - applications/status
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sga.clientRoleBindingName" . }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "sga.clientRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sga.clientServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/sga/values.yaml
+++ b/helm/sga/values.yaml
@@ -47,6 +47,37 @@ controlPlane:
       application.storage.apps.configuration.deployer-runtime.image-pull-policy: Never
       application.storage.global.type: kubernetes
 
+client:
+  replicaCount: 1
+  image:
+    repository: datastax/sga-cli
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+    role:
+      name: "sga-client"
+    roleBinding:
+      name: "sga-client-role-binding"
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  app:
+    config:
+      webServiceUrl: http://sga-control-plane.default.svc.cluster.local:8090
+      apiGatewayUrl: ws://sga-api-gateway.default.svc.cluster.local:8091
+      defaultTenant: default
+
 deployer:
   replicaCount: 1
   image:


### PR DESCRIPTION
Summary:
- some enhancements to the "cli" docker image (add the /app/bin PATH to the PATH env for interactive sessions)
- add a "client" deployment to the helm chart (with pre-configured service urls) 