### PR TITLE
Create Java Admin client module

### DIFF
--- a/langstream-admin-client/pom.xml
+++ b/langstream-admin-client/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>langstream-ai</artifactId>
+    <groupId>ai.langstream</groupId>
+    <version>0.0.6-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>langstream-admin-client</artifactId>
+
+
+
+  <dependencies>
+    <dependency>
+      <groupId>net.lingala.zip4j</groupId>
+      <artifactId>zip4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClientConfiguration.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClientConfiguration.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.admin.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class AdminClientConfiguration {
+    private String webServiceUrl;
+    private String apiGatewayUrl;
+    private String tenant;
+    private String token;
+}

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClientLogger.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClientLogger.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.admin.client;
+
+public interface AdminClientLogger {
+    void log(Object message);
+
+    void error(Object message);
+
+    void debug(Object message);
+}

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.admin.client.model;
+
+import ai.langstream.admin.client.util.MultiPartBodyPublisher;
+import java.net.http.HttpResponse;
+
+public interface Applications {
+    void deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher);
+
+    void update(String application, MultiPartBodyPublisher multiPartBodyPublisher);
+
+    void delete(String application);
+
+    String get(String application);
+
+    String list();
+
+    HttpResponse<byte[]> download(String application);
+}

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/util/MultiPartBodyPublisher.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/util/MultiPartBodyPublisher.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.cli.util;
+package ai.langstream.admin.client.util;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,7 +22,11 @@ import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 public class MultiPartBodyPublisher {
@@ -83,7 +87,7 @@ public class MultiPartBodyPublisher {
             STRING, FILE, STREAM, FINAL_BOUNDARY
         }
 
-        PartsSpecification.TYPE type;
+        TYPE type;
         String name;
         String value;
         Path path;

--- a/langstream-cli/pom.xml
+++ b/langstream-cli/pom.xml
@@ -36,14 +36,10 @@
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>net.lingala.zip4j</groupId>
-      <artifactId>zip4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-admin-client</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
@@ -52,7 +48,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ai.langstream</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>langstream-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
@@ -15,7 +15,6 @@
  */
 package ai.langstream.cli.commands;
 
-import ai.langstream.cli.client.LangStreamClient;
 import ai.langstream.cli.commands.configure.ConfigureCmd;
 import lombok.Getter;
 import picocli.AutoComplete;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -15,10 +15,9 @@
  */
 package ai.langstream.cli.commands.applications;
 
+import ai.langstream.admin.client.util.MultiPartBodyPublisher;
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.Dependency;
-
-import ai.langstream.cli.util.MultiPartBodyPublisher;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationLogsCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationLogsCmd.java
@@ -15,7 +15,7 @@
  */
 package ai.langstream.cli.commands.applications;
 
-import ai.langstream.cli.client.LangStreamClient;
+import ai.langstream.admin.client.AdminClient;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -39,7 +39,7 @@ public class GetApplicationLogsCmd extends BaseApplicationCmd {
     @SneakyThrows
     public void run() {
         final String filterStr = filter == null ? "" : "?filter=" + String.join(",", filter);
-        final LangStreamClient client = getClient();
+        final AdminClient client = getClient();
         client.getHttpClient().sendAsync(client.newGet(client.tenantAppPath("/" + name + "/logs" + filterStr)), HttpResponse.BodyHandlers.ofByteArrayConsumer(
                         new Consumer<Optional<byte[]>>() {
                             @Override

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/configure/ConfigureCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/configure/ConfigureCmd.java
@@ -46,7 +46,7 @@ public class ConfigureCmd extends BaseCmd {
     @Override
     @SneakyThrows
     public void run() {
-        getClient().updateConfig(clientConfig -> {
+        updateConfig(clientConfig -> {
             switch (configKey) {
                 case tenant:
                     clientConfig.setTenant(newValue);

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
@@ -15,10 +15,10 @@
  */
 package ai.langstream.cli.commands.gateway;
 
+import ai.langstream.admin.client.AdminClient;
 import ai.langstream.api.model.Gateway;
 import ai.langstream.api.model.Gateways;
 import ai.langstream.api.webservice.application.ApplicationDescription;
-import ai.langstream.cli.client.LangStreamClient;
 import ai.langstream.cli.commands.BaseCmd;
 import ai.langstream.cli.commands.RootCmd;
 import ai.langstream.cli.commands.RootGatewayCmd;
@@ -92,7 +92,7 @@ public abstract class BaseGatewayCmd extends BaseCmd {
     protected void validateGateway(String application, String gatewayId, Gateway.GatewayType type,
                                    Map<String, String> params, Map<String, String> options, String credentials) {
 
-        final LangStreamClient client = getClient();
+        final AdminClient client = getClient();
 
         final String applicationContent = client.applications()
                 .get(application);

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentCodeDownloader.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentCodeDownloader.java
@@ -58,6 +58,9 @@ public class AgentCodeDownloader {
     }
 
     private static void downloadCustomCode(CodeStorageConfig codeStorageConfig, Path codeDownloadPath) throws Exception {
+
+
+
         if (codeStorageConfig != null) {
             log.info("Downloading custom code from {}", codeStorageConfig);
             log.info("Custom code is stored in {}", codeDownloadPath);

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <module>langstream-admin-client</module>
         <module>langstream-api</module>
         <module>langstream-cli</module>
         <module>langstream-core</module>


### PR DESCRIPTION
This basically split the CLI code and the actual http client for the control plane. 
For now only applications are implemented. 
This is a preparatory work for moving the code download to use the new endpoint instead of s3 directly