### PR TITLE
Vector Database Support: vector-db-sink agent + support for Pinecone

### DIFF
--- a/examples/applications/query-pinecone/README.md
+++ b/examples/applications/query-pinecone/README.md
@@ -33,15 +33,32 @@ You also have to set your OpenAI API keys in the secrets.yaml file.
 ./bin/langstream apps deploy test -app examples/applications/query-pinecone -i examples/instances/kafka-kubernetes.yaml -s /path/to/secrets.yaml
 ```
 
-## Start a Producer
-```
-kubectl -n kafka run kafka-producer -ti --image=quay.io/strimzi/kafka:0.35.1-kafka-3.4.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic input-topic
-```
+## Start a Producer to index a document
 
-Insert a JSON with "id", "name" and "description":
+Let's start a produce that sends messages to the vectors-topic:
 
 ```
-Hello
+kubectl -n kafka run kafka-producer -ti --image=quay.io/strimzi/kafka:0.35.1-kafka-3.4.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic vectors-topic
+```
+
+Insert a JSON with "id" and "document" and a genre:
+
+```json
+{"id": "myid", "document": "Hello", "genre": "comedy"}
+```
+
+The Write pipeline will compute the embeddings on the "document" field and then write a Vector into Pinecone.
+
+## Start a Producer to Trigger a query
+
+```
+kubectl -n kafka run kafka-producer-question -ti --image=quay.io/strimzi/kafka:0.35.1-kafka-3.4.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic input-topic
+```
+
+Insert a JSON with a "question":
+
+```json
+{"question": "Hello"}
 ```
 
 

--- a/examples/applications/query-pinecone/query.yaml
+++ b/examples/applications/query-pinecone/query.yaml
@@ -16,24 +16,37 @@
 
 name: "Index Products on Vector Database"
 topics:
-  - name: "vectors-topic"
+  - name: "input-topic"
+    creation-mode: create-if-not-exists
+  - name: "output-topic"
     creation-mode: create-if-not-exists
 errors:
     on-failure: skip
 pipeline:
   - name: "compute-embeddings"
-    id: "step1"
     type: "compute-ai-embeddings"
-    input: "vectors-topic"
+    input: "input-topic"
     configuration:
       model: "text-embedding-ada-002" # This needs to match the name of the model deployment, not the base model
       embeddings-field: "value.embeddings"
-      text: "{{% value.document }}"
-  - name: "Write to Pinecone"
-    type: "vector-db-sink"
+      text: "{{% value.question }}"
+  - name: "Execute Query"
+    type: "query-vector-db"
     configuration:
       datasource: "PineconeDatasource"
-      vector.id: "value.id"
-      vector.vector: "value.embeddings"
-      vector.namespace: ""
-      vector.metadata.genre: "value.genre"
+      query: |
+        {
+              "vector": ?,
+              "topK": 5,
+              "filter":
+                {"$or": [{"genre": "comedy"}, {"year":2019}]}
+         }
+      fields:
+        - "value.embeddings"
+      output-field: "value.query-result"
+  - name: "Remove embeddings from the output"
+    type: "drop-fields"
+    output: "output-topic"
+    configuration:
+      fields:
+        - "embeddings"

--- a/examples/applications/query-pinecone/wite.yaml
+++ b/examples/applications/query-pinecone/wite.yaml
@@ -24,7 +24,7 @@ pipeline:
   - name: "compute-embeddings"
     id: "step1"
     type: "compute-ai-embeddings"
-    input: "input-topic"
+    input: "vectors-topic"
     configuration:
       model: "text-embedding-ada-002" # This needs to match the name of the model deployment, not the base model
       embeddings-field: "value.embeddings"

--- a/examples/applications/query-pinecone/wite.yaml
+++ b/examples/applications/query-pinecone/wite.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Index Products on Vector Database"
+topics:
+  - name: "vectors-topic"
+    creation-mode: create-if-not-exists
+errors:
+    on-failure: skip
+pipeline:
+  - name: "compute-embeddings"
+    id: "step1"
+    type: "compute-ai-embeddings"
+    input: "input-topic"
+    configuration:
+      model: "text-embedding-ada-002" # This needs to match the name of the model deployment, not the base model
+      embeddings-field: "value.embeddings"
+      text: "{{% value.document }}"
+  - name: "Write to Pinecone"
+    type: "vector-db-sink"
+    configuration:
+      datasource: "PineconeDatasource"
+      vector.id: "value.id"
+      vector.vector: "value.embeddings"
+      vector.namespace: ""
+      vector.metadata.genre: "value.genre"

--- a/examples/applications/query-pinecone/write.yaml
+++ b/examples/applications/query-pinecone/write.yaml
@@ -16,38 +16,23 @@
 
 name: "Index Products on Vector Database"
 topics:
-  - name: "input-topic"
-    creation-mode: create-if-not-exists
-  - name: "output-topic"
+  - name: "vectors-topic"
     creation-mode: create-if-not-exists
 errors:
     on-failure: skip
 pipeline:
   - name: "compute-embeddings"
-    id: "step1"
     type: "compute-ai-embeddings"
-    input: "input-topic"
+    input: "vectors-topic"
     configuration:
       model: "text-embedding-ada-002" # This needs to match the name of the model deployment, not the base model
       embeddings-field: "value.embeddings"
-      text: "{{% value.question }}"
-  - name: "Execute Query"
-    type: "query-vector-db"
+      text: "{{% value.document }}"
+  - name: "Write to Pinecone"
+    type: "vector-db-sink"
     configuration:
       datasource: "PineconeDatasource"
-      query: |
-        {
-              "vector": ?,
-              "topK": 5,
-              "filter":
-                {"$or": [{"genre": "comedy"}, {"year":2019}]}
-         }
-      fields:
-        - "value.embeddings"
-      output-field: "value.query-result"
-  - name: "Remove embeddings from the output"
-    type: "drop-fields"
-    output: "output-topic"
-    configuration:
-      fields:
-        - "embeddings"
+      vector.id: "value.id"
+      vector.vector: "value.embeddings"
+      vector.namespace: ""
+      vector.metadata.genre: "value.genre"

--- a/langstream-agents/langstream-ai-agents/pom.xml
+++ b/langstream-agents/langstream-ai-agents/pom.xml
@@ -45,12 +45,21 @@
       <artifactId>java-driver-core</artifactId>
     </dependency>
     <dependency>
+      <!-- Transform Function -->
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>streaming-ai</artifactId>
       <exclusions>
         <exclusion>
           <groupId>ai.langstream</groupId>
           <artifactId>java-driver-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.datastax.oss</groupId>
+          <artifactId>pulsar-functions-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/DataSourceProviderRegistry.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/DataSourceProviderRegistry.java
@@ -42,7 +42,7 @@ public class DataSourceProviderRegistry {
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("No DataSource found for resource " + dataSourceConfig));
 
-        final QueryStepDataSource implementation = provider.get().createImplementation(dataSourceConfig);
+        final QueryStepDataSource implementation = provider.get().createDataSourceImplementation(dataSourceConfig);
         return implementation;
     }
 

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/impl/AstraDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/impl/AstraDataSource.java
@@ -30,7 +30,7 @@ public class AstraDataSource implements DataSourceProvider {
     }
 
     @Override
-    public QueryStepDataSource createImplementation(Map<String, Object> dataSourceConfig) {
+    public QueryStepDataSource createDataSourceImplementation(Map<String, Object> dataSourceConfig) {
         AstraDBDataSource result =  new AstraDBDataSource();
         DataSourceConfig implConfig = new DataSourceConfig();
         implConfig.setPassword((String) dataSourceConfig.get("password"));

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/impl/JdbcDataSourceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/impl/JdbcDataSourceProvider.java
@@ -46,7 +46,7 @@ public class JdbcDataSourceProvider implements DataSourceProvider {
 
     @Override
     @SneakyThrows
-    public QueryStepDataSource createImplementation(Map<String, Object> dataSourceConfig){
+    public QueryStepDataSource createDataSourceImplementation(Map<String, Object> dataSourceConfig){
         return new DataSourceImpl(dataSourceConfig);
     }
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/datasource/JdbcDataSourceProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/datasource/JdbcDataSourceProviderTest.java
@@ -34,7 +34,7 @@ public class JdbcDataSourceProviderTest {
     @Test
     public void testQuery() throws Exception {
         JdbcDataSourceProvider jdbcDataSourceProvider = new JdbcDataSourceProvider();
-        QueryStepDataSource implementation = jdbcDataSourceProvider.createImplementation(Map.of("url", "jdbc:h2:mem:test",
+        QueryStepDataSource implementation = jdbcDataSourceProvider.createDataSourceImplementation(Map.of("url", "jdbc:h2:mem:test",
                 "user", "sa", "password", "sa", "driverClass", "org.h2.Driver"));
 
         try (Connection conn = DriverManager.

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorAgentsCodeProvider.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorAgentsCodeProvider.java
@@ -23,6 +23,7 @@ public class VectorAgentsCodeProvider implements AgentCodeProvider {
     public boolean supports(String agentType) {
         switch (agentType) {
             case "query-vector-db":
+            case "vector-db-sink":
                 return true;
             default:
                 return false;
@@ -34,6 +35,8 @@ public class VectorAgentsCodeProvider implements AgentCodeProvider {
         switch (agentType) {
             case "query-vector-db":
                 return new QueryVectorDBAgent();
+            case "vector-db-sink":
+                return new VectorDBSinkAgent();
             default:
                 throw new IllegalStateException();
         }

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.vector;
+
+import ai.langstream.api.database.VectorDatabaseWriter;
+import ai.langstream.api.database.VectorDatabaseWriterProvider;
+import ai.langstream.api.database.VectorDatabaseWriterProviderRegistry;
+import ai.langstream.api.runner.code.AbstractAgentCode;
+import ai.langstream.api.runner.code.AgentSink;
+import ai.langstream.api.runner.code.Record;
+
+import java.util.List;
+import java.util.Map;
+
+public class VectorDBSinkAgent extends AbstractAgentCode implements AgentSink {
+
+    private VectorDatabaseWriter writer;
+    private CommitCallback callback;
+
+    @Override
+    public void init(Map<String, Object> configuration) throws Exception {
+        Map<String, Object> datasourceConfiguration = (Map<String, Object>) configuration.get("datasource");
+        writer = VectorDatabaseWriterProviderRegistry.createWriter(datasourceConfiguration);
+        writer.initialise(configuration);
+    }
+
+    @Override
+    public void start() throws Exception {
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (writer != null) {
+            writer.close();
+        }
+    }
+
+    @Override
+    public void write(List<Record> records) throws Exception {
+
+        // naive implementation, no batching
+        Map<String, Object> context = Map.of();
+        for (Record record : records) {
+            writer.upsert(record, context);
+            callback.commit(List.of(record));
+        }
+    }
+
+    @Override
+    public void setCommitCallback(CommitCallback callback) {
+        this.callback = callback;
+    }
+}

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/datasource/impl/PineconeConfig.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/datasource/impl/PineconeConfig.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.vector.datasource.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public final class PineconeConfig {
+    @JsonProperty(value = "api-key", required = true)
+    private String apiKey;
+    @JsonProperty(value = "environment", required = true)
+    private String environment = "default";
+    @JsonProperty(value = "project-name", required = true)
+    private String projectName;
+    @JsonProperty(value = "index-name", required = true)
+    private String indexName;
+    @JsonProperty(value = "endpoint")
+    private String endpoint;
+    @JsonProperty("server-side-timeout-sec")
+    private int serverSideTimeoutSec = 10;
+}

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/datasource/impl/PineconeWriter.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/datasource/impl/PineconeWriter.java
@@ -15,9 +15,15 @@
  */
 package ai.langstream.agents.vector.datasource.impl;
 
-import ai.langstream.ai.agents.datasource.DataSourceProvider;
+import ai.langstream.ai.agents.GenAIToolKitAgent;
+import ai.langstream.api.database.VectorDatabaseWriter;
+import ai.langstream.api.database.VectorDatabaseWriterProvider;
+import ai.langstream.api.runner.code.Record;
+import com.datastax.oss.streaming.ai.TransformContext;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import com.datastax.oss.streaming.ai.jstl.JstlEvaluator;
 import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -25,39 +31,38 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NegotiationType;
-import io.grpc.netty.NettyChannelBuilder;
 import io.pinecone.PineconeClient;
 import io.pinecone.PineconeClientConfig;
 import io.pinecone.PineconeConnection;
 import io.pinecone.PineconeConnectionConfig;
-import io.pinecone.PineconeException;
 import io.pinecone.proto.QueryRequest;
 import io.pinecone.proto.QueryResponse;
 import io.pinecone.proto.QueryVector;
 import io.pinecone.proto.SparseValues;
+import io.pinecone.proto.UpsertRequest;
+import io.pinecone.proto.UpsertResponse;
+import io.pinecone.proto.Vector;
 import lombok.Data;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 
-import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class PineconeDataSource implements DataSourceProvider {
+public class PineconeWriter implements VectorDatabaseWriterProvider {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -67,29 +72,11 @@ public class PineconeDataSource implements DataSourceProvider {
         return "pinecone".equals(dataSourceConfig.get("service"));
     }
 
-    @Data
-    public static final class PineconeConfig {
-        @JsonProperty(value = "api-key", required = true)
-        private String apiKey;
-        @JsonProperty(value = "environment", required = true)
-        private String environment = "default";
-        @JsonProperty(value = "project-name", required = true)
-        private String projectName;
-        @JsonProperty(value = "index-name", required = true)
-        private String indexName;
-        @JsonProperty(value = "endpoint")
-        private String endpoint;
-        @JsonProperty("server-side-timeout-sec")
-        private int serverSideTimeoutSec = 10;
-    }
-
     @Override
-    public QueryStepDataSource createDataSourceImplementation(Map<String, Object> dataSourceConfig) {
-
-        PineconeConfig clientConfig = MAPPER.convertValue(dataSourceConfig, PineconeConfig.class);
-
-        return new PinecodeQueryStepDataSource(clientConfig);
+    public VectorDatabaseWriter createImplementation(Map<String, Object> datasourceConfig) {
+        return new PineconeVectorDatabaseWriter(datasourceConfig);
     }
+
 
     private static class PinecodeQueryStepDataSource implements QueryStepDataSource {
 
@@ -355,4 +342,102 @@ public class PineconeDataSource implements DataSourceProvider {
         private List<Float> values;
     }
 
+    private static class PineconeVectorDatabaseWriter implements VectorDatabaseWriter {
+
+        private PineconeConnection connection;
+        private JstlEvaluator idFunction;
+        private JstlEvaluator namespaceFunction;
+        private JstlEvaluator vectorFunction;
+        private Map<String, JstlEvaluator> metadataFunctions;
+        private final PineconeConfig clientConfig;
+
+        public PineconeVectorDatabaseWriter(Map<String, Object> datasourceConfig) {
+            this.clientConfig = MAPPER.convertValue(datasourceConfig, PineconeConfig.class);
+        }
+
+        @Override
+        public void initialise(Map<String, Object> agentConfiguration) throws Exception {
+
+            this.idFunction = buildEvaluator(agentConfiguration, "vector.id", String.class);
+            this.vectorFunction = buildEvaluator(agentConfiguration, "vector.vector", List.class);
+            this.namespaceFunction = buildEvaluator(agentConfiguration, "vector.namespace", String.class);
+
+            this.metadataFunctions = new HashMap<>();
+            agentConfiguration.forEach((key, value) -> {
+                if (key.startsWith("vector.metadata.")) {
+                    String metadataKey = key.substring("vector.metadata.".length());
+                    metadataFunctions.put(metadataKey, buildEvaluator(agentConfiguration, key, Object.class));
+                }
+            });
+
+
+            PineconeClientConfig pineconeClientConfig = new PineconeClientConfig()
+                    .withApiKey(clientConfig.getApiKey())
+                    .withEnvironment(clientConfig.getEnvironment())
+                    .withProjectName(clientConfig.getProjectName())
+                    .withServerSideTimeoutSec(clientConfig.getServerSideTimeoutSec());
+            PineconeClient pineconeClient = new PineconeClient(pineconeClientConfig);
+            PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig()
+                    .withIndexName(clientConfig.getIndexName());
+            connection = pineconeClient.connect(connectionConfig);
+        }
+
+        @Override
+        public void upsert(Record record, Map<String, Object> context) throws Exception {
+
+            TransformContext transformContext = GenAIToolKitAgent.recordToTransformContext(record, true);
+            String id = idFunction != null ? (String) idFunction.evaluate(transformContext) : null;
+            String namespace = namespaceFunction != null ? (String) namespaceFunction.evaluate(transformContext) : null;
+            List<Object> vector = vectorFunction != null ? (List<Object>) vectorFunction.evaluate(transformContext) : null;
+            Map<String, Object> metadata = metadataFunctions.entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().evaluate(transformContext)));
+            Struct metadataStruct = Struct.newBuilder()
+                    .putAllFields(metadata.entrySet().stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey, e -> PinecodeQueryStepDataSource.convertToValue(e.getValue()))))
+                    .build();
+
+            List<Float> vectorFloat = null;
+            if (vector != null) {
+                vectorFloat = vector.stream()
+                        .map(n -> {
+                            if (n instanceof String s) {
+                                return Float.parseFloat(s);
+                            } else if (n instanceof Number u) {
+                                return u.floatValue();
+                            } else {
+                                throw new IllegalArgumentException("only vectors of floats are supported");
+                            }
+                        })
+                        .collect(Collectors.toList());
+            }
+
+            Vector v1 = Vector.newBuilder()
+                    .setId(id)
+                    .addAllValues(vectorFloat)
+                    .setMetadata(metadataStruct)
+                    .build();
+
+            UpsertRequest.Builder builder = UpsertRequest.newBuilder()
+                    .addVectors(v1);
+
+            if (namespace != null) {
+                builder.setNamespace(namespace);
+            }
+            UpsertRequest upsertRequest = builder.build();
+
+            UpsertResponse upsertResponse = connection.getBlockingStub()
+                    .upsert(upsertRequest);
+
+            log.info("Result {}", upsertResponse);
+
+        }
+    }
+
+    private static JstlEvaluator buildEvaluator(Map<String, Object> agentConfiguration, String param, Class type) {
+        String expression = agentConfiguration.getOrDefault(param, "").toString();
+        if (expression == null || expression.isEmpty()) {
+            return null;
+        }
+        return new JstlEvaluator("${" + expression + "}", type);
+    }
 }

--- a/langstream-agents/langstream-vector-agents/src/main/resources/META-INF/services/ai.langstream.api.database.VectorDatabaseWriterProvider
+++ b/langstream-agents/langstream-vector-agents/src/main/resources/META-INF/services/ai.langstream.api.database.VectorDatabaseWriterProvider
@@ -1,0 +1,1 @@
+ai.langstream.agents.vector.datasource.impl.PineconeWriter

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
@@ -31,7 +31,7 @@ class PineconeDataSourceTest {
     void testPineconeQuery() {
         PineconeDataSource dataSource = new PineconeDataSource();
         Map<String, Object> config = Map.of(
-                "api-key", "1ba1052e-e4a7-48a0-8568-42dba961207e",
+                "api-key", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
                 "environment","asia-southeast1-gcp-free",
                 "project-name", "032e3d0",
                 "index-name", "example-index");
@@ -56,7 +56,7 @@ class PineconeDataSourceTest {
     void testPineconeQueryWithFilter() {
         PineconeDataSource dataSource = new PineconeDataSource();
         Map<String, Object> config = Map.of(
-                "api-key", "1ba1052e-e4a7-48a0-8568-42dba961207e",
+                "api-key", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
                 "environment","asia-southeast1-gcp-free",
                 "project-name", "032e3d0",
                 "index-name", "example-index");

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @Slf4j
 class PineconeDataSourceTest {
 
@@ -37,7 +35,7 @@ class PineconeDataSourceTest {
                 "environment","asia-southeast1-gcp-free",
                 "project-name", "032e3d0",
                 "index-name", "example-index");
-        QueryStepDataSource implementation = dataSource.createImplementation(config);
+        QueryStepDataSource implementation = dataSource.createDataSourceImplementation(config);
         implementation.initialize(null);
 
         String query = """
@@ -62,7 +60,7 @@ class PineconeDataSourceTest {
                 "environment","asia-southeast1-gcp-free",
                 "project-name", "032e3d0",
                 "index-name", "example-index");
-        QueryStepDataSource implementation = dataSource.createImplementation(config);
+        QueryStepDataSource implementation = dataSource.createDataSourceImplementation(config);
         implementation.initialize(null);
 
         String query = """

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
@@ -38,10 +38,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class PineconeWriterTest {
 
     @Test
+    @Disabled
     void testPineconeWrite() throws Exception {
 
         Map<String, Object> datasourceConfig = Map.of("service", "pinecone",
-                "api-key", "1ba1052e-e4a7-48a0-8568-42dba961207e",
+                "api-key", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
                 "environment", "asia-southeast1-gcp-free",
                 "project-name", "032e3d0",
                 "index-name", "example-index");

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.vector.datasource.impl;
+
+import ai.langstream.agents.vector.VectorDBSinkAgent;
+import ai.langstream.api.runner.code.AgentCodeRegistry;
+import ai.langstream.api.runner.code.AgentSink;
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.code.SimpleRecord;
+import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+class PineconeWriterTest {
+
+    @Test
+    void testPineconeWrite() throws Exception {
+
+        Map<String, Object> datasourceConfig = Map.of("service", "pinecone",
+                "api-key", "1ba1052e-e4a7-48a0-8568-42dba961207e",
+                "environment", "asia-southeast1-gcp-free",
+                "project-name", "032e3d0",
+                "index-name", "example-index");
+        VectorDBSinkAgent agent = (VectorDBSinkAgent) new AgentCodeRegistry().getAgentCode("vector-db-sink");
+        Map<String, Object> configuration = new HashMap<>();
+        configuration.put("datasource", datasourceConfig);
+
+        configuration.put("vector.id", "value.id");
+        configuration.put("vector.vector", "value.vector");
+        configuration.put("vector.namespace", "");
+        configuration.put("vector.metadata.genre", "value.genre");
+
+        agent.init(configuration);
+        agent.start();
+        List<Record> committed = new ArrayList<>();
+        agent.setCommitCallback(new AgentSink.CommitCallback() {
+            @Override
+            public void commit(List<Record> records) {
+                committed.addAll(records);
+            }
+        });
+        String genre = "random" + UUID.randomUUID();
+        List<Float> vector = new ArrayList<>();
+        for (int i = 0; i < 1536; i++) {
+            vector.add((float) (1f / i));
+        }
+        Map<String, Object> value = Map.of("id", "1",
+                "vector", vector, "genre", genre);
+        SimpleRecord record = SimpleRecord.of(null, new ObjectMapper().writeValueAsString(value));
+        agent.write(List.of(record));
+
+        assertEquals(committed.get(0), record);
+        agent.close();
+
+        PineconeDataSource dataSource = new PineconeDataSource();
+        QueryStepDataSource implementation = dataSource.createDataSourceImplementation(datasourceConfig);
+        implementation.initialize(null);
+
+        String query = """
+                {
+                      "vector": ?,
+                      "topK": 5,
+                      "filter":
+                        {"genre": ?}
+                    }
+                """;
+        List<Object> params = List.of(
+                vector,
+                genre
+        );
+        List<Map<String, String>> results = implementation.fetchData(query, params);
+        log.info("Results: {}", results);
+
+        assertEquals(results.size(), 1);
+    }
+
+}

--- a/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriter.java
+++ b/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriter.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.database;
+
+import ai.langstream.api.runner.code.Record;
+
+import java.util.Map;
+
+/**
+ * This is the interface for writing to a vector database.
+ * this interface is really simple by intention.
+ * For advanced usages users should use Kafka Connect connectors.
+ */
+public interface VectorDatabaseWriter {
+
+    default void initialise(Map<String, Object> agentConfiguration) throws Exception  {}
+
+    /**
+     * Update a record, insert if it does not exist.
+     * If value is NULL then the record is deleted.
+     * @param record the record
+     * @param context additional context
+     * @throws Exception
+     */
+    void upsert(Record record, Map<String, Object> context) throws Exception ;
+    default void close() throws Exception {}
+}

--- a/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriterProvider.java
+++ b/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriterProvider.java
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.ai.agents.datasource;
+package ai.langstream.api.database;
 
-import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import ai.langstream.api.gateway.GatewayAuthenticationResult;
+import ai.langstream.api.gateway.GatewayRequestContext;
 
 import java.util.Map;
 
-public interface DataSourceProvider {
+public interface VectorDatabaseWriterProvider {
 
-    boolean supports(Map<String, Object> dataSourceConfig);
+    boolean supports(Map<String, Object> datasource);
 
-    QueryStepDataSource createDataSourceImplementation(Map<String, Object> dataSourceConfig);
+    VectorDatabaseWriter createImplementation(Map<String, Object> datasource);
+
 }

--- a/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriterProviderRegistry.java
+++ b/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriterProviderRegistry.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.database;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+
+public class VectorDatabaseWriterProviderRegistry {
+
+
+    public static VectorDatabaseWriter createWriter(Map<String, Object> configuration) {
+        Map<String, Object> conf = configuration == null ? Map.of() : configuration;
+        ServiceLoader<VectorDatabaseWriterProvider> loader = ServiceLoader.load(VectorDatabaseWriterProvider.class);
+        final VectorDatabaseWriterProvider store = loader
+                .stream()
+                .filter(p -> {
+                    return p.get().supports(conf);
+                })
+                .findFirst()
+                .orElseThrow(
+                        () -> new RuntimeException("No VectorDatabaseWriterProvider found for datasource " + configuration)
+                )
+                .get();
+        return store.createImplementation(configuration);
+    }
+}

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProvider.java
@@ -36,7 +36,7 @@ import java.util.Set;
 public class QueryVectorDBAgentProvider extends AbstractComposableAgentProvider {
 
     public QueryVectorDBAgentProvider() {
-        super(Set.of("query-vector-db"), List.of(KubernetesClusterRuntime.CLUSTER_TYPE));
+        super(Set.of("query-vector-db", "vector-db-sink"), List.of(KubernetesClusterRuntime.CLUSTER_TYPE));
     }
 
     @Override

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProvider.java
@@ -41,7 +41,14 @@ public class QueryVectorDBAgentProvider extends AbstractComposableAgentProvider 
 
     @Override
     protected ComponentType getComponentType(AgentConfiguration agentConfiguration) {
-        return ComponentType.PROCESSOR;
+        switch (agentConfiguration.getType()) {
+            case "query-vector-db":
+                return ComponentType.PROCESSOR;
+            case "vector-db-sink":
+                return ComponentType.SINK;
+            default:
+                throw new IllegalStateException();
+        }
     }
 
     @Override

--- a/langstream-pulsar/pom.xml
+++ b/langstream-pulsar/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>pulsar-client-admin</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>pulsar</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
         <version>${pulsar.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-client</artifactId>
+        <version>${pulsar.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>streaming-ai</artifactId>
         <version>${streaming-ai.version}</version>


### PR DESCRIPTION
Summary:
- introduce a new "vector-db-sink" agent, that is able to write to "Vector databases"
- introduce the first implementation for Pinecone
- the examples/applications/query-pinecone application now both writes and reads from Pinecone
- the syntax for the mapping is the same as for the "compute" step (based on the JSTL Expression Language)

In Pinecone a Vector has an id, a vector and a bunch of metadata (please refer to the Pinecone docs).
In the Sink you can declare how those fields are computed.
The syntax depends on the Vector DB, as each Vector DB has its own model.

Sample pipeline:

```
name: "Index Products on Vector Database"
topics:
  - name: "vectors-topic"
    creation-mode: create-if-not-exists
errors:
    on-failure: skip
pipeline:
  - name: "compute-embeddings"
    id: "step1"
    type: "compute-ai-embeddings"
    input: "vectors-topic"
    configuration:
      model: "text-embedding-ada-002" # This needs to match the name of the model deployment, not the base model
      embeddings-field: "value.embeddings"
      text: "{{% value.document }}"
  - name: "Write to Pinecone"
    type: "vector-db-sink"
    configuration:
      datasource: "PineconeDatasource"
      vector.id: "value.id"
      vector.vector: "value.embeddings"
      vector.namespace: ""
      vector.metadata.genre: "value.genre"
```
