### PR TITLE
Add /app-code-download/python/lib to the PYTHONPATH

### DIFF
--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -213,7 +213,10 @@ public class AgentRunner
         log.info("Python code directory {}", pythonCodeDirectory);
 
         final String pythonPath = System.getenv("PYTHONPATH");
-        final String newPythonPath = "%s:%s".formatted(pythonPath, pythonCodeDirectory.toAbsolutePath().toString());
+        final String newPythonPath = "%s:%s:%s".formatted(
+            pythonPath,
+            pythonCodeDirectory.toAbsolutePath(),
+            pythonCodeDirectory.resolve("lib").toAbsolutePath());
 
         // copy input/output to standard input/output of the java process
         // this allows to use "kubectl logs" easily


### PR DESCRIPTION
This way users can install target libs to their `python/lib` dir.
When they run locally they shouldn't have `python/lib` on their python path so the libs won't be used.