### PR TITLE
Move runtime pods from args to env

### DIFF
--- a/langstream-cli/src/main/java/ai/langstream/cli/websocket/WebSocketClient.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/websocket/WebSocketClient.java
@@ -75,7 +75,7 @@ public class WebSocketClient implements AutoCloseable {
             final ClientEndpointConfig clientEndpointConfig = ClientEndpointConfig.Builder.create().build();
             if (timeout != null) {
                 clientEndpointConfig.getUserProperties()
-                        .put(Constants.IO_TIMEOUT_MS_PROPERTY, timeout.toMillis());
+                        .put(Constants.IO_TIMEOUT_MS_PROPERTY, timeout.toMillis() + "");
             }
             userSession = container.connectToServer(endpoint, clientEndpointConfig, uri);
         } catch (DeploymentException e) {

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
@@ -51,10 +51,10 @@ public class PythonFunctionIT extends BaseEndToEndTest {
                 .withName(applicationId + "-module-1-pipeline-1-python-function-1")
                 .waitUntilReady(4, TimeUnit.MINUTES);
 
-        executeCommandOnClient("bin/langstream gateway produce %s produce-input -v my-value".formatted(applicationId).split(" "));
+        executeCommandOnClient("bin/langstream gateway produce %s produce-input -v my-value --connect-timeout 30".formatted(applicationId).split(" "));
 
         final String output = executeCommandOnClient(
-                "bin/langstream gateway consume %s consume-output --position earliest -n 1".formatted(applicationId)
+                "bin/langstream gateway consume %s consume-output --position earliest -n 1 --connect-timeout 30".formatted(applicationId)
                         .split(" "));
         log.info("Output: {}", output);
         Assertions.assertTrue(output.contains("{\"record\":{\"key\":null,\"value\":\"my-value!!super secret value\","

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
@@ -24,6 +24,7 @@ import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
 import ai.langstream.deployer.k8s.api.crds.agents.AgentSpec;
 import ai.langstream.deployer.k8s.util.KubeUtil;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
+import ai.langstream.runtime.api.agent.AgentRunnerConstants;
 import ai.langstream.runtime.api.agent.CodeStorageConfig;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -169,6 +171,16 @@ public class AgentResourcesFactory {
 //                .withLivenessProbe(createLivenessProbe())
 //                .withReadinessProbe(createReadinessProbe())
                 .withResources(convertResources(spec.getResources(), agentResourceUnitConfiguration))
+                .withEnv(new EnvVarBuilder()
+                        .withName(AgentRunnerConstants.POD_CONFIG_ENV)
+                        .withValue("/app-config/config")
+                        .build(),
+                        new EnvVarBuilder()
+                                .withName(AgentRunnerConstants.CODE_CONFIG_ENV)
+                                .withValue("/app-code-download")
+                                .build()
+                )
+                // keep args for backward compatibility
                 .withArgs("agent-runtime", "/app-config/config", "/app-code-download")
                 .withVolumeMounts(new VolumeMountBuilder()
                         .withName(appConfigVolume)

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -26,9 +26,11 @@ import ai.langstream.deployer.k8s.PodTemplate;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationSpec;
 import ai.langstream.runtime.api.deployer.RuntimeDeployerConfiguration;
+import ai.langstream.runtime.api.deployer.RuntimeDeployerConstants;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
@@ -111,6 +113,20 @@ public class AppResourcesFactory {
                 .withName("deployer")
                 .withImage(containerImage)
                 .withImagePullPolicy(containerImagePullPolicy)
+                .withEnv(new EnvVarBuilder()
+                        .withName(RuntimeDeployerConstants.APP_CONFIG_ENV)
+                        .withValue("/app-config/config")
+                        .build(),
+                        new EnvVarBuilder()
+                                .withName(RuntimeDeployerConstants.CLUSTER_RUNTIME_CONFIG_ENV)
+                                .withValue("/cluster-runtime-config/config")
+                                .build(),
+                        new EnvVarBuilder()
+                                .withName(RuntimeDeployerConstants.APP_SECRETS_ENV)
+                                .withValue("/app-secrets/secrets")
+                                .build()
+                        )
+                // keep args for backward compatibility
                 .withArgs("deployer-runtime", command, "/cluster-runtime-config/config", "/app-config/config",
                         "/app-secrets/secrets")
                 .withVolumeMounts(new VolumeMountBuilder()

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -89,6 +89,11 @@ class AgentResourcesFactoryTest {
                                 - agent-runtime
                                 - /app-config/config
                                 - /app-code-download
+                                env:
+                                - name: LANGSTREAM_AGENT_RUNNER_POD_CONFIGURATION
+                                  value: /app-config/config
+                                - name: LANGSTREAM_AGENT_RUNNER_CODE_CONFIGURATION
+                                  value: /app-code-download
                                 image: busybox
                                 imagePullPolicy: Never
                                 name: runtime

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -81,6 +81,13 @@ class AppResourcesFactoryTest {
                                 - /cluster-runtime-config/config
                                 - /app-config/config
                                 - /app-secrets/secrets
+                                env:
+                                - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_CONFIGURATION
+                                  value: /app-config/config
+                                - name: LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_RUNTIME_CONFIGURATION
+                                  value: /cluster-runtime-config/config
+                                - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_SECRETS
+                                  value: /app-secrets/secrets
                                 image: ubuntu
                                 imagePullPolicy: Always
                                 name: deployer
@@ -160,6 +167,13 @@ class AppResourcesFactoryTest {
                                 - /cluster-runtime-config/config
                                 - /app-config/config
                                 - /app-secrets/secrets
+                                env:
+                                - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_CONFIGURATION
+                                  value: /app-config/config
+                                - name: LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_RUNTIME_CONFIGURATION
+                                  value: /cluster-runtime-config/config
+                                - name: LANGSTREAM_RUNTIME_DEPLOYER_APP_SECRETS
+                                  value: /app-secrets/secrets
                                 image: ubuntu
                                 imagePullPolicy: Always
                                 name: deployer

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AgentControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AgentControllerIT.java
@@ -107,6 +107,10 @@ public class AgentControllerIT {
         int args = 0;
         assertEquals("agent-runtime", container.getArgs().get(args++));
         assertEquals("/app-config/config", container.getArgs().get(args++));
+        assertEquals("/app-config/config",
+                container.getEnv().stream().filter(e -> "LANGSTREAM_AGENT_RUNNER_POD_CONFIGURATION".equals(e.getName())).findFirst().get().getValue());
+        assertEquals("/app-code-download",
+                container.getEnv().stream().filter(e -> "LANGSTREAM_AGENT_RUNNER_CODE_CONFIGURATION".equals(e.getName())).findFirst().get().getValue());
 
     }
     private AgentCustomResource getCr(String yaml) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -117,6 +117,12 @@ public class AppControllerIT {
             assertEquals("/app-config/config", container.getArgs().get(args++));
             assertEquals("/app-secrets/secrets", container.getArgs().get(args++));
         }
+        assertEquals("/app-config/config",
+                container.getEnv().stream().filter(e -> "LANGSTREAM_RUNTIME_DEPLOYER_APP_CONFIGURATION".equals(e.getName())).findFirst().get().getValue());
+        assertEquals("/cluster-runtime-config/config",
+                container.getEnv().stream().filter(e -> "LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_RUNTIME_CONFIGURATION".equals(e.getName())).findFirst().get().getValue());
+        assertEquals("/app-secrets/secrets",
+                container.getEnv().stream().filter(e -> "LANGSTREAM_RUNTIME_DEPLOYER_APP_SECRETS".equals(e.getName())).findFirst().get().getValue());
 
         final Container initContainer = templateSpec.getInitContainers().get(0);
         assertEquals("busybox", initContainer.getImage());

--- a/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/agent/AgentRunnerConstants.java
+++ b/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/agent/AgentRunnerConstants.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.api.agent;
+
+public class AgentRunnerConstants {
+
+    public static final String POD_CONFIG_ENV = "LANGSTREAM_AGENT_RUNNER_POD_CONFIGURATION";
+    public static final String POD_CONFIG_ENV_DEFAULT = "/app-config/config";
+    public static final String CODE_CONFIG_ENV = "LANGSTREAM_AGENT_RUNNER_CODE_CONFIGURATION";
+    public static final String CODE_CONFIG_ENV_DEFAULT = "/app-code-download";
+    public static final String AGENTS_ENV = "LANGSTREAM_AGENT_RUNNER_AGENTS";
+    public static final String AGENTS_ENV_DEFAULT = "/app/agents";
+}

--- a/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/deployer/RuntimeDeployerConstants.java
+++ b/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/deployer/RuntimeDeployerConstants.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.api.deployer;
+
+public class RuntimeDeployerConstants {
+
+    public static final String CLUSTER_RUNTIME_CONFIG_ENV = "LANGSTREAM_RUNTIME_DEPLOYER_CLUSTER_RUNTIME_CONFIGURATION";
+    public static final String CLUSTER_RUNTIME_CONFIG_ENV_DEFAULT = "/cluster-runtime-config/config";
+
+    public static final String APP_CONFIG_ENV = "LANGSTREAM_RUNTIME_DEPLOYER_APP_CONFIGURATION";
+    public static final String APP_CONFIG_ENV_DEFAULT = "/app-config/config";
+
+    public static final String APP_SECRETS_ENV = "LANGSTREAM_RUNTIME_DEPLOYER_APP_SECRETS";
+
+    /*
+    "/cluster-runtime-config/config", "/app-config/config",
+                        "/app-secrets/secrets"
+     */
+}

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/Main.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/Main.java
@@ -16,8 +16,10 @@
 package ai.langstream.runtime;
 
 import ai.langstream.runtime.agent.AgentCodeDownloader;
+import ai.langstream.runtime.agent.AgentRunnerStarter;
 import ai.langstream.runtime.deployer.RuntimeDeployer;
 import ai.langstream.runtime.agent.AgentRunner;
+import ai.langstream.runtime.deployer.RuntimeDeployerStarter;
 
 public class Main {
 
@@ -31,13 +33,13 @@ public class Main {
         System.arraycopy(args, 1, newArgs, 0, newArgs.length);
         switch (command) {
             case "agent-runtime":
-                AgentRunner.main(newArgs);
+                AgentRunnerStarter.main(newArgs);
                 break;
             case "agent-code-download":
                 AgentCodeDownloader.main(newArgs);
                 break;
             case "deployer-runtime":
-                RuntimeDeployer.main(newArgs);
+                RuntimeDeployerStarter.main(newArgs);
                 break;
             default: {
                 System.err.println("Unknown command. Only ['agent-runtime', 'deployer-runtime', 'agent-code-download']");

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentCodeDownloader.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentCodeDownloader.java
@@ -20,6 +20,7 @@ import ai.langstream.api.codestorage.CodeStorage;
 import ai.langstream.api.codestorage.CodeStorageRegistry;
 import ai.langstream.runtime.api.agent.CodeStorageConfig;
 import ai.langstream.runtime.deployer.RuntimeDeployer;
+import ai.langstream.runtime.deployer.RuntimeDeployerStarter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.nio.file.Path;
@@ -33,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AgentCodeDownloader {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static RuntimeDeployer.ErrorHandler errorHandler = error -> {
+    private static RuntimeDeployerStarter.ErrorHandler errorHandler = error -> {
         log.error("Unexpected error", error);
         System.exit(-1);
     };

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.agent;
+
+import static ai.langstream.api.model.ErrorsSpec.DEAD_LETTER;
+import static ai.langstream.api.model.ErrorsSpec.FAIL;
+import static ai.langstream.api.model.ErrorsSpec.SKIP;
+import static ai.langstream.runtime.api.agent.AgentRunnerConstants.AGENTS_ENV;
+import static ai.langstream.runtime.api.agent.AgentRunnerConstants.AGENTS_ENV_DEFAULT;
+import static ai.langstream.runtime.api.agent.AgentRunnerConstants.CODE_CONFIG_ENV;
+import static ai.langstream.runtime.api.agent.AgentRunnerConstants.CODE_CONFIG_ENV_DEFAULT;
+import static ai.langstream.runtime.api.agent.AgentRunnerConstants.POD_CONFIG_ENV;
+import static ai.langstream.runtime.api.agent.AgentRunnerConstants.POD_CONFIG_ENV_DEFAULT;
+import ai.langstream.api.runner.code.AgentCode;
+import ai.langstream.api.runner.code.AgentCodeAndLoader;
+import ai.langstream.api.runner.code.AgentCodeRegistry;
+import ai.langstream.api.runner.code.AgentContext;
+import ai.langstream.api.runner.code.AgentProcessor;
+import ai.langstream.api.runner.code.AgentSink;
+import ai.langstream.api.runner.code.AgentSource;
+import ai.langstream.api.runner.code.BadRecordHandler;
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.topics.TopicAdmin;
+import ai.langstream.api.runner.topics.TopicConnectionProvider;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
+import ai.langstream.api.runner.topics.TopicConsumer;
+import ai.langstream.api.runner.topics.TopicProducer;
+import ai.langstream.runtime.agent.api.AgentInfo;
+import ai.langstream.runtime.agent.api.AgentInfoServlet;
+import ai.langstream.runtime.agent.api.MetricsHttpServlet;
+import ai.langstream.runtime.agent.nar.NarFileHandler;
+import ai.langstream.runtime.agent.python.PythonCodeAgentProvider;
+import ai.langstream.runtime.agent.simple.IdentityAgentProvider;
+import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.prometheus.client.hotspot.DefaultExports;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+/**
+ * This is the main entry point for the pods that run the LangStream runtime and Java code.
+ */
+@Slf4j
+public class AgentRunnerStarter {
+    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private static MainErrorHandler mainErrorHandler = error -> {
+        log.error("Unexpected error", error);
+        System.exit(-1);
+    };
+
+    public interface MainErrorHandler {
+        void handleError(Throwable error);
+    }
+
+    @SneakyThrows
+    public static void main(String... args) {
+        try {
+            new AgentRunnerStarter().run(new AgentRunner(), args);
+        } catch (Throwable error) {
+            log.info("Error, NOW SLEEPING", error);
+            Thread.sleep(60000);
+            mainErrorHandler.handleError(error);
+        }
+    }
+
+    @SneakyThrows
+    public void run(AgentRunner agentRunner, String... args) {
+
+        // backward compatibility: <pod configuration file> <code directory> <agents directory>
+        Path podRuntimeConfiguration;
+        Path codeDirectory;
+        Path agentsDirectory;
+        if (args.length == 0) {
+            podRuntimeConfiguration =
+                    getPathFromEnv(POD_CONFIG_ENV, POD_CONFIG_ENV_DEFAULT);
+            codeDirectory = getPathFromEnv(CODE_CONFIG_ENV, CODE_CONFIG_ENV_DEFAULT);
+            agentsDirectory = getPathFromEnv(AGENTS_ENV, AGENTS_ENV_DEFAULT);
+        } else if (args.length == 1) {
+            podRuntimeConfiguration = Path.of(args[0]);
+            codeDirectory = getPathFromEnv(CODE_CONFIG_ENV, CODE_CONFIG_ENV_DEFAULT);
+            agentsDirectory = getPathFromEnv(AGENTS_ENV, AGENTS_ENV_DEFAULT);
+        } else if (args.length == 2) {
+            podRuntimeConfiguration = Path.of(args[0]);
+            codeDirectory = Path.of(args[1]);
+            agentsDirectory = getPathFromEnv(AGENTS_ENV, AGENTS_ENV_DEFAULT);
+        } else if (args.length == 3) {
+            podRuntimeConfiguration = Path.of(args[0]);
+            codeDirectory = Path.of(args[1]);
+            agentsDirectory = Path.of(args[2]);
+        } else {
+            throw new IllegalArgumentException("Invalid arguments: " + String.join(", ", args));
+        }
+
+        log.info("Loading pod configuration from {}", podRuntimeConfiguration);
+        RuntimePodConfiguration configuration = MAPPER.readValue(podRuntimeConfiguration.toFile(),
+                RuntimePodConfiguration.class);
+
+        log.info("Loading code from {}", codeDirectory);
+        log.info("Loading agents from {}", agentsDirectory);
+
+        agentRunner.run(configuration, podRuntimeConfiguration, codeDirectory, agentsDirectory,
+                new AgentInfo(), -1);
+
+    }
+
+    private Path getPathFromEnv(String envVar, String defaultValue) {
+        String value = getEnv(envVar);
+        if (value == null) {
+            value = defaultValue;
+        }
+        final Path path = Path.of(value);
+        if (!path.toFile().exists()) {
+            throw new IllegalArgumentException("File " + path + " does not exist");
+        }
+        return path;
+    }
+
+    String getEnv(String key) {
+        return System.getenv(key);
+    }
+}

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/deployer/RuntimeDeployerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/deployer/RuntimeDeployerStarter.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.deployer;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.Secrets;
+import ai.langstream.api.runtime.ClusterRuntimeRegistry;
+import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.impl.deploy.ApplicationDeployer;
+import ai.langstream.runtime.api.deployer.RuntimeDeployerConfiguration;
+import ai.langstream.runtime.api.deployer.RuntimeDeployerConstants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is the main entry point for the deployer runtime.
+ */
+@Slf4j
+public class RuntimeDeployerStarter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(FAIL_ON_UNKNOWN_PROPERTIES, false); // this helps with forward compatibility
+    private static ErrorHandler errorHandler = error -> {
+        log.error("Unexpected error", error);
+        System.exit(-1);
+    };
+
+    public interface ErrorHandler {
+        void handleError(Throwable error);
+    }
+
+    public static void main(String... args) {
+        try {
+
+            new RuntimeDeployerStarter()
+                    .run(new RuntimeDeployer(), args);
+        } catch (Throwable error) {
+            errorHandler.handleError(error);
+            return;
+        }
+    }
+
+    public void run(RuntimeDeployer runtimeDeployer, String... args) throws Exception {
+        // backward compatibility: <cmd> <clusterRuntimeConfigPath> <appConfigPath> <secretsPath>
+        Path clusterRuntimeConfigPath;
+        Path appConfigPath;
+        Path secretsPath;
+        if (args.length == 0) {
+            throw new IllegalArgumentException("Missing arguments");
+        }
+        if (args.length == 1) {
+            clusterRuntimeConfigPath =
+                    getPathFromEnv(RuntimeDeployerConstants.CLUSTER_RUNTIME_CONFIG_ENV,
+                            RuntimeDeployerConstants.CLUSTER_RUNTIME_CONFIG_ENV_DEFAULT);
+            appConfigPath = getPathFromEnv(RuntimeDeployerConstants.APP_CONFIG_ENV,
+                    RuntimeDeployerConstants.APP_CONFIG_ENV_DEFAULT);
+            secretsPath = getOptionalPathFromEnv(RuntimeDeployerConstants.APP_SECRETS_ENV);
+        } else if (args.length == 2) {
+            clusterRuntimeConfigPath = Path.of(args[1]);
+            appConfigPath = getPathFromEnv(RuntimeDeployerConstants.APP_CONFIG_ENV,
+                    RuntimeDeployerConstants.APP_CONFIG_ENV_DEFAULT);
+            secretsPath = getOptionalPathFromEnv(RuntimeDeployerConstants.APP_SECRETS_ENV);
+        } else if (args.length == 3) {
+            clusterRuntimeConfigPath = Path.of(args[1]);
+            appConfigPath = Path.of(args[2]);
+            secretsPath = getOptionalPathFromEnv(RuntimeDeployerConstants.APP_SECRETS_ENV);
+        } else if (args.length == 4) {
+            clusterRuntimeConfigPath = Path.of(args[1]);
+            appConfigPath = Path.of(args[2]);
+            secretsPath = Path.of(args[3]);
+        } else {
+            throw new IllegalArgumentException("Invalid arguments: " + String.join(", ", args));
+        }
+        final String arg0 = args[0];
+
+        log.info("Loading cluster runtime config from {}", clusterRuntimeConfigPath);
+        final Map<String, Map<String, Object>> clusterRuntimeConfiguration =
+                (Map<String, Map<String, Object>>) MAPPER.readValue(clusterRuntimeConfigPath.toFile(), Map.class);
+        log.info("clusterRuntimeConfiguration {}", clusterRuntimeConfiguration);
+
+        log.info("Loading app configuration from {}", appConfigPath);
+        final RuntimeDeployerConfiguration configuration =
+                MAPPER.readValue(appConfigPath.toFile(), RuntimeDeployerConfiguration.class);
+        log.info("RuntimeDeployerConfiguration {}", configuration);
+
+        Secrets secrets = null;
+        if (secretsPath != null) {
+            log.info("Loading secrets from {}", secretsPath);
+            secrets = MAPPER.readValue(secretsPath.toFile(), Secrets.class);
+        } else {
+            log.info("No secrets file provided");
+        }
+
+        switch (arg0) {
+            case "delete":
+                runtimeDeployer.delete(clusterRuntimeConfiguration, configuration, secrets);
+                break;
+            case "deploy":
+                runtimeDeployer.deploy(clusterRuntimeConfiguration, configuration, secrets);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown command " + arg0);
+        }
+
+    }
+
+    private Path getPathFromEnv(String envVar, String defaultValue) {
+        return getPathFromEnv(envVar, defaultValue, true);
+    }
+
+    private Path getOptionalPathFromEnv(String envVar) {
+        return getPathFromEnv(envVar, null, false);
+    }
+
+    private Path getPathFromEnv(String envVar, String defaultValue, boolean required) {
+        String value = getEnv(envVar);
+        if (value == null) {
+            value = defaultValue;
+        }
+        if (!required && value == null) {
+            return null;
+        }
+        final Path path = Path.of(value);
+        if (!path.toFile().exists()) {
+            throw new IllegalArgumentException("File " + path + " does not exist");
+        }
+        return path;
+    }
+
+    String getEnv(String key) {
+        return System.getenv(key);
+    }
+}
+

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -220,7 +220,7 @@ public abstract class AbstractApplicationRunner {
                         log.info("{} AgentPod {} Started", runnerExecutionId, podConfiguration.agent().agentId());
                         AgentInfo agentInfo = new AgentInfo();
                         allAgentsInfo.put(podConfiguration.agent().agentId(), agentInfo);
-                        AgentRunner.run(podConfiguration, null, null, agentsDirectory, agentInfo, 10);
+                        AgentRunner.runAgent(podConfiguration, null, null, agentsDirectory, agentInfo, 10);
                         List<?> infos = agentInfo.serveWorkerStatus();
                         log.info("{} AgentPod {} AgentInfo {}", runnerExecutionId, podConfiguration.agent().agentId(), infos);
                         handle.complete(null);

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
@@ -126,7 +126,7 @@ class PulsarRunnerDockerTest {
                     .send();
             producer.flush();
 
-            AgentRunner.run(runtimePodConfiguration, null, null, AbstractApplicationRunner.agentsDirectory, new AgentInfo(), 5);
+            AgentRunner.runAgent(runtimePodConfiguration, null, null, AbstractApplicationRunner.agentsDirectory, new AgentInfo(), 5);
 
             // receive one message from the output-topic (written by the PodJavaRuntime)
             Message<byte[]> record = consumer.receive();

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.agent;
+
+import static org.junit.jupiter.api.Assertions.*;
+import ai.langstream.api.model.Secrets;
+import ai.langstream.runtime.api.agent.AgentRunnerConstants;
+import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AgentRunnerStarterTest {
+
+
+    static ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void test() throws Exception {
+
+        String podRuntimeFile = Files.createTempFile("langstream", ".json").toFile().getAbsolutePath();
+        mapper.writeValue(new File(podRuntimeFile), new RuntimePodConfiguration(null, null, null, null));
+        String codeDir = Files.createTempDirectory("langstream-cli-test").toFile().getAbsolutePath();
+        String agentsDir = Files.createTempDirectory("langstream-cli-test").toFile().getAbsolutePath();
+
+
+        runTest(false, Map.of());
+        runTest(false, Map.of(), podRuntimeFile);
+        runTest(false, Map.of(), podRuntimeFile, codeDir);
+        runTest(true, Map.of(), podRuntimeFile, codeDir, agentsDir);
+        runTest(false, Map.of(AgentRunnerConstants.POD_CONFIG_ENV, podRuntimeFile,
+                        AgentRunnerConstants.CODE_CONFIG_ENV, codeDir));
+        runTest(true, Map.of(AgentRunnerConstants.POD_CONFIG_ENV, podRuntimeFile,
+                AgentRunnerConstants.CODE_CONFIG_ENV, codeDir, AgentRunnerConstants.AGENTS_ENV, agentsDir));
+    }
+
+    @SneakyThrows
+    private void runTest(boolean expectOk, Map<String, String> env, String... args) {
+        final AgentRunner agentRunner = Mockito.mock(AgentRunner.class);
+
+        try {
+            new TestDeployer(env).run(agentRunner, args);
+        } catch (Exception e) {
+            if (expectOk) {
+                throw new RuntimeException(e);
+            } else {
+                return;
+            }
+        }
+        if (!expectOk) {
+            throw new RuntimeException("Expected exception");
+        }
+        Mockito.verify(agentRunner).run(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt());
+
+    }
+
+    static class TestDeployer extends AgentRunnerStarter {
+        private final Map<String, String> map;
+
+        public TestDeployer(Map<String, String> map) {
+            this.map = map;
+        }
+
+        @Override
+        String getEnv(String key) {
+            return map.get(key);
+        }
+    }
+
+
+}

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/deployer/RuntimeDeployerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/deployer/RuntimeDeployerStarterTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.deployer;
+
+import ai.langstream.api.model.Secrets;
+import ai.langstream.runtime.api.deployer.RuntimeDeployerConfiguration;
+import ai.langstream.runtime.api.deployer.RuntimeDeployerConstants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RuntimeDeployerStarterTest {
+
+    static ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void test() throws Exception {
+
+        String clusterRuntimeFile = Files.createTempFile("langstream", ".json").toFile().getAbsolutePath();
+        mapper.writeValue(new File(clusterRuntimeFile), Map.of("config", "config"));
+
+        String appConfigFile = Files.createTempFile("langstream-cli-test", ".json").toFile().getAbsolutePath();
+        mapper.writeValue(new File(appConfigFile), new RuntimeDeployerConfiguration());
+
+        String secretsConfigFile = Files.createTempFile("langstream-cli-test", ".json").toFile().getAbsolutePath();
+        mapper.writeValue(new File(secretsConfigFile), new Secrets(null));
+
+
+        runTest(false, Map.of());
+        runTest(false, Map.of(), "");
+        runTest(false, Map.of(), "unknown");
+
+        runTest(false, Map.of(), "deploy");
+        runTest(false, Map.of(), "deploy", clusterRuntimeFile);
+        runTest(true, Map.of(), "deploy", clusterRuntimeFile, appConfigFile);
+        runTest(true, Map.of(), "deploy", clusterRuntimeFile, appConfigFile, secretsConfigFile);
+        runTest(true, Map.of(RuntimeDeployerConstants.APP_CONFIG_ENV, appConfigFile,
+                        RuntimeDeployerConstants.CLUSTER_RUNTIME_CONFIG_ENV, clusterRuntimeFile),
+                "deploy");
+        runTest(true, Map.of(RuntimeDeployerConstants.APP_CONFIG_ENV, appConfigFile,
+                        RuntimeDeployerConstants.CLUSTER_RUNTIME_CONFIG_ENV, clusterRuntimeFile,
+                        RuntimeDeployerConstants.APP_SECRETS_ENV, secretsConfigFile),
+                "deploy");
+
+
+    }
+
+    @SneakyThrows
+    private void runTest(boolean expectOk, Map<String, String> env, String... args) {
+        final RuntimeDeployer runtimeDeployer = Mockito.mock(RuntimeDeployer.class);
+
+        try {
+            new TestDeployer(env).run(runtimeDeployer, args);
+        } catch (Exception e) {
+            if (expectOk) {
+                throw new RuntimeException(e);
+            } else {
+                return;
+            }
+        }
+        if (!expectOk) {
+            throw new RuntimeException("Expected exception");
+        }
+        Mockito.verify(runtimeDeployer).deploy(Mockito.any(), Mockito.any(), Mockito.any());
+
+    }
+
+    static class TestDeployer extends RuntimeDeployerStarter {
+        private final Map<String, String> map;
+
+        public TestDeployer(Map<String, String> map) {
+            this.map = map;
+        }
+
+        @Override
+        String getEnv(String key) {
+            return map.get(key);
+        }
+    }
+
+}


### PR DESCRIPTION
In order to guarantee compatibility when adding/removing arguments in the runtime pods (both deployer and agent) it's better to not use positional arguments which may leads to inverted parameters and unexpected behaviours. 
* For each property, reads the env first. If not found, use the arg as it was before
* Deployer now only uses env

Old deployer will still generate args so the new runtime pod is still compatible 