### PR TITLE
Deployer: set infinite retries

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/InfiniteRetry.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/InfiniteRetry.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.deployer.k8s.controllers;
 
 import io.javaoperatorsdk.operator.processing.retry.GenericRetry;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/InfiniteRetry.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/InfiniteRetry.java
@@ -1,0 +1,14 @@
+package ai.langstream.deployer.k8s.controllers;
+
+import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
+import io.javaoperatorsdk.operator.processing.retry.GenericRetryExecution;
+import io.javaoperatorsdk.operator.processing.retry.Retry;
+import io.javaoperatorsdk.operator.processing.retry.RetryExecution;
+
+public class InfiniteRetry implements Retry {
+    private static final GenericRetry RETRY = new GenericRetry().withoutMaxAttempts();
+    @Override
+    public RetryExecution initExecution() {
+        return new GenericRetryExecution(RETRY);
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
@@ -18,6 +18,7 @@ package ai.langstream.deployer.k8s.controllers.agents;
 import ai.langstream.api.model.AgentLifecycleStatus;
 import ai.langstream.deployer.k8s.ResolvedDeployerConfiguration;
 import ai.langstream.deployer.k8s.agents.AgentResourcesFactory;
+import ai.langstream.deployer.k8s.controllers.InfiniteRetry;
 import ai.langstream.deployer.k8s.util.KubeUtil;
 import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
 import ai.langstream.deployer.k8s.controllers.BaseController;
@@ -43,7 +44,8 @@ import lombok.extern.jbosslog.JBossLog;
         dependents = {
                 @Dependent(type = AgentController.StsDependantResource.class),
                 @Dependent(type = AgentController.ServiceDependantResource.class)
-        })
+        },
+        retry = InfiniteRetry.class)
 @JBossLog
 public class AgentController extends BaseController<AgentCustomResource>
         implements ErrorStatusHandler<AgentCustomResource> {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
@@ -18,6 +18,7 @@ package ai.langstream.deployer.k8s.controllers.apps;
 import ai.langstream.api.model.ApplicationLifecycleStatus;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
 import ai.langstream.deployer.k8s.apps.AppResourcesFactory;
+import ai.langstream.deployer.k8s.controllers.InfiniteRetry;
 import ai.langstream.deployer.k8s.util.JSONComparator;
 import ai.langstream.deployer.k8s.util.KubeUtil;
 import ai.langstream.deployer.k8s.util.SpecDiffer;
@@ -35,7 +36,10 @@ import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
 import lombok.extern.jbosslog.JBossLog;
 
-@ControllerConfiguration(namespaces = Constants.WATCH_ALL_NAMESPACES, name = "app-controller")
+@ControllerConfiguration(
+        namespaces = Constants.WATCH_ALL_NAMESPACES,
+        name = "app-controller",
+        retry = InfiniteRetry.class)
 @JBossLog
 public class AppController extends BaseController<ApplicationCustomResource> implements
         ErrorStatusHandler<ApplicationCustomResource> {


### PR DESCRIPTION
* Currently the deployer uses the default retry config. This retry config is applied when the reconciliation loop fails. The correct behaviour would to be retry forever until the patch is in the requested state otherwise it seems everything is fine even if it's not able to update the resources for some reasons. 