### PR TITLE
AgentCodeRegistry/NarFileHandler: do not unpack unecessary nar files

### DIFF
--- a/langstream-agents/langstream-agent-s3/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agent-s3/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,1 @@
+s3-source

--- a/langstream-agents/langstream-agent-webcrawler/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,1 @@
+webcrawler-source

--- a/langstream-agents/langstream-agents-text-processing/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agents-text-processing/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,5 @@
+text-extractor
+language-detector
+text-splitter
+text-normaliser
+document-to-json

--- a/langstream-agents/langstream-ai-agents/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-ai-agents/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,10 @@
+drop-fields
+merge-key-value
+unwrap-key-value
+cast
+flatten
+drop
+compute
+compute-ai-embeddings
+query
+ai-chat-completions

--- a/langstream-agents/langstream-vector-agents/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-vector-agents/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,0 +1,2 @@
+query-vector-db
+vector-db-sink


### PR DESCRIPTION
Summary:
- allow to add a META-INF/ai.langstream.agents.index file that contains a static list of agent types that are handled by the package
- when looking for the AgentCode given an agent-type, load only the package that contains the agent, fall back to looking into all the packages in case the agent is not found


Follow up:
should we forbid to not have the static index ?
after all we have full control of the .nar files and if a .nar file has no static index then it is not built by us.

Unfortunately this index file conflicts with the dynamic AgentCodeProvider way based on ServiceLoader, that is more powerful.
