### PR TITLE
Control plane/CLI: add endpoint to download application's code

### DIFF
--- a/langstream-api/src/main/java/ai/langstream/api/codestorage/DownloadedCodeArchive.java
+++ b/langstream-api/src/main/java/ai/langstream/api/codestorage/DownloadedCodeArchive.java
@@ -16,6 +16,7 @@
 package ai.langstream.api.codestorage;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 
 
@@ -27,6 +28,10 @@ import java.nio.file.Path;
  * - connectors: contains the jars for Kafka Connect connectors
  */
 public interface DownloadedCodeArchive {
+
+    InputStream getInputStream() throws IOException, CodeStorageException;
+
+    byte[] getData() throws IOException, CodeStorageException;
 
     /**
      * This method is used to extract the contents of the archive to a directory.

--- a/langstream-api/src/main/java/ai/langstream/api/codestorage/GenericZipFileArchiveFile.java
+++ b/langstream-api/src/main/java/ai/langstream/api/codestorage/GenericZipFileArchiveFile.java
@@ -28,14 +28,12 @@ import java.util.zip.ZipInputStream;
  */
 public abstract class GenericZipFileArchiveFile implements DownloadedCodeArchive {
 
-    public abstract InputStream getData()  throws IOException, CodeStorageException ;
-
     @Override
     public void extractTo(Path directory) throws CodeStorageException {
         try {
             File destDirectory = directory.toFile();
             byte[] buffer = new byte[1024];
-            ZipInputStream zis = new ZipInputStream(getData());
+            ZipInputStream zis = new ZipInputStream(getInputStream());
             ZipEntry zipEntry = zis.getNextEntry();
             while (zipEntry != null) {
                 File newFile = newFile(destDirectory, zipEntry);

--- a/langstream-api/src/main/java/ai/langstream/api/codestorage/LocalZipFileArchiveFile.java
+++ b/langstream-api/src/main/java/ai/langstream/api/codestorage/LocalZipFileArchiveFile.java
@@ -32,8 +32,12 @@ public class LocalZipFileArchiveFile extends GenericZipFileArchiveFile {
     }
 
     @Override
-    public InputStream getData() throws IOException, CodeStorageException {
+    public InputStream getInputStream() throws IOException, CodeStorageException {
         return Files.newInputStream(path);
     }
 
+    @Override
+    public byte[] getData() throws IOException, CodeStorageException {
+        return Files.readAllBytes(path);
+    }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/client/LangStreamClient.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/client/LangStreamClient.java
@@ -58,6 +58,7 @@ public class LangStreamClient {
         void delete(String application);
         String get(String application);
         String list();
+        HttpResponse<byte[]> download(String application);
     }
 
     public LangStreamClient(String configPath, Logger logger) {
@@ -266,6 +267,11 @@ public class LangStreamClient {
             @Override
             public String list() {
                 return http(newGet(tenantAppPath(""))).body();
+            }
+
+            @Override
+            public HttpResponse<byte[]> download(String application) {
+                return http(newGet(tenantAppPath("/" + application + "/code")), HttpResponse.BodyHandlers.ofByteArray());
             }
         };
     }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
@@ -17,6 +17,7 @@ package ai.langstream.cli.commands;
 
 import ai.langstream.cli.commands.applications.AbstractDeployApplicationCmd;
 import ai.langstream.cli.commands.applications.DeleteApplicationCmd;
+import ai.langstream.cli.commands.applications.DownloadApplicationCodeCmd;
 import ai.langstream.cli.commands.applications.GetApplicationCmd;
 import ai.langstream.cli.commands.applications.GetApplicationLogsCmd;
 import ai.langstream.cli.commands.applications.ListApplicationCmd;
@@ -30,7 +31,8 @@ import picocli.CommandLine;
                 ListApplicationCmd.class,
                 DeleteApplicationCmd.class,
                 GetApplicationCmd.class,
-                GetApplicationLogsCmd.class
+                GetApplicationLogsCmd.class,
+                DownloadApplicationCodeCmd.class
         })
 @Getter
 public class RootAppCmd {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DownloadApplicationCodeCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DownloadApplicationCodeCmd.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.applications;
+
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "download",
+        mixinStandardHelpOptions = true,
+        description = "Get LangStream application code")
+public class DownloadApplicationCodeCmd extends BaseApplicationCmd {
+
+    protected static final Pattern REGEX_PATTERN = Pattern.compile("filename=[\"']?([^\"'\r\n]+)[\"']?");
+    @CommandLine.Parameters(description = "ID of the application")
+    private String applicationId;
+
+    @CommandLine.Option(names = {"-o", "--output-file"}, description = "Output file")
+    private String outputFile;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        final HttpResponse<byte[]> response = getClient().applications().download(applicationId);
+        final Path path;
+        if (outputFile != null) {
+            path = Paths.get(outputFile);
+        } else {
+            String filename = null;
+            final String contentDispositionValue = response.headers().firstValue("Content-Disposition")
+                    .orElse(null);
+            if (contentDispositionValue != null) {
+
+                Matcher matcher = REGEX_PATTERN.matcher(contentDispositionValue);
+                if (matcher.find()) {
+                    filename = matcher.group(1);
+                }
+            }
+            if (filename == null) {
+                filename = "%s-%s.zip".formatted(getConfig().getTenant(), applicationId);
+            }
+            path = Path.of(filename);
+        }
+        Files.write(path, response.body());
+        log("Downloaded application code to %s".formatted(path.toAbsolutePath()));
+    }
+}

--- a/langstream-core/src/main/java/ai/langstream/impl/codestorage/NoopCodeStorageProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/codestorage/NoopCodeStorageProvider.java
@@ -21,6 +21,9 @@ import ai.langstream.api.codestorage.CodeStorageException;
 import ai.langstream.api.codestorage.CodeStorageProvider;
 import ai.langstream.api.codestorage.DownloadedCodeArchive;
 import ai.langstream.api.codestorage.UploadableCodeArchive;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.file.Path;
@@ -45,6 +48,18 @@ public class NoopCodeStorageProvider implements CodeStorageProvider {
             @Override
             public void downloadApplicationCode(String tenant, String codeStoreId, DownloadedCodeHandled codeArchive) throws CodeStorageException {
                 codeArchive.accept(new DownloadedCodeArchive() {
+
+                    @Override
+                    public byte[] getData() throws IOException, CodeStorageException {
+                        return "content-of-the-code-archive-%s-%s".formatted(tenant, codeStoreId).getBytes(
+                                StandardCharsets.UTF_8);
+                    }
+
+                    @Override
+                    public InputStream getInputStream() throws IOException, CodeStorageException {
+                        throw new UnsupportedOperationException();
+                    }
+
                     @Override
                     public void extractTo(Path directory) throws CodeStorageException {
                         log.info("CodeArchive should have been extracted to {}, but this is a no-op implementation", directory);

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
@@ -15,16 +15,21 @@
  */
 package ai.langstream.webservice.application;
 
+import ai.langstream.api.codestorage.CodeStorage;
+import ai.langstream.api.codestorage.CodeStorageException;
+import ai.langstream.api.codestorage.DownloadedCodeArchive;
 import ai.langstream.api.model.StoredApplication;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.api.webservice.application.ApplicationDescription;
 import ai.langstream.impl.parser.ModelBuilder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -33,14 +38,20 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.lingala.zip4j.ZipFile;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -48,6 +59,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
@@ -182,37 +194,32 @@ public class ApplicationResource {
                 });
     }
 
-    @DeleteMapping("/{tenant}/{name}")
-    @Operation(summary = "Delete application by name")
+    @DeleteMapping("/{tenant}/{applicationId}")
+    @Operation(summary = "Delete application by id")
     void deleteApplication(@NotBlank @PathVariable("tenant") String tenant,
-                           @NotBlank @PathVariable("name") String name) {
-        applicationService.deleteApplication(tenant, name);
-        log.info("Deleted application {}", name);
+                           @NotBlank @PathVariable("applciationId") String applicationId) {
+        applicationService.deleteApplication(tenant, applicationId);
+        log.info("Deleted application {}", applicationId);
     }
 
-    @GetMapping("/{tenant}/{name}")
-    @Operation(summary = "Get an application by name")
+    @GetMapping("/{tenant}/{applicationId}")
+    @Operation(summary = "Get an application by id")
     ApplicationDescription getApplication(@NotBlank @PathVariable("tenant") String tenant,
-                                     @NotBlank @PathVariable("name") String name) {
-        final StoredApplication app = applicationService.getApplication(tenant, name);
-        if (app == null) {
-            throw new ResponseStatusException(
-                    HttpStatus.NOT_FOUND, "application not found"
-            );
-        }
+                                     @NotBlank @PathVariable("applicationId") String applicationId) {
+        final StoredApplication app = getAppOrThrow(tenant, applicationId, true);
         return new ApplicationDescription(app.getApplicationId(), app.getInstance(), app.getStatus());
     }
 
 
-    @GetMapping(value = "/{tenant}/{name}/logs", produces = MediaType.APPLICATION_NDJSON_VALUE)
+    @GetMapping(value = "/{tenant}/{applicationId}/logs", produces = MediaType.APPLICATION_NDJSON_VALUE)
     @Operation(summary = "Get application logs by name")
     Flux<String> getApplicationLogs(@NotBlank @PathVariable("tenant") String tenant,
-                                    @NotBlank @PathVariable("name") String name,
+                                    @NotBlank @PathVariable("applicationId") String applicationId,
                                     @RequestParam("filter") Optional<List<String>> filterReplicas) {
 
 
         final List<ApplicationStore.PodLogHandler> podLogs =
-                applicationService.getPodLogs(tenant, name,
+                applicationService.getPodLogs(tenant, applicationId,
                         new ApplicationStore.LogOptions(filterReplicas.orElse(null)));
         if (podLogs.isEmpty()) {
             return Flux.empty();
@@ -231,6 +238,48 @@ public class ApplicationResource {
                 });
             }
         }).subscribeOn(Schedulers.fromExecutor(logsThreadPool));
+    }
+
+    @GetMapping(value = "/{tenant}/{applicationId}/code", produces = "application/zip")
+    @Operation(summary = "Get code of an application by id")
+    @ResponseBody
+    Resource getApplicationCode(@NotBlank @PathVariable("tenant") String tenant,
+                              @NotBlank @PathVariable("applicationId") String applicationId,
+                              HttpServletResponse response) throws Exception {
+        final StoredApplication app = getAppOrThrow(tenant, applicationId, false);
+        final String codeArchiveId = app.getCodeArchiveReference();
+        return downloadCode(tenant, applicationId, response, codeArchiveId);
+    }
+
+    @GetMapping(value = "/{tenant}/{applicationId}/code/{codeArchiveReference}", produces = "application/zip")
+    @Operation(summary = "Get code of an application by id and code archive reference")
+    @ResponseBody
+    Resource getApplicationCode(@NotBlank @PathVariable("tenant") String tenant,
+                                   @NotBlank @PathVariable("applicationId") String applicationId,
+                                   @NotBlank @PathVariable("codeArchiveReference") String codeArchiveReference,
+                                   HttpServletResponse response) throws Exception {
+        getAppOrThrow(tenant, applicationId, false);
+        return downloadCode(tenant, applicationId, response, codeArchiveReference);
+    }
+
+    private Resource downloadCode(String tenant, String applicationId, HttpServletResponse response,
+                                  String codeArchiveId) throws CodeStorageException {
+
+        final byte[] code = codeStorageService.downloadApplicationCode(tenant, applicationId, codeArchiveId);
+        final String filename = "%s-%s.zip".formatted(tenant, applicationId);
+
+        response.addHeader("Content-Disposition", "attachment; filename=\"%s\"".formatted(filename));
+        return new ByteArrayResource(code);
+    }
+
+    private StoredApplication getAppOrThrow(String tenant, String applicationId, boolean queryPods) {
+        final StoredApplication app = applicationService.getApplication(tenant, applicationId, queryPods);
+        if (app == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND, "application not found"
+            );
+        }
+        return app;
     }
 }
 

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
@@ -197,7 +197,7 @@ public class ApplicationResource {
     @DeleteMapping("/{tenant}/{applicationId}")
     @Operation(summary = "Delete application by id")
     void deleteApplication(@NotBlank @PathVariable("tenant") String tenant,
-                           @NotBlank @PathVariable("applciationId") String applicationId) {
+                           @NotBlank @PathVariable("applicationId") String applicationId) {
         applicationService.deleteApplication(tenant, applicationId);
         log.info("Deleted application {}", applicationId);
     }

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
@@ -247,9 +247,9 @@ public class ApplicationService {
     }
 
     @SneakyThrows
-    public StoredApplication getApplication(String tenant, String applicationId) {
+    public StoredApplication getApplication(String tenant, String applicationId, boolean queryPods) {
         checkTenant(tenant);
-        return applicationStore.get(tenant, applicationId, true);
+        return applicationStore.get(tenant, applicationId, queryPods);
     }
 
     @SneakyThrows

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
@@ -245,11 +245,11 @@ class ApplicationResourceTest {
 
     @Test
     void testDownloadCode() throws Exception {
-        mockMvc.perform(put("/api/tenants/my-tenant"))
+        mockMvc.perform(put("/api/tenants/my-tenant2"))
                 .andExpect(status().isOk());
         mockMvc
                 .perform(
-                        multipart(HttpMethod.POST, "/api/applications/my-tenant/test")
+                        multipart(HttpMethod.POST, "/api/applications/my-tenant2/test")
                                 .file(getMultipartFile("""
                                         id: app1
                                         name: test
@@ -270,13 +270,13 @@ class ApplicationResourceTest {
 
         mockMvc
                 .perform(
-                        multipart(HttpMethod.GET, "/api/applications/my-tenant/test/code")
+                        multipart(HttpMethod.GET, "/api/applications/my-tenant2/test/code")
                 )
                 .andExpect(status().isOk())
                 .andExpect(result -> {
-                    assertEquals("attachment; filename=\"my-tenant-test.zip\"", result.getResponse().getHeader("Content-Disposition"));
+                    assertEquals("attachment; filename=\"my-tenant2-test.zip\"", result.getResponse().getHeader("Content-Disposition"));
                     assertEquals("application/zip", result.getResponse().getHeader("Content-Type"));
-                    assertEquals("content-of-the-code-archive-my-tenant-my-tenant-test", result.getResponse().getContentAsString());
+                    assertEquals("content-of-the-code-archive-my-tenant2-my-tenant2-test", result.getResponse().getContentAsString());
                 });
 
     }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
@@ -178,49 +178,49 @@ class ApplicationResourceTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(result -> assertEquals("""
-                         {
-                           "application-id" : "test",
-                           "application" : {
-                             "resources" : { },
-                             "modules" : [ {
-                               "id" : "default",
-                               "pipelines" : [ {
-                                 "id" : "app1",
-                                 "module" : "default",
-                                 "name" : "test",
-                                 "resources" : {
-                                   "parallelism" : 1,
-                                   "size" : 1
-                                 },
-                                 "errors" : {
-                                   "retries" : 0,
-                                   "on-failure" : "fail"
-                                 },
-                                 "agents" : [ ]
-                               } ],
-                               "topics" : [ ]
-                             } ],
-                             "gateways" : null,
-                             "instance" : {
-                               "streamingCluster" : {
-                                 "type" : "pulsar",
-                                 "configuration" : { }
-                               },
-                               "computeCluster" : {
-                                 "type" : "none",
-                                 "configuration" : { }
-                               },
-                               "globals" : null
-                             }
-                           },
-                           "status" : {
-                             "status" : {
-                               "status" : "CREATED",
-                               "reason" : null
-                             },
-                             "executors" : [ ]
-                           }
-                         }""", result.getResponse().getContentAsString()));
+                        {
+                          "application-id" : "test",
+                          "application" : {
+                            "resources" : { },
+                            "modules" : [ {
+                              "id" : "default",
+                              "pipelines" : [ {
+                                "id" : "app1",
+                                "module" : "default",
+                                "name" : "test",
+                                "resources" : {
+                                  "parallelism" : 1,
+                                  "size" : 1
+                                },
+                                "errors" : {
+                                  "retries" : 0,
+                                  "on-failure" : "fail"
+                                },
+                                "agents" : [ ]
+                              } ],
+                              "topics" : [ ]
+                            } ],
+                            "gateways" : null,
+                            "instance" : {
+                              "streamingCluster" : {
+                                "type" : "pulsar",
+                                "configuration" : { }
+                              },
+                              "computeCluster" : {
+                                "type" : "none",
+                                "configuration" : { }
+                              },
+                              "globals" : null
+                            }
+                          },
+                          "status" : {
+                            "status" : {
+                              "status" : "CREATED",
+                              "reason" : null
+                            },
+                            "executors" : [ ]
+                          }
+                        }""", result.getResponse().getContentAsString()));
 
         mockMvc
                 .perform(
@@ -241,5 +241,45 @@ class ApplicationResourceTest {
                 )
                 .andExpect(status().isNotFound());
     }
+
+
+    @Test
+    void testDownloadCode() throws Exception {
+        mockMvc.perform(put("/api/tenants/my-tenant"))
+                .andExpect(status().isOk());
+        mockMvc
+                .perform(
+                        multipart(HttpMethod.POST, "/api/applications/my-tenant/test")
+                                .file(getMultipartFile("""
+                                        id: app1
+                                        name: test
+                                        topics: []
+                                        pipeline: []
+                                        """))
+                                .part(new MockPart("instance",
+                                        """
+                                                instance:
+                                                  streamingCluster:
+                                                    type: pulsar
+                                                  computeCluster:
+                                                    type: none
+                                                """.getBytes(StandardCharsets.UTF_8)
+                                ))
+                )
+                .andExpect(status().isOk());
+
+        mockMvc
+                .perform(
+                        multipart(HttpMethod.GET, "/api/applications/my-tenant/test/code")
+                )
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    assertEquals("attachment; filename=\"my-tenant-test.zip\"", result.getResponse().getHeader("Content-Disposition"));
+                    assertEquals("application/zip", result.getResponse().getHeader("Content-Type"));
+                    assertEquals("content-of-the-code-archive-my-tenant-my-tenant-test", result.getResponse().getContentAsString());
+                });
+
+    }
+
 
 }


### PR DESCRIPTION
* New GET endpoints `/api/applications/{tenant}/{app}/code` and  `/api/applications/{tenant}/{app}/code/{codeArchiveRef}` to download the code from s3. Note that the latter one will be used only internal since the ID is not retrievable from the base user. In any case the ref must own to that application and tenant.
* New CLI command `langstream apps download myapp -o /myfile.zip` or `langstream apps download myapp`