### PR TITLE
Package system agents with isolated classpath (using NiFi Nar)

### DIFF
--- a/examples/applications/query-jdbc/configuration.yaml
+++ b/examples/applications/query-jdbc/configuration.yaml
@@ -24,7 +24,7 @@ configuration:
         driverClass: "org.postgresql.Driver"
         url: "jdbc:postgresql://postgresql.default.svc.cluster.local:5432/"
         user: "postgres"
-        password: "dL3WGSrrpq"
+        password: "pCVieR3u1q"
   dependencies:
     - name: "PostGRES JDBC Driver"
       url: "https://jdbc.postgresql.org/download/postgresql-42.6.0.jar"

--- a/langstream-agents/langstream-agent-s3/pom.xml
+++ b/langstream-agents/langstream-agent-s3/pom.xml
@@ -35,6 +35,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-api</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.minio</groupId>

--- a/langstream-agents/langstream-agent-s3/pom.xml
+++ b/langstream-agents/langstream-agent-s3/pom.xml
@@ -73,4 +73,25 @@
       <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
+++ b/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
@@ -150,7 +150,7 @@ public class S3SourceTest {
     }
 
     private AgentSource buildAgentSource(String bucket) throws Exception {
-        AgentSource agentSource = (AgentSource) AGENT_CODE_REGISTRY.getAgentCode("s3-source");
+        AgentSource agentSource = (AgentSource) AGENT_CODE_REGISTRY.getAgentCode("s3-source").agentCode();
         Map<String, Object> configs = new HashMap<>();
         String endpoint = localstack.getEndpointOverride(S3).toString();
         configs.put("endpoint", endpoint);

--- a/langstream-agents/langstream-agent-webcrawler/pom.xml
+++ b/langstream-agents/langstream-agent-webcrawler/pom.xml
@@ -40,6 +40,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-api</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.minio</groupId>

--- a/langstream-agents/langstream-agent-webcrawler/pom.xml
+++ b/langstream-agents/langstream-agent-webcrawler/pom.xml
@@ -83,4 +83,25 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -178,7 +178,7 @@ public class WebCrawlerSourceTest {
     }
 
     private WebCrawlerSource buildAgentSource(String bucket, String domain, String seedUrl) throws Exception {
-        AgentSource agentSource = (AgentSource) AGENT_CODE_REGISTRY.getAgentCode("webcrawler-source");
+        AgentSource agentSource = (AgentSource) AGENT_CODE_REGISTRY.getAgentCode("webcrawler-source").agentCode();
         Map<String, Object> configs = new HashMap<>();
         String endpoint = localstack.getEndpointOverride(S3).toString();
         configs.put("endpoint", endpoint);

--- a/langstream-agents/langstream-agents-text-processing/pom.xml
+++ b/langstream-agents/langstream-agents-text-processing/pom.xml
@@ -95,4 +95,25 @@
       <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/langstream-agents/langstream-agents-text-processing/pom.xml
+++ b/langstream-agents/langstream-agents-text-processing/pom.xml
@@ -35,6 +35,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-api</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>

--- a/langstream-agents/langstream-ai-agents/pom.xml
+++ b/langstream-agents/langstream-ai-agents/pom.xml
@@ -114,6 +114,28 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <repositories>
     <repository>
       <id>public-datastax-releases</id>

--- a/langstream-agents/langstream-ai-agents/pom.xml
+++ b/langstream-agents/langstream-ai-agents/pom.xml
@@ -34,6 +34,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-api</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>

--- a/langstream-agents/langstream-vector-agents/pom.xml
+++ b/langstream-agents/langstream-vector-agents/pom.xml
@@ -75,4 +75,25 @@
       <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>nar</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-nar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>nar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/langstream-agents/langstream-vector-agents/pom.xml
+++ b/langstream-agents/langstream-vector-agents/pom.xml
@@ -35,6 +35,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-api</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
@@ -46,7 +46,7 @@ class PineconeWriterTest {
                 "environment", "asia-southeast1-gcp-free",
                 "project-name", "032e3d0",
                 "index-name", "example-index");
-        VectorDBSinkAgent agent = (VectorDBSinkAgent) new AgentCodeRegistry().getAgentCode("vector-db-sink");
+        VectorDBSinkAgent agent = (VectorDBSinkAgent) new AgentCodeRegistry().getAgentCode("vector-db-sink").agentCode();
         Map<String, Object> configuration = new HashMap<>();
         configuration.put("datasource", datasourceConfig);
 

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeAndLoader.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.runner.code;
+
+import ai.langstream.api.runtime.ComponentType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public record AgentCodeAndLoader(AgentCode agentCode, ClassLoader classLoader) {
+
+    public boolean isSource() {
+        return agentCode instanceof AgentSource;
+    }
+
+    public boolean isSink() {
+        return agentCode instanceof AgentSink;
+    }
+
+    public boolean isProcessor() {
+        return agentCode instanceof AgentProcessor;
+    }
+
+    public boolean is(Predicate<AgentCode> predicate) {
+        return predicate.test(agentCode);
+    }
+
+    public void executeWithContextClassloader(RunnableWithException code) throws Exception {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            code.run(agentCode);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public void executeNoExceptionWithContextClassloader(RunnableNoException code) {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            code.run(agentCode);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public <T> T callWithContextClassloader(CallableWithException code) throws Exception {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return (T) code.call(agentCode);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public <T> T callNoExceptionWithContextClassloader(CallableNoException code) {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return (T) code.call(agentCode);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public AgentSource asSource() {
+
+        return new AgentSource() {
+            @Override
+            public List<Record> read() throws Exception {
+                return callWithContextClassloader(agentCode -> ((AgentSource) agentCode).read());
+            }
+
+            @Override
+            public void commit(List<Record> records) throws Exception {
+                executeWithContextClassloader(agentCode -> ((AgentSource) agentCode).commit(records));
+            }
+
+            @Override
+            public String agentId() {
+                return callNoExceptionWithContextClassloader(AgentCode::agentId);
+            }
+
+            @Override
+            public String agentType() {
+                return callNoExceptionWithContextClassloader(AgentCode::agentType);
+            }
+
+            @Override
+            public List<AgentStatusResponse> getAgentStatus() {
+                return callNoExceptionWithContextClassloader(AgentCode::getAgentStatus);
+            }
+
+            @Override
+            public void setMetadata(String id, String agentType, long startedAt) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.setMetadata(id, agentType, startedAt));
+            }
+
+            @Override
+            public void init(Map<String, Object> configuration) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.init(configuration));
+            }
+
+            @Override
+            public void setContext(AgentContext context) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.setContext(context));
+            }
+
+            @Override
+            public void start() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.start());
+            }
+
+            @Override
+            public void close() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.close());
+            }
+
+            @Override
+            public ComponentType componentType() {
+                return callNoExceptionWithContextClassloader(AgentCode::componentType);
+            }
+        };
+    }
+
+    public AgentSink asSink() {
+
+        return new AgentSink() {
+
+            @Override
+            public void write(List<Record> records) throws Exception {
+                executeWithContextClassloader(agentCode -> ((AgentSink) agentCode).write(records));
+            }
+
+            @Override
+            public void setCommitCallback(CommitCallback callback) {
+                executeNoExceptionWithContextClassloader(agentCode -> ((AgentSink) agentCode).setCommitCallback(callback));
+            }
+
+            @Override
+            public String agentId() {
+                return callNoExceptionWithContextClassloader(AgentCode::agentId);
+            }
+
+            @Override
+            public String agentType() {
+                return callNoExceptionWithContextClassloader(AgentCode::agentType);
+            }
+
+            @Override
+            public List<AgentStatusResponse> getAgentStatus() {
+                return callNoExceptionWithContextClassloader(AgentCode::getAgentStatus);
+            }
+
+            @Override
+            public void setMetadata(String id, String agentType, long startedAt) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.setMetadata(id, agentType, startedAt));
+            }
+
+            @Override
+            public void init(Map<String, Object> configuration) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.init(configuration));
+            }
+
+            @Override
+            public void setContext(AgentContext context) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.setContext(context));
+            }
+
+            @Override
+            public void start() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.start());
+            }
+
+            @Override
+            public void close() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.close());
+            }
+
+            @Override
+            public ComponentType componentType() {
+                return callNoExceptionWithContextClassloader(AgentCode::componentType);
+            }
+        };
+    }
+
+    public AgentProcessor asProcessor() {
+
+        return new AgentProcessor() {
+            @Override
+            public List<SourceRecordAndResult> process(List<Record> records) throws Exception {
+                return callWithContextClassloader(agentCode -> ((AgentProcessor) agentCode).process(records));
+            }
+
+            @Override
+            public String agentId() {
+                return callNoExceptionWithContextClassloader(AgentCode::agentId);
+            }
+
+            @Override
+            public String agentType() {
+                return callNoExceptionWithContextClassloader(AgentCode::agentType);
+            }
+
+            @Override
+            public List<AgentStatusResponse> getAgentStatus() {
+                return callNoExceptionWithContextClassloader(AgentCode::getAgentStatus);
+            }
+
+            @Override
+            public void setMetadata(String id, String agentType, long startedAt) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.setMetadata(id, agentType, startedAt));
+            }
+
+            @Override
+            public void init(Map<String, Object> configuration) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.init(configuration));
+            }
+
+            @Override
+            public void setContext(AgentContext context) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.setContext(context));
+            }
+
+            @Override
+            public void start() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.start());
+            }
+
+            @Override
+            public void close() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.close());
+            }
+
+            @Override
+            public ComponentType componentType() {
+                return callNoExceptionWithContextClassloader(AgentCode::componentType);
+            }
+        };
+    }
+
+    public void close() throws Exception {
+        executeWithContextClassloader(agentCode -> agentCode.close());
+    }
+
+    @FunctionalInterface
+    public interface RunnableWithException {
+        void run(AgentCode agent) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface RunnableNoException {
+        void run(AgentCode agent);
+    }
+
+    @FunctionalInterface
+    public interface CallableWithException {
+        Object call(AgentCode agent) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface CallableNoException {
+        Object call(AgentCode agent) ;
+    }
+}

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeRegistry.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeRegistry.java
@@ -15,8 +15,13 @@
  */
 package ai.langstream.api.runner.code;
 
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The runtime registry is a singleton that holds all the runtime information about the
@@ -24,16 +29,31 @@ import java.util.ServiceLoader;
  */
 public class AgentCodeRegistry {
 
-    public AgentCode getAgentCode(String agentType) {
-        Objects.requireNonNull(agentType, "agentType cannot be null");
-        ServiceLoader<AgentCodeProvider> loader = ServiceLoader.load(AgentCodeProvider.class);
-        ServiceLoader.Provider<AgentCodeProvider> agentCodeProviderProvider = loader
-                .stream()
-                .filter(p -> p.get().supports(agentType))
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException("No AgentCodeProvider found for type " + agentType));
+    private List<ClassLoader> classloaders = new CopyOnWriteArrayList<>();
 
-        return agentCodeProviderProvider.get().createInstance(agentType);
+    public AgentCodeRegistry() {
+        this.classloaders.add(AgentCodeRegistry.class.getClassLoader());
     }
 
+    public AgentCode getAgentCode(String agentType) {
+        Objects.requireNonNull(agentType, "agentType cannot be null");
+
+        for (ClassLoader classLoader :classloaders) {
+            ServiceLoader<AgentCodeProvider> loader = ServiceLoader.load(AgentCodeProvider.class, classLoader);
+            Optional<ServiceLoader.Provider<AgentCodeProvider>> agentCodeProviderProvider = loader
+                    .stream()
+                    .filter(p -> p.get().supports(agentType))
+                    .findFirst();
+
+            if (agentCodeProviderProvider.isPresent()) {
+                return agentCodeProviderProvider.get().get().createInstance(agentType);
+            }
+        }
+
+        throw new RuntimeException("No AgentCodeProvider found for type " + agentType);
+    }
+
+    public void addClassloaders(List<? extends ClassLoader> classloaders) {
+        this.classloaders.addAll(classloaders);
+    }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeRegistry.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeRegistry.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.api.runner.code;
 
-import java.net.URLClassLoader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -35,7 +33,9 @@ public class AgentCodeRegistry {
         this.classloaders.add(AgentCodeRegistry.class.getClassLoader());
     }
 
-    public AgentCode getAgentCode(String agentType) {
+
+
+    public AgentCodeAndLoader getAgentCode(String agentType) {
         Objects.requireNonNull(agentType, "agentType cannot be null");
 
         for (ClassLoader classLoader :classloaders) {
@@ -46,7 +46,7 @@ public class AgentCodeRegistry {
                     .findFirst();
 
             if (agentCodeProviderProvider.isPresent()) {
-                return agentCodeProviderProvider.get().get().createInstance(agentType);
+                return new AgentCodeAndLoader(agentCodeProviderProvider.get().get().createInstance(agentType), classLoader);
             }
         }
 

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -99,13 +99,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- main implementation for the AI Agents -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>langstream-ai-agents</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-k8s-runtime-core</artifactId>
@@ -327,6 +320,15 @@
               <artifactItems>
 
                 <!-- main implementation for the Agents -->
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>langstream-ai-agents</artifactId>
+                  <version>${project.version}</version>
+                  <type>nar</type>
+                  <classifier>nar</classifier>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                </artifactItem>
 
                 <artifactItem>
                     <groupId>${project.groupId}</groupId>

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -113,34 +113,7 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- main implementation for the Agents -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>langstream-agent-s3</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-    </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>langstream-agent-webcrawler</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>langstream-agents-text-processing</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>langstream-vector-agents</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-    </dependency>
 
     <!-- used by Pulsar and Pinecone -->
     <dependency>
@@ -339,6 +312,110 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+
+                <!-- main implementation for the Agents -->
+
+                <artifactItem>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>langstream-agents-text-processing</artifactId>
+                    <version>${project.version}</version>
+                    <type>nar</type>
+                    <classifier>nar</classifier>
+                    <overWrite>false</overWrite>
+                    <outputDirectory>${build.directory}/agents</outputDirectory>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>langstream-agent-s3</artifactId>
+                  <version>${project.version}</version>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>langstream-agent-webcrawler</artifactId>
+                  <version>${project.version}</version>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>langstream-vector-agents</artifactId>
+                  <version>${project.version}</version>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                </artifactItem>
+
+              </artifactItems>
+
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptors>
+            <descriptor>${project.basedir}/src/main/assemble/langstream-runtime.xml</descriptor>
+          </descriptors>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+          <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+          <runOrder>alphabetical</runOrder>
+          <includes>
+            <include>**/*IT*</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -344,6 +344,8 @@
                   <groupId>${project.groupId}</groupId>
                   <artifactId>langstream-agent-s3</artifactId>
                   <version>${project.version}</version>
+                  <type>nar</type>
+                  <classifier>nar</classifier>
                   <overWrite>false</overWrite>
                   <outputDirectory>${build.directory}/agents</outputDirectory>
                 </artifactItem>
@@ -352,6 +354,8 @@
                   <groupId>${project.groupId}</groupId>
                   <artifactId>langstream-agent-webcrawler</artifactId>
                   <version>${project.version}</version>
+                  <type>nar</type>
+                  <classifier>nar</classifier>
                   <overWrite>false</overWrite>
                   <outputDirectory>${build.directory}/agents</outputDirectory>
                 </artifactItem>
@@ -360,6 +364,8 @@
                   <groupId>${project.groupId}</groupId>
                   <artifactId>langstream-vector-agents</artifactId>
                   <version>${project.version}</version>
+                  <type>nar</type>
+                  <classifier>nar</classifier>
                   <overWrite>false</overWrite>
                   <outputDirectory>${build.directory}/agents</outputDirectory>
                 </artifactItem>

--- a/langstream-runtime/langstream-runtime-impl/src/main/assemble/langstream-runtime.xml
+++ b/langstream-runtime/langstream-runtime-impl/src/main/assemble/langstream-runtime.xml
@@ -20,7 +20,7 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>runtime</id>
   <formats>
-    <format>tar.gz</format>
+    <format>dir</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
   <fileSets>
@@ -56,6 +56,10 @@
       <outputDirectory>.</outputDirectory>
       <lineEnding>unix</lineEnding>
       <fileMode>755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>target/agents</directory>
+      <outputDirectory>./agents</outputDirectory>
     </fileSet>
   </fileSets>
   <dependencySets>

--- a/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
@@ -68,6 +68,8 @@ ADD maven/lib /app/lib
 ADD maven/entrypoint.sh /app/entrypoint.sh
 ADD maven/langstream /app/langstream
 ADD maven/langstream_runtime /app/langstream_runtime
+ADD maven/agents /app/agents
+
 WORKDIR /app
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
@@ -16,6 +16,8 @@
 package ai.langstream.runtime.agent;
 
 import ai.langstream.api.runner.code.AbstractAgentCode;
+import ai.langstream.api.runner.code.AgentCode;
+import ai.langstream.api.runner.code.AgentCodeAndLoader;
 import ai.langstream.api.runner.code.AgentCodeRegistry;
 import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentStatusResponse;
@@ -68,14 +70,16 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
             String agentId1 = (String) sourceDefinition.get("agentId");
             String agentType1 = (String) sourceDefinition.get("agentType");
             Map<String, Object> agentConfiguration = (Map<String, Object>) sourceDefinition.get("configuration");
-            source = (AgentSource) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry);
+            source = AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry)
+                    .asSource();
         }
 
         for (Map<String, Object> agentDefinition : processorsDefinition) {
             String agentId1 = (String) agentDefinition.get("agentId");
             String agentType1 = (String) agentDefinition.get("agentType");
             Map<String, Object> agentConfiguration = (Map<String, Object>) agentDefinition.get("configuration");
-            AgentProcessor agent = (AgentProcessor) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry);
+            AgentProcessor agent = AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry)
+                            .asProcessor();
             processors.add(agent);
         }
 
@@ -83,7 +87,8 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
             String agentId1 = (String) sinkDefinition.get("agentId");
             String agentType1 = (String) sinkDefinition.get("agentType");
             Map<String, Object> agentConfiguration = (Map<String, Object>) sinkDefinition.get("configuration");
-            sink = (AgentSink) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry);
+            sink = AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry)
+                    .asSink();
         }
     }
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
@@ -16,6 +16,7 @@
 package ai.langstream.runtime.agent;
 
 import ai.langstream.api.runner.code.AbstractAgentCode;
+import ai.langstream.api.runner.code.AgentCodeRegistry;
 import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentStatusResponse;
 import ai.langstream.api.runner.code.AgentProcessor;
@@ -39,6 +40,12 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
     private final List<AgentProcessor> processors = new ArrayList<>();
     private AgentSink sink;
 
+    private AgentCodeRegistry agentCodeRegistry;
+
+    public void configureAgentCodeRegistry(AgentCodeRegistry agentCodeRegistry) {
+        this.agentCodeRegistry = agentCodeRegistry;
+    }
+
     @Override
     public void init(Map<String, Object> configuration) throws Exception {
         List<Map<String, Object>> processorsDefinition = null;
@@ -61,14 +68,14 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
             String agentId1 = (String) sourceDefinition.get("agentId");
             String agentType1 = (String) sourceDefinition.get("agentType");
             Map<String, Object> agentConfiguration = (Map<String, Object>) sourceDefinition.get("configuration");
-            source = (AgentSource) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration);
+            source = (AgentSource) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry);
         }
 
         for (Map<String, Object> agentDefinition : processorsDefinition) {
             String agentId1 = (String) agentDefinition.get("agentId");
             String agentType1 = (String) agentDefinition.get("agentType");
             Map<String, Object> agentConfiguration = (Map<String, Object>) agentDefinition.get("configuration");
-            AgentProcessor agent = (AgentProcessor) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration);
+            AgentProcessor agent = (AgentProcessor) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry);
             processors.add(agent);
         }
 
@@ -76,7 +83,7 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
             String agentId1 = (String) sinkDefinition.get("agentId");
             String agentType1 = (String) sinkDefinition.get("agentType");
             Map<String, Object> agentConfiguration = (Map<String, Object>) sinkDefinition.get("configuration");
-            sink = (AgentSink) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration);
+            sink = (AgentSink) AgentRunner.initAgent(agentId1, agentType1, startedAt(), agentConfiguration, agentCodeRegistry);
         }
     }
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/api/AgentInfo.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/api/AgentInfo.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.runtime.agent.api;
 
+import ai.langstream.api.runner.code.AgentCode;
 import ai.langstream.api.runner.code.AgentStatusResponse;
 import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.AgentSink;
@@ -25,19 +26,19 @@ import java.util.List;
 
 public class AgentInfo {
     private AgentProcessor processor;
-    private AgentSource source;
-    private AgentSink sink;
+    private AgentCode source;
+    private AgentCode sink;
 
 
     public void watchProcessor(AgentProcessor processor) {
         this.processor = processor;
     }
 
-    public void watchSource(AgentSource source) {
+    public void watchSource(AgentCode source) {
         this.source = source;
     }
 
-    public void watchSink(AgentSink sink) {
+    public void watchSink(AgentCode sink) {
         this.sink = sink;
     }
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/nar/NarFileHandler.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/nar/NarFileHandler.java
@@ -130,7 +130,6 @@ public class NarFileHandler implements AutoCloseable {
                     try (DirectoryStream<Path> allFiles = Files.newDirectoryStream(dependencies);) {
                         for (Path file : allFiles) {
                             if (file.getFileName().toString().endsWith(".jar")) {
-                                log.info("Adding dependency {}", file);
                                 urls.add(file.toUri().toURL());
                             }
                         }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/nar/NarFileHandler.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/nar/NarFileHandler.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.agent.nar;
+
+import ai.langstream.api.codestorage.GenericZipFileArchiveFile;
+import ai.langstream.api.codestorage.LocalZipFileArchiveFile;
+import com.datastax.dse.driver.api.core.cql.reactive.ReactiveSession;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.zip.ZipUtil;
+import org.apache.pulsar.common.nar.FileUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+
+public class NarFileHandler implements AutoCloseable {
+
+    private final Path packagesDirectory;
+    private final Path temporaryDirectory;
+
+    @Getter
+    private List<URLClassLoader> classloaders;
+    private Map<String, PackageMetadata> packages = new HashMap<>();
+
+    public NarFileHandler(Path packagesDirectory) throws Exception {
+        this.packagesDirectory = packagesDirectory;
+        this.temporaryDirectory = Files.createTempDirectory("nar");
+    }
+
+
+    private static void deleteDirectory(Path dir) throws Exception {
+        try (DirectoryStream<Path> all = Files.newDirectoryStream(dir)) {
+            for (Path file : all) {
+                if (Files.isDirectory(file)) {
+                    deleteDirectory(file);
+                } else {
+                    Files.delete(file);
+                }
+            }
+            Files.delete(dir);
+        }
+    }
+
+    public void close() {
+
+        if (classloaders != null) {
+            for (URLClassLoader classLoader : classloaders) {
+                try {
+                    classLoader.close();
+                } catch (Exception err) {
+                    log.error("Cannot close classloader {}", classLoader, err);
+                }
+            }
+        }
+
+        try {
+            deleteDirectory(temporaryDirectory);
+        } catch ( Exception e ) {
+            log.error("Cannot delete temporary directory {}", temporaryDirectory, e);
+        }
+    }
+
+    record PackageMetadata (Path nar, String name, Set<String> agents, Path directory) {}
+
+    public void scan() throws Exception {
+        try (DirectoryStream<Path> all = Files.newDirectoryStream(packagesDirectory, "*.nar")) {
+            for (Path narFile : all) {
+                handleNarFile(narFile);
+            }
+        } catch (Exception err) {
+            log.error("Failed to scan packages directory", err);
+            throw err;
+        }
+    }
+
+    public void handleNarFile(Path narFile) throws Exception {
+        String filename = narFile.getFileName().toString();
+        Path dest = temporaryDirectory.resolve(narFile.getFileName().toString() + ".dir");
+        log.info("Unpacking NAR file {} to {}", narFile, dest);
+        GenericZipFileArchiveFile file = new LocalZipFileArchiveFile(narFile);
+        file.extractTo(dest);
+
+
+        Path services = dest.resolve("META-INF/services");
+        if (Files.isDirectory(services)) {
+            Path agents = services.resolve("ai.langstream.api.runner.code.AgentCodeProvider");
+            if (Files.isRegularFile(agents)) {
+                PackageMetadata metadata = new PackageMetadata(narFile, filename, Set.of(), dest);
+                packages.put(filename, metadata);
+            }
+        }
+    }
+
+
+
+    public void createClassloaders(ClassLoader parent) throws Exception {
+        classloaders = new ArrayList<>();
+        for (PackageMetadata metadata : packages.values()) {
+            log.info("Creating classloader for package {}", metadata.name);
+            List<URL> urls = new ArrayList<>();
+
+            log.info("Adding agents code {}", metadata.directory);
+            urls.add(metadata.directory.toFile().toURI().toURL());
+
+            Path metaInfDirectory = metadata.directory
+                    .resolve("META-INF");
+            if (Files.isDirectory(metaInfDirectory)) {
+
+                Path dependencies = metaInfDirectory.resolve("bundled-dependencies");
+                if (Files.isDirectory(dependencies)) {
+                    try (DirectoryStream<Path> allFiles = Files.newDirectoryStream(dependencies);) {
+                        for (Path file : allFiles) {
+                            if (file.getFileName().toString().endsWith(".jar")) {
+                                log.info("Adding dependency {}", file);
+                                urls.add(file.toUri().toURL());
+                            }
+                        }
+                    }
+                }
+            }
+
+            URLClassLoader result = new URLClassLoader(urls.toArray(URL[]::new), parent);
+            classloaders.add(result);
+        }
+    }
+
+}

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/nar/NarFileHandler.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/nar/NarFileHandler.java
@@ -17,14 +17,8 @@ package ai.langstream.runtime.agent.nar;
 
 import ai.langstream.api.codestorage.GenericZipFileArchiveFile;
 import ai.langstream.api.codestorage.LocalZipFileArchiveFile;
-import com.datastax.dse.driver.api.core.cql.reactive.ReactiveSession;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.archivers.zip.ZipUtil;
-import org.apache.pulsar.common.nar.FileUtils;
-
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.DirectoryStream;

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -28,6 +28,8 @@ import ai.langstream.runtime.agent.AgentRunner;
 import ai.langstream.runtime.agent.api.AgentInfo;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import io.fabric8.kubernetes.api.model.Secret;
+
+import java.nio.file.Path;
 import java.util.HashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -59,6 +61,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 public abstract class AbstractApplicationRunner {
+
+    public static final Path agentsDirectory;
+
+    static {
+        agentsDirectory = Path.of(System.getProperty("user.dir"), "target", "agents");
+        log.info("Agents directory is {}", agentsDirectory);
+    }
 
 
     @RegisterExtension
@@ -211,7 +220,7 @@ public abstract class AbstractApplicationRunner {
                         log.info("{} AgentPod {} Started", runnerExecutionId, podConfiguration.agent().agentId());
                         AgentInfo agentInfo = new AgentInfo();
                         allAgentsInfo.put(podConfiguration.agent().agentId(), agentInfo);
-                        AgentRunner.run(podConfiguration, null, null, agentInfo, 10);
+                        AgentRunner.run(podConfiguration, null, null, agentsDirectory, agentInfo, 10);
                         List<?> infos = agentInfo.serveWorkerStatus();
                         log.info("{} AgentPod {} AgentInfo {}", runnerExecutionId, podConfiguration.agent().agentId(), infos);
                         handle.complete(null);

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ComputeEmbeddingsIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ComputeEmbeddingsIT.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @WireMockTest
-class ComputeEmbeddingsTest extends AbstractApplicationRunner {
+class ComputeEmbeddingsIT extends AbstractApplicationRunner {
 
 
     @AllArgsConstructor

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/GenIAgentsRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/GenIAgentsRunnerIT.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Slf4j
-class GenIAgentsRunnerTest extends AbstractApplicationRunner  {
+class GenIAgentsRunnerIT extends AbstractApplicationRunner  {
 
 
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/KafkaConnectSinkRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/KafkaConnectSinkRunnerIT.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Slf4j
-class KafkaConnectSinkRunnerTest extends AbstractApplicationRunner  {
+class KafkaConnectSinkRunnerIT extends AbstractApplicationRunner  {
 
 
     @Test

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/KafkaConnectSourceRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/KafkaConnectSourceRunnerIT.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 @Slf4j
-class KafkaConnectSourceRunnerTest extends AbstractApplicationRunner {
+class KafkaConnectSourceRunnerIT extends AbstractApplicationRunner {
 
     @Test
     public void testRunKafkaConnectSource() throws Exception {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/LoadAgentCodeIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/LoadAgentCodeIT.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
-class LoadAgentCodeTest {
+class LoadAgentCodeIT {
 
     @Test
     public void testLoadNoop() throws Exception {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/LoadAgentCodeTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/LoadAgentCodeTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
-class LoadAgentCodeIT {
+class LoadAgentCodeTest {
 
     @Test
     public void testLoadNoop() throws Exception {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/LoadAgentCodeTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/LoadAgentCodeTest.java
@@ -33,7 +33,7 @@ class LoadAgentCodeTest {
     @Test
     public void testLoadNoop() throws Exception {
         AgentCodeRegistry registry = new AgentCodeRegistry();
-        AgentProcessor noop = (AgentProcessor) registry.getAgentCode("noop");
+        AgentProcessor noop = (AgentProcessor) registry.getAgentCode("noop").agentCode();
         MyRecord myRecord = new MyRecord();
         assertTrue(noop.process(List.of(myRecord)).isEmpty());
     }
@@ -41,7 +41,7 @@ class LoadAgentCodeTest {
     @Test
     public void testLoadIdentity() throws Exception {
         AgentCodeRegistry registry = new AgentCodeRegistry();
-        AgentProcessor noop = (AgentProcessor) registry.getAgentCode("identity");
+        AgentProcessor noop = (AgentProcessor) registry.getAgentCode("identity").agentCode();
         MyRecord myRecord = new MyRecord();
         assertEquals(1, noop.process(List.of(myRecord)).get(0).getResultRecords().size());
         assertSame(myRecord, noop.process(List.of(myRecord)).get(0).getResultRecords().get(0));

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/QueryVectorDBIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/QueryVectorDBIT.java
@@ -16,15 +16,11 @@
 package ai.langstream.kafka;
 
 import ai.langstream.AbstractApplicationRunner;
-import ai.langstream.ai.agents.services.impl.HuggingFaceProvider;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.burningwave.tools.net.HostResolutionRequestInterceptor;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +31,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 
 @Slf4j
 @WireMockTest
-class QueryVectorDBTest extends AbstractApplicationRunner {
+class QueryVectorDBIT extends AbstractApplicationRunner {
 
 
     @Test

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/TextProcessingAgentsRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/TextProcessingAgentsRunnerIT.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-class TextProcessingAgentsRunnerTest extends AbstractApplicationRunner {
+class TextProcessingAgentsRunnerIT extends AbstractApplicationRunner {
 
     @Test
     public void testFullLanguageProcessingPipeline() throws Exception {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
@@ -159,7 +159,6 @@ class PulsarRunnerDockerTest {
     public static void setup() throws Exception {
         pulsarContainer = new PulsarContainer(DockerImageName.parse(IMAGE)
                 .asCompatibleSubstituteFor("apachepulsar/pulsar"))
-                .withFunctionsWorker()
                 .withStartupTimeout(Duration.ofSeconds(120)) // Mac M1 is slow with Intel docker images
                 .withLogConsumer(new Consumer<OutputFrame>() {
                     @Override

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Slf4j
 class PulsarRunnerDockerTest {
 
-    private static final String IMAGE = "datastax/lunastreaming-all:2.10_4.9";
+    private static final String IMAGE = "apachepulsar/pulsar:3.1.0";
 
     private static PulsarContainer pulsarContainer;
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.pulsar;
 
+import ai.langstream.AbstractApplicationRunner;
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.Connection;
 import ai.langstream.api.model.Module;
@@ -125,7 +126,7 @@ class PulsarRunnerDockerTest {
                     .send();
             producer.flush();
 
-            AgentRunner.run(runtimePodConfiguration, null, null, new AgentInfo(), 5);
+            AgentRunner.run(runtimePodConfiguration, null, null, AbstractApplicationRunner.agentsDirectory, new AgentInfo(), 5);
 
             // receive one message from the output-topic (written by the PodJavaRuntime)
             Message<byte[]> record = consumer.receive();

--- a/pom.xml
+++ b/pom.xml
@@ -454,6 +454,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.nifi</groupId>
+          <artifactId>nifi-nar-maven-plugin</artifactId>
+          <version>1.5.1</version>
+        </plugin>
+        <plugin>
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
           <version>${jib-maven-plugin.version}</version>
@@ -563,6 +568,16 @@
             <exclude>**/*CucumberTest*</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.6.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Summary:
- in order to prevent classpath pollution we have to package each system agent into a self-contained bundle
- at runtime we load each agent from their own package
