### PR TITLE
Use Python3 executable to allow M1 users to build

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.agents.webcrawler.crawler;
 
 import java.util.Map;

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.agents.webcrawler.crawler;
 
 import org.junit.jupiter.api.Test;

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -314,7 +314,7 @@
             </goals>
             <configuration>
               <workingDirectory>${project.build.directory}/python</workingDirectory>
-              <executable>python</executable>
+              <executable>python3</executable>
               <arguments>
                 <argument>-m</argument>
                 <argument>build</argument>


### PR DESCRIPTION
Summary:
- on my Mac you have to use python3 and not python as executable name
- fix license headers