### PR TITLE
WebCrawler: improvements

### DIFF
--- a/examples/applications/webcrawler-source/crawler.yaml
+++ b/examples/applications/webcrawler-source/crawler.yaml
@@ -25,6 +25,9 @@ pipeline:
       seed-urls: "https://docs.langstream.ai/"
       allowed-domains: "https://docs.langstream.ai"
       min-time-between-requests: 100
+      max-error-count: 5
+      http-timeout: 10000
+      handle-cookies: true
       max-unflushed-pages: 100
       user-agent: "langstream.ai-webcrawler/1.0"
       bucketName: "{{{secrets.s3-credentials.bucket-name}}}"

--- a/examples/applications/webcrawler-source/crawler.yaml
+++ b/examples/applications/webcrawler-source/crawler.yaml
@@ -22,8 +22,8 @@ pipeline:
   - name: "Crawl the WebSite"
     type: "webcrawler-source"
     configuration:
-      seed-urls: "https://docs.langstream.ai/,https://github.com/LangStream/langstream"
-      allowed-domains: "https://docs.langstream.ai,https://github.com/LangStream/langstream"
+      seed-urls: ["https://docs.langstream.ai/", "https://github.com/LangStream/langstream"]
+      allowed-domains: ["https://docs.langstream.ai", "https://github.com/LangStream/langstream"]
       min-time-between-requests: 100
       max-error-count: 5
       http-timeout: 10000

--- a/examples/applications/webcrawler-source/crawler.yaml
+++ b/examples/applications/webcrawler-source/crawler.yaml
@@ -22,8 +22,8 @@ pipeline:
   - name: "Crawl the WebSite"
     type: "webcrawler-source"
     configuration:
-      seed-urls: "https://docs.langstream.ai/"
-      allowed-domains: "https://docs.langstream.ai"
+      seed-urls: "https://docs.langstream.ai/,https://github.com/LangStream/langstream"
+      allowed-domains: "https://docs.langstream.ai,https://github.com/LangStream/langstream"
       min-time-between-requests: 100
       max-error-count: 5
       http-timeout: 10000

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -52,6 +52,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 
+import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
+import static ai.langstream.api.util.ConfigurationUtils.getInt;
+import static ai.langstream.api.util.ConfigurationUtils.getSet;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+
 @Slf4j
 public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
 
@@ -75,28 +80,27 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
 
     private final StatusStorage statusStorage = new S3StatusStorage();
 
+
     @Override
     public void init(Map<String, Object> configuration) throws Exception {
         bucketName = configuration.getOrDefault("bucketName", "langstream-source").toString();
-        String endpoint = configuration.getOrDefault("endpoint", "http://minio-endpoint.-not-set:9090").toString();
-        String username =  configuration.getOrDefault("access-key", "minioadmin").toString();
-        String password =  configuration.getOrDefault("secret-key", "minioadmin").toString();
-        String region = configuration.getOrDefault("region", "").toString();
-        allowedDomains = Set.of(configuration.getOrDefault("allowed-domains", "")
-                .toString().split(","));
-        seedUrls = Set.of(configuration.getOrDefault("seed-urls", "")
-                .toString().split(","));
-        idleTime = Integer.parseInt(configuration.getOrDefault("idle-time", 1).toString());
-        maxUnflushedPages = Integer.parseInt(configuration.getOrDefault("max-unflushed-pages", 100).toString());
+        String endpoint = getString("endpoint", "http://minio-endpoint.-not-set:9090", configuration);
+        String username =  getString("access-key", "minioadmin", configuration);
+        String password =  getString("secret-key", "minioadmin", configuration);
+        String region = getString("region", "", configuration);
+        allowedDomains = getSet("allowed-domains", configuration);
+        seedUrls = getSet("seed-urls", configuration);
+        idleTime = getInt("idle-time", 1, configuration);
+        maxUnflushedPages = getInt("max-unflushed-pages", 100, configuration);
 
         flushNext.set(maxUnflushedPages);
         int minTimeBetweenRequests =
-            Integer.parseInt(configuration.getOrDefault("min-time-between-requests", 100).toString());
-        String userAgent = configuration.getOrDefault("user-agent", "langstream.ai-webcrawler/1.0").toString();
-        int maxErrorCount = Integer.parseInt(configuration.getOrDefault("max-error-count", "5").toString());
-        int httpTimeout = Integer.parseInt(configuration.getOrDefault("http-timeout", "10000").toString());
+            getInt("min-time-between-requests", 100, configuration);
+        String userAgent = getString("user-agent", "langstream.ai-webcrawler/1.0", configuration);
+        int maxErrorCount = getInt("max-error-count", 5, configuration);
+        int httpTimeout = getInt("http-timeout", 10000, configuration);
 
-        boolean handleCookies = Boolean.parseBoolean(configuration.getOrDefault("handle-cookies", true).toString());
+        boolean handleCookies = getBoolean("handle-cookies", true, configuration);
 
         log.info("Connecting to S3 Bucket at {} in region {} with user {}", endpoint, region, username);
         log.info("allowed-domains: {}", allowedDomains);

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -18,8 +18,12 @@ package ai.langstream.agents.webcrawler.crawler;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Connection;
+import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+
+import java.net.CookieManager;
+import java.net.CookieStore;
 
 @Slf4j
 @Getter
@@ -31,12 +35,18 @@ public class WebCrawler {
 
     private final DocumentVisitor visitor;
 
+    private final CookieStore cookieStore;
+
     public WebCrawler(WebCrawlerConfiguration configuration,
                       WebCrawlerStatus status,
                       DocumentVisitor visitor) {
         this.configuration = configuration;
         this.visitor = visitor;
         this.status = status;
+
+        CookieManager cookieManager = new CookieManager();
+        cookieManager.setCookiePolicy(java.net.CookiePolicy.ACCEPT_ALL);
+        this.cookieStore = cookieManager.getCookieStore();
     }
 
     public void crawl(String startUrl) {
@@ -51,23 +61,83 @@ public class WebCrawler {
         if (current == null) {
             return false;
         }
+        log.info("Crawling url: {}", current);
         Connection connect = Jsoup.connect(current);
+        connect.cookieStore(cookieStore);
+        connect.followRedirects(false);
         if (configuration.getUserAgent() != null) {
             connect.userAgent(configuration.getUserAgent());
         }
-        Document document = connect.get();
-        document.getElementsByAttribute("href").forEach(element -> {
-            if (configuration.isAllowedTag(element.tagName())) {
-                String url = element.absUrl("href");
-                if (configuration.isAllowedDomain(url)) {
-                    status.addUrl(url, true);
-                } else {
-                    log.info("Ignoring not allowed url: {}", url);
-                    status.addUrl(url, false);
+        connect.timeout(configuration.getHttpTimeout());
+
+        boolean redirectedToForbiddenDomain = false;
+        Document document;
+        try {
+            document = connect.get();
+            Connection.Response response = connect.response();
+            int statusCode = response.statusCode();
+            if (statusCode >= 300 && statusCode < 400) {
+                String location = response.header("Location");
+                if (!location.equals(current)) {
+                    if (!configuration.isAllowedDomain(location)) {
+                        redirectedToForbiddenDomain = true;
+                        log.warn("A redirection to a forbidden domain happened (from {} to {})", current, location);
+                    } else {
+                        log.info("A redirection happened from {} to {}", current, location);
+                        status.addUrl(location, true);
+                        return true;
+                    }
                 }
             }
-        });
-        visitor.visit(new ai.langstream.agents.webcrawler.crawler.Document(current, document.html()));
+        } catch (HttpStatusException e) {
+            int code = e.getStatusCode();
+            log.info("Error while crawling url: {}, HTTP code {}", current, code);
+
+            if (code >= 400 && code < 500) {
+                // not found, forbidden...this is a fatal error
+                log.info("Skipping the url {}", current);
+            } else if (code < 400 || (code >= 500 && code < 600)) {
+                // 1xx, 2xx, 3xx...this is not expected as it is not an "ERROR"
+                // 5xx errors are server side errors, we can retry
+
+                int currentCount = status.temporaryErrorOnUrl(current);
+                if (currentCount >= configuration.getMaxErrorCount()) {
+                    log.info("Too many errors ({}) on url {}, skipping it", currentCount, current);
+                    status.addUrl(current, false);
+                } else {
+                    log.info("Putting back the url {} into the backlog", current);
+                    status.addUrl(current, true);
+                }
+            }
+
+            // prevent from being banned for flooding
+            if (configuration.getMinTimeBetweenRequests() > 0) {
+                Thread.sleep(configuration.getMinTimeBetweenRequests());
+            }
+
+            // we did something
+            return true;
+        }
+        try {
+
+            if (!redirectedToForbiddenDomain) {
+                document.getElementsByAttribute("href").forEach(element -> {
+                    if (configuration.isAllowedTag(element.tagName())) {
+                        String url = element.absUrl("href");
+                        if (configuration.isAllowedDomain(url)) {
+                            status.addUrl(url, true);
+                        } else {
+                            log.info("Ignoring not allowed url: {}", url);
+                            status.addUrl(url, false);
+                        }
+                    }
+                });
+                visitor.visit(new ai.langstream.agents.webcrawler.crawler.Document(current, document.html()));
+            }
+        } catch (RuntimeException error) {
+            log.error("Error while processing url: {}", current, error);
+            status.addUrl(current, false);
+        }
 
         // prevent from being banned for flooding
         if (configuration.getMinTimeBetweenRequests() > 0) {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Connection;
 import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
+import org.jsoup.UnsupportedMimeTypeException;
 import org.jsoup.nodes.Document;
 
 import java.net.CookieManager;
@@ -109,6 +110,17 @@ public class WebCrawler {
                     status.addUrl(current, true);
                 }
             }
+
+            // prevent from being banned for flooding
+            if (configuration.getMinTimeBetweenRequests() > 0) {
+                Thread.sleep(configuration.getMinTimeBetweenRequests());
+            }
+
+            // we did something
+            return true;
+        } catch (UnsupportedMimeTypeException notHtml) {
+            log.info("Url {} lead to a {} content-type document. Skipping", current, notHtml.getMimeType());
+            status.addUrl(current, false);
 
             // prevent from being banned for flooding
             if (configuration.getMinTimeBetweenRequests() > 0) {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -130,25 +130,20 @@ public class WebCrawler {
             // we did something
             return true;
         }
-        try {
 
-            if (!redirectedToForbiddenDomain) {
-                document.getElementsByAttribute("href").forEach(element -> {
-                    if (configuration.isAllowedTag(element.tagName())) {
-                        String url = element.absUrl("href");
-                        if (configuration.isAllowedDomain(url)) {
-                            status.addUrl(url, true);
-                        } else {
-                            log.info("Ignoring not allowed url: {}", url);
-                            status.addUrl(url, false);
-                        }
+        if (!redirectedToForbiddenDomain) {
+            document.getElementsByAttribute("href").forEach(element -> {
+                if (configuration.isAllowedTag(element.tagName())) {
+                    String url = element.absUrl("href");
+                    if (configuration.isAllowedDomain(url)) {
+                        status.addUrl(url, true);
+                    } else {
+                        log.info("Ignoring not allowed url: {}", url);
+                        status.addUrl(url, false);
                     }
-                });
-                visitor.visit(new ai.langstream.agents.webcrawler.crawler.Document(current, document.html()));
-            }
-        } catch (RuntimeException error) {
-            log.error("Error while processing url: {}", current, error);
-            status.addUrl(current, false);
+                }
+            });
+            visitor.visit(new ai.langstream.agents.webcrawler.crawler.Document(current, document.html()));
         }
 
         // prevent from being banned for flooding

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -96,6 +96,39 @@ public class WebCrawlerSourceTest {
         }
     }
 
+
+    @Test
+    @Disabled("This test is disabled because it connects to a real live website")
+    void testReadLangStreamGithubRepo() throws Exception {
+        try {
+            String bucket = "langstream-test-" + UUID.randomUUID();
+            String url = "https://github.com/LangStream/langstream";
+            String allowed = "https://github.com/LangStream/langstream";
+
+            // perform multiple iterations, in order to see the recovery mechanism in action
+
+            int count = 1000;
+            WebCrawlerSource agentSource = buildAgentSource(bucket, allowed, url);
+            List<Record> read = agentSource.read();
+            Set<String> urls = new HashSet<>();
+            while (count -- > 0) {
+                log.info("read: {}", read);
+                for (Record r : read) {
+                    String docUrl = r.key().toString();
+                    log.info("content: {}", new String((byte[]) r.value()));
+                    assertTrue(urls.add(docUrl), "Read twice the same url: " + docUrl);
+                }
+                agentSource.commit(read);
+                read = agentSource.read();
+            }
+            agentSource.close();
+        } catch (Throwable error) {
+            log.error("Bad error", error);
+            throw error;
+        }
+    }
+
+
     @Test
     void testBasic(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfigurationTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright DataStax, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfigurationTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfigurationTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.webcrawler.crawler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WebCrawlerConfigurationTest {
+    @Test
+    void testAllowedDomains() {
+        assertTrue(verifyDomain("http://domain/something/....", Set.of("domain")));
+        assertTrue(verifyDomain("https://domain/something/....", Set.of("domain")));
+        assertTrue(verifyDomain("https://domain/something/....", Set.of("https://domain")));
+
+        assertFalse(verifyDomain("https://domain/something/....", Set.of("https://domain/else")));
+        assertFalse(verifyDomain("not-an-url", Set.of("domain")));
+        assertFalse(verifyDomain("http://domain/something/....", Set.of()));
+    }
+
+
+    private boolean verifyDomain(String url, Set<String> allowedDomains) {
+        WebCrawlerConfiguration configuration = WebCrawlerConfiguration.builder()
+                .allowedDomains(allowedDomains)
+                .build();
+        return configuration.isAllowedDomain(url);
+    }
+}

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright DataStax, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.webcrawler.crawler;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
+import static com.github.tomakehurst.wiremock.client.WireMock.serviceUnavailable;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.temporaryRedirect;
+import static org.junit.jupiter.api.Assertions.*;
+
+@WireMockTest
+class WebCrawlerTest {
+
+    @Test
+    void testWebSiteErrors(WireMockRuntimeInfo vmRuntimeInfo) throws Exception {
+
+        stubFor(get("/index.html")
+                .willReturn(okForContentType("text/html",
+                        """
+                                  <a href="internalErrorPage.html">link</a>
+                                  <a href="notFoundPage.html">link</a>
+                              """)));
+        stubFor(get("/internalErrorPage.html")
+                .willReturn(serviceUnavailable()));
+        stubFor(get("/notFoundPage.html")
+                .willReturn(notFound()));
+
+        WebCrawlerConfiguration configuration = WebCrawlerConfiguration
+                .builder()
+                .allowedDomains(Set.of(vmRuntimeInfo.getHttpBaseUrl()))
+                .maxErrorCount(5)
+                .build();
+        WebCrawlerStatus status = new WebCrawlerStatus();
+        List<Document> documents = new ArrayList<>();
+        WebCrawler crawler = new WebCrawler(configuration, status, documents::add);
+        crawler.crawl(vmRuntimeInfo.getHttpBaseUrl() + "/index.html");
+        crawler.runCycle();
+
+        assertEquals(1 , documents.size());
+        assertEquals(vmRuntimeInfo.getHttpBaseUrl()+"/index.html", documents.get(0).url());
+        assertEquals(2, status.getPendingUrls().size());
+        assertEquals(3, status.getVisitedUrls().size());
+
+        // process the internalErrorPage
+        crawler.runCycle();
+
+        assertEquals(2, status.getPendingUrls().size());
+        assertEquals(3, status.getVisitedUrls().size());
+
+        // process the notFoundPage
+        crawler.runCycle();
+
+        assertEquals(1, status.getPendingUrls().size());
+        assertEquals(3, status.getVisitedUrls().size());
+
+        // process the internalErrorPage
+        crawler.runCycle();
+
+        assertEquals(1, status.getPendingUrls().size());
+        assertEquals(3, status.getVisitedUrls().size());
+
+
+        // now the error page starts to work again
+        stubFor(get("/internalErrorPage.html")
+                .willReturn(okForContentType("text/html",
+                        """
+                                  ok !
+                              """)));
+
+
+        // process the internalErrorPage
+        crawler.runCycle();
+
+        assertEquals(0, status.getPendingUrls().size());
+        assertEquals(3, status.getVisitedUrls().size());
+    }
+
+    @Test
+    void testWebSitePermanentErrors(WireMockRuntimeInfo vmRuntimeInfo) throws Exception {
+
+        stubFor(get("/index.html")
+                .willReturn(okForContentType("text/html",
+                        """
+                                  <a href="internalErrorPage.html">link</a>
+                              """)));
+        stubFor(get("/internalErrorPage.html")
+                .willReturn(serviceUnavailable()));
+
+
+        // after 3 errors we give up
+        WebCrawlerConfiguration configuration = WebCrawlerConfiguration
+                .builder()
+                .allowedDomains(Set.of(vmRuntimeInfo.getHttpBaseUrl()))
+                .maxErrorCount(3)
+                .build();
+        WebCrawlerStatus status = new WebCrawlerStatus();
+        List<Document> documents = new ArrayList<>();
+        WebCrawler crawler = new WebCrawler(configuration, status, documents::add);
+        crawler.crawl(vmRuntimeInfo.getHttpBaseUrl() + "/index.html");
+        crawler.runCycle();
+
+        assertEquals(1 , documents.size());
+        assertEquals(vmRuntimeInfo.getHttpBaseUrl()+"/index.html", documents.get(0).url());
+        assertEquals(1, status.getPendingUrls().size());
+        assertEquals(2, status.getVisitedUrls().size());
+
+        // process the internalErrorPage
+        crawler.runCycle();
+
+        assertEquals(1, status.getPendingUrls().size());
+        assertEquals(2, status.getVisitedUrls().size());
+
+        // process the internalErrorPage
+        crawler.runCycle();
+
+        assertEquals(1, status.getPendingUrls().size());
+        assertEquals(2, status.getVisitedUrls().size());
+
+        // process the internalErrorPage
+        crawler.runCycle();
+
+        assertEquals(0, status.getPendingUrls().size());
+        assertEquals(2, status.getVisitedUrls().size());
+
+        // nothing to do
+        assertFalse(crawler.runCycle());
+    }
+
+
+    @Test
+    void testRedirects(WireMockRuntimeInfo vmRuntimeInfo) throws Exception {
+
+        stubFor(get("/index.html")
+                .willReturn(okForContentType("text/html",
+                        """
+                                  <a href="redirectToGoodWebsite.html">link</a>
+                                  <a href="redirectToBadWebsite.html">link</a>
+                              """)));
+        stubFor(get("/redirectToGoodWebsite.html")
+                .willReturn(temporaryRedirect(vmRuntimeInfo.getHttpBaseUrl()+"/goodWebsite.html")));
+
+        stubFor(get("/redirectToBadWebsite.html")
+                .willReturn(temporaryRedirect("http://go-away-from-here/somewhere.html")));
+
+        stubFor(get("/goodWebsite.html")
+                .willReturn(okForContentType("text/html", "ok")));
+
+
+        WebCrawlerConfiguration configuration = WebCrawlerConfiguration
+                .builder()
+                .allowedDomains(Set.of(vmRuntimeInfo.getHttpBaseUrl()))
+                .build();
+        WebCrawlerStatus status = new WebCrawlerStatus();
+        List<Document> documents = new ArrayList<>();
+        WebCrawler crawler = new WebCrawler(configuration, status, documents::add);
+        crawler.crawl(vmRuntimeInfo.getHttpBaseUrl() + "/index.html");
+        crawler.runCycle();
+
+        assertEquals(1 , documents.size());
+        assertEquals(vmRuntimeInfo.getHttpBaseUrl()+"/index.html", documents.get(0).url());
+        assertEquals(2, status.getPendingUrls().size());
+        assertEquals(3, status.getVisitedUrls().size());
+
+        // redirectToGoodWebsite
+        crawler.runCycle();
+        assertEquals(2, status.getPendingUrls().size());
+        assertEquals(4, status.getVisitedUrls().size());
+
+        assertEquals(vmRuntimeInfo.getHttpBaseUrl()+"/index.html", documents.get(0).url());
+        // the document that did the redirection is not reported to the DocumentVisitor
+        assertEquals(1, documents.size());
+
+        // redirectToBadWebsite
+        crawler.runCycle();
+
+        assertEquals(1, status.getPendingUrls().size());
+        assertEquals(4, status.getVisitedUrls().size());
+
+        // goodWebsite
+        crawler.runCycle();
+        assertEquals(0, status.getPendingUrls().size());
+        assertEquals(4, status.getVisitedUrls().size());
+
+        assertEquals(vmRuntimeInfo.getHttpBaseUrl()+"/index.html", documents.get(0).url());
+        assertEquals(vmRuntimeInfo.getHttpBaseUrl()+"/goodWebsite.html", documents.get(1).url());
+
+        // nothing to do
+        assertFalse(crawler.runCycle());
+    }
+}

--- a/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.api.util;
 
 import java.util.Collection;

--- a/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright DataStax, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
@@ -1,0 +1,82 @@
+package ai.langstream.api.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for configuration related operations.
+ * This class is widely used and changing the behaviour may cause breaking changes.
+ */
+public class ConfigurationUtils {
+
+
+    /**
+     * Decode a configuration map into a list of strings.
+     * Nulls are removed
+     * @param key the entry
+     * @param configuration the agent configuration
+     * @return a list of strings
+     */
+    public static List<String> getList(String key, Map<String, Object> configuration) {
+        Object value = configuration.get(key);
+        if (value == null) {
+            return List.of();
+        }
+        if (value instanceof String s) {
+            return List.of(s.split(",")).stream().map(String::trim).collect(Collectors.toList());
+        } else if (value instanceof Collection) {
+            return ((Collection<String>) value)
+                    .stream()
+                    .filter(v -> v != null)
+                    .map(v -> v.toString())
+                    .map(String::trim).collect(Collectors.toList());
+        } else {
+            throw new IllegalArgumentException("Unsupported type for " + key + ": " + value.getClass());
+        }
+    }
+
+    /**
+     * Decode a configuration map into a set of unique and unordered strings.
+     * @param key the entry
+     * @param configuration the agent configuration
+     * @return a set of unique strings
+     */
+    public static Set<String> getSet(String key, Map<String, Object> configuration) {
+        return Collections.unmodifiableSet(new HashSet<>(getList(key, configuration)));
+    }
+
+    public static int getInt(String key, int defaultValue, Map<String, Object> configuration) {
+        Object value = configuration.getOrDefault(key, defaultValue);
+        if (value instanceof Number n) {
+            return n.intValue();
+        } else {
+            return Integer.parseInt(value.toString());
+        }
+    }
+
+    public static boolean getBoolean(String key, boolean defaultValue, Map<String, Object> configuration) {
+        Object value = configuration.getOrDefault(key, defaultValue);
+        if (value instanceof Boolean n) {
+            return n.booleanValue();
+        } else {
+            return Boolean.parseBoolean(value.toString());
+        }
+    }
+
+    public static String getString(String key, String defaultValue, Map<String, Object> configuration) {
+        Object value = configuration.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof String n) {
+            return n;
+        } else {
+            return value.toString();
+        }
+    }
+}

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaProducerWrapper.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaProducerWrapper.java
@@ -194,4 +194,11 @@ class KafkaProducerWrapper implements TopicProducer {
         }
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "KafkaProducerWrapper{" +
+                "topicName='" + topicName + '\'' +
+                '}';
+    }
 }


### PR DESCRIPTION
Summary:
- handle redirections
- handle permanent failures (skip the document, forever)
- handle temporary failures (put back the document into the backlog, retry N times)
- handle cookies
- handle timeout
- allowed-domains: now this is a list of "domains" and "url prefixes" (for compatibility reasons) 

Full example:

```
pipeline:
  - name: "Crawl the WebSite"
    type: "webcrawler-source"
    configuration:
      seed-urls: "https://docs.langstream.ai/"
      allowed-domains: "docs.langstream.ai"
      min-time-between-requests: 100
      max-error-count: 5
      http-timeout: 10000
      handle-cookies: true
      max-unflushed-pages: 100
      user-agent: "langstream.ai-webcrawler/1.0"
      bucketName: "{{{secrets.s3-credentials.bucket-name}}}"
      endpoint: "{{{secrets.s3-credentials.endpoint}}}"
      access-key: "{{{secrets.s3-credentials.access-key}}}"
      secret-key: "{{{secrets.s3-credentials.secret}}}"
      region: "{{{secrets.s3-credentials.region}}}"
      idle-time: 5
```


The new parameters are:
max-error-count: 5
The maximum number of temporary failures while downloading a document


http-timeout: 10000
Timeout to get a response to the website

handle-cookies: true
Store (in memory) the cookies between one request and the other.