### PR TITLE
Fixes using OIDC on AWS

### DIFF
--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/BaseEndToEndTest.java
@@ -528,10 +528,7 @@ public class BaseEndToEndTest implements TestWatcher {
                   app:
                     config:
                       application.storage.global.type: kubernetes
-                      application.security.enabled: true
-                      application.security.token.secret-key: jDdra78Vo1+RVMGY2easnWe0sAFrEa2581ra5YMotbE=
-                      application.security.token.auth-claim: iss
-                      application.security.token.admin-roles: admin
+                      application.security.enabled: false
                                 
                 deployer:
                   image:

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/BaseEndToEndTest.java
@@ -410,7 +410,7 @@ public class BaseEndToEndTest implements TestWatcher {
     @BeforeAll
     @SneakyThrows
     public static void setup() {
-        namespace = "ls-test-" + UUID.randomUUID().toString().substring(0, 8);
+
 
         // kubeServer = new LocalK3sContainer();
         kubeServer = new RunningHostCluster();
@@ -420,16 +420,7 @@ public class BaseEndToEndTest implements TestWatcher {
                 .withConfig(Config.fromKubeconfig(kubeServer.getKubeConfig()))
                 .build();
 
-        // cleanup previous runs
-        cleanupAllEndToEndTestsNamespaces();
 
-        client.resource(new NamespaceBuilder()
-                        .withNewMetadata()
-                        .withName(namespace)
-                        .withLabels(Map.of("app", "ls-test"))
-                        .endMetadata()
-                        .build())
-                .serverSideApply();
         try {
 
 
@@ -450,17 +441,31 @@ public class BaseEndToEndTest implements TestWatcher {
             imagesFutures.add(CompletableFuture.runAsync(() ->
                     kubeServer.ensureImage("langstream/langstream-api-gateway:latest-dev")));
 
-            final CompletableFuture<Void> allFuture =
-                    CompletableFuture.runAsync(BaseEndToEndTest::installLangStream);
             CompletableFuture.allOf(kafkaFuture, minioFuture, imagesFutures.get(0), imagesFutures.get(1), imagesFutures.get(2),
-                    allFuture).join();
+                    imagesFutures.get(3)).join();
 
-            awaitControlPlaneReady();
-            awaitApiGatewayReady();
         } catch (Throwable ee) {
             dumpTest("BeforeAll");
             throw ee;
         }
+    }
+
+    @BeforeEach
+    @SneakyThrows
+    public void setupSingleTest() {
+        // cleanup previous runs
+        cleanupAllEndToEndTestsNamespaces();
+        namespace = "ls-test-" + UUID.randomUUID().toString().substring(0, 8);
+
+        client.resource(new NamespaceBuilder()
+                        .withNewMetadata()
+                        .withName(namespace)
+                        .withLabels(Map.of("app", "ls-test"))
+                        .endMetadata()
+                        .build())
+                .serverSideApply();
+
+
     }
 
     private static void cleanupAllEndToEndTestsNamespaces() {
@@ -475,7 +480,14 @@ public class BaseEndToEndTest implements TestWatcher {
     }
 
     @SneakyThrows
-    private static void installLangStream() {
+    protected void installLangStreamCluster(boolean authentication) {
+        CompletableFuture.runAsync(() -> installLangStream(authentication)).get();
+        awaitControlPlaneReady();
+        awaitApiGatewayReady();
+    }
+
+    @SneakyThrows
+    private static void installLangStream(boolean authentication) {
         client.resources(ClusterRole.class)
                 .withName("langstream-deployer")
                 .delete();
@@ -503,11 +515,6 @@ public class BaseEndToEndTest implements TestWatcher {
                 .delete();
 
 
-        final String deleteCmd =
-                "helm delete %s -n %s".formatted("langstream", namespace);
-        log.info("Running {}", deleteCmd);
-        runProcess(deleteCmd.split(" "), true);
-
         final String values = """
                 controlPlane:
                   image:
@@ -521,6 +528,10 @@ public class BaseEndToEndTest implements TestWatcher {
                   app:
                     config:
                       application.storage.global.type: kubernetes
+                      application.security.enabled: true
+                      application.security.token.secret-key: jDdra78Vo1+RVMGY2easnWe0sAFrEa2581ra5YMotbE=
+                      application.security.token.auth-claim: iss
+                      application.security.token.admin-roles: admin
                                 
                 deployer:
                   image:

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
@@ -28,9 +28,10 @@ public class PythonFunctionIT extends BaseEndToEndTest {
 
     @Test
     public void test() {
+        installLangStreamCluster(false);
         final String tenant = "ten-" + System.currentTimeMillis();
         executeCommandOnClient("""
-                bin/langstream tenants put %s && 
+                bin/langstream tenants put %s &&
                 bin/langstream configure tenant %s""".formatted(
                 tenant,
                 tenant).replace(System.lineSeparator(), " ").split(" "));

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
@@ -273,6 +273,7 @@ public class AgentResourcesFactory {
                                 .withNewEmptyDir().endEmptyDir()
                                 .build()
                 )
+                .withServiceAccountName(spec.getTenant())
                 .endSpec()
                 .endTemplate()
                 .endSpec()

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -166,7 +166,7 @@ public class AppResourcesFactory {
                 .withNewSpec()
                 .withTolerations(podTemplate != null ? podTemplate.tolerations() : null)
                 .withNodeSelector(podTemplate != null ? podTemplate.nodeSelector() : null)
-                .withServiceAccount(tenant)
+                .withServiceAccountName(tenant)
                 .withVolumes(new VolumeBuilder()
                                 .withName("app-config")
                                 .withEmptyDir(new EmptyDirVolumeSource())

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -148,6 +148,7 @@ class AgentResourcesFactoryTest {
                                   name: download-config
                                 - mountPath: /app-code-download
                                   name: code-download
+                              serviceAccountName: my-tenant
                               terminationGracePeriodSeconds: 60
                               volumes:
                               - name: app-config

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -118,7 +118,7 @@ class AppResourcesFactoryTest {
                                 - mountPath: /cluster-runtime-config
                                   name: cluster-runtime-config
                               restartPolicy: Never
-                              serviceAccount: my-tenant
+                              serviceAccountName: my-tenant
                               volumes:
                               - emptyDir: {}
                                 name: app-config
@@ -204,7 +204,7 @@ class AppResourcesFactoryTest {
                                 - mountPath: /cluster-runtime-config
                                   name: cluster-runtime-config
                               restartPolicy: Never
-                              serviceAccount: my-tenant
+                              serviceAccountName: my-tenant
                               volumes:
                               - emptyDir: {}
                                 name: app-config

--- a/langstream-webservice/src/main/docker/jib/entrypoint.sh
+++ b/langstream-webservice/src/main/docker/jib/entrypoint.sh
@@ -17,11 +17,15 @@
 set -e
 local_k8s_cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 if [ -f $local_k8s_cert ]; then
-  echo "Importing local Kubernetes certificate"
-  truststorepath=$(realpath /tmp/truststore.jks)
-  keytool -import -trustcacerts -noprompt -alias kubernetes -file $local_k8s_cert -keystore $truststorepath -storepass langstream
-  echo "Certificate imported"
-  JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=$truststorepath -Djavax.net.ssl.trustStorePassword=langstream"
+  java_home=$(dirname $(dirname $(readlink -f $(which java))))
+  java_keystore=$java_home/lib/security/cacerts
+  keystore=$(realpath /tmp/langstream-keystore.jks)
+  keytool -import -trustcacerts -noprompt -alias kubernetes -file $local_k8s_cert -keystore $keystore -storepass langstream
+  echo "Keystore created"
+  echo "Keystore created, importing local Kubernetes certificate into $java_keystore"
+  keytool -importkeystore -srckeystore $java_keystore -destkeystore $keystore -srcstorepass changeit -deststorepass langstream
+  echo "Keystore updated"
+  JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=$keystore -Djavax.net.ssl.trustStorePassword=langstream"
 fi
 
 exec java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -cp /app/resources/:/app/classes/:/app/libs/* "ai.langstream.webservice.LangStreamControlPlaneWebApplication" "$@"

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
@@ -48,6 +48,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -83,8 +84,13 @@ public class ApplicationResource {
         if (!authentication.isAuthenticated()) {
             throw new IllegalStateException();
         }
-        if (authentication.getAuthorities().contains(TokenAuthFilter.ROLE_ADMIN)) {
-            return;
+        if (authentication.getAuthorities() != null) {
+            final GrantedAuthority grantedAuthority = authentication.getAuthorities().stream()
+                    .filter(authority -> authority.getAuthority().equals(TokenAuthFilter.ROLE_ADMIN))
+                    .findFirst().orElse(null);
+            if (grantedAuthority != null) {
+                return;
+            }
         }
         if (authentication.getPrincipal() == null) {
             throw new IllegalStateException();

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/JwksUriSigningKeyResolver.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/JwksUriSigningKeyResolver.java
@@ -46,6 +46,8 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
 
     public record JwksUri(String uri, boolean checkHost, String token) {
     }
+    public record JwksUriCacheKey(JwksUri uri, String keyId) {
+    }
 
 
     private static final Logger log = LoggerFactory.getLogger(JwksUriSigningKeyResolver.class);
@@ -56,7 +58,7 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
     private final Key fallbackKey;
     private final HttpClient httpClient;
     private final LocalKubernetesJwksUriSigningKeyResolver localKubernetesJwksUriSigningKeyResolver;
-    private Map<JwksUri, Key> keyMap = new ConcurrentHashMap<>();
+    private Map<JwksUriCacheKey, Key> keyMap = new ConcurrentHashMap<>();
 
     public JwksUriSigningKeyResolver(String algorithm, String hostsAllowlist, Key fallbackKey) {
         this.algorithm = algorithm;
@@ -84,14 +86,14 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
             if (issuer != null) {
                 log.debug("No jwks_uri claim in JWT, checking issuer");
                 jwksUri = localKubernetesJwksUriSigningKeyResolver.getJwksUriFromIssuer(issuer);
-                log.debug("Got jwks_uri from issuer {}: {}", issuer, jwksUri);
+                log.debug("Got jwks_uri from issuer {}: {}", issuer, jwksUri.uri());
             }
         }
         if (jwksUri == null) {
             log.debug("No jwks_uri claim in JWT, using fallback key");
             return fallbackKey;
         }
-        return getKey(jwksUri);
+        return getKey(new JwksUriCacheKey(jwksUri, header.getKeyId()));
     }
 
 
@@ -100,11 +102,12 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
         throw new UnsupportedOperationException();
     }
 
-    private Key getKey(JwksUri uri) {
+    private Key getKey(JwksUriCacheKey uri) {
         return keyMap.computeIfAbsent(uri, this::fetchKey);
     }
 
-    private Key fetchKey(JwksUri jwksUri) {
+    private Key fetchKey(JwksUriCacheKey jwksKey) {
+        final JwksUri jwksUri = jwksKey.uri();
         final String uri = jwksUri.uri();
         try {
             final URL src = new URL(uri);
@@ -118,6 +121,9 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
                 if (!algorithm.equals(key.alg())) {
                     continue;
                 }
+                if (!jwksKey.keyId().equals(key.kid())) {
+                    continue;
+                }
                 BigInteger modulus = base64ToBigInteger(key.n());
                 BigInteger exponent = base64ToBigInteger(key.e());
                 RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(modulus, exponent);
@@ -128,9 +134,8 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
                     throw new IllegalStateException("Failed to parse public key");
                 }
             }
-            throw new JwtException("No valid keys found from URL: " + uri);
+            throw new JwtException("No valid keys found from URL: " + uri + ", keyId: " + jwksKey.keyId());
         } catch (IOException e) {
-            System.out.println(e);
             log.error("Failed to fetch keys from URL: {}", uri, e);
             throw new JwtException("Failed to fetch keys from URL: " + uri, e);
         }

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/JwksUriSigningKeyResolver.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/JwksUriSigningKeyResolver.java
@@ -86,7 +86,11 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
             if (issuer != null) {
                 log.debug("No jwks_uri claim in JWT, checking issuer");
                 jwksUri = localKubernetesJwksUriSigningKeyResolver.getJwksUriFromIssuer(issuer);
-                log.debug("Got jwks_uri from issuer {}: {}", issuer, jwksUri.uri());
+                if (jwksUri == null) {
+                    log.debug("Not able to get jwks_uri from issuer {}", issuer);
+                } else {
+                    log.debug("Got jwks_uri from issuer {}: {}", issuer, jwksUri.uri());
+                }
             }
         }
         if (jwksUri == null) {

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/JwksUriSigningKeyResolver.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/JwksUriSigningKeyResolver.java
@@ -125,7 +125,8 @@ public class JwksUriSigningKeyResolver implements SigningKeyResolver {
                 if (!algorithm.equals(key.alg())) {
                     continue;
                 }
-                if (!jwksKey.keyId().equals(key.kid())) {
+                // no kid requested, use the first one
+                if (jwksKey.keyId() != null && !jwksKey.keyId().equals(key.kid())) {
                     continue;
                 }
                 BigInteger modulus = base64ToBigInteger(key.n());

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/security/infrastructure/primary/SecurityConfigurationTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/security/infrastructure/primary/SecurityConfigurationTest.java
@@ -102,11 +102,11 @@ class SecurityConfigurationTest {
             mockMvc.perform(MockMvcRequestBuilders.request(entry.getKey(), entry.getValue().replace("{tenant}", "another-tenant"))
                             .header("Authorization", "Bearer " + token))
                     .andExpect(status().isForbidden());
-        }
-        
 
-        mockMvc.perform(get("/api/applications/another-tenant").header("Authorization", "Bearer " + token))
-                .andExpect(status().isForbidden());
+            mockMvc.perform(MockMvcRequestBuilders.request(entry.getKey(), entry.getValue().replace("{tenant}", "notadmin"))
+                            .header("Authorization", "Bearer " + ROLE_TESTROLE))
+                    .andExpect(status().isNotFound());
+        }
     }
 
 }


### PR DESCRIPTION
* Added support for oidc issuer that doesn't resolve to local kubernetes dns
* Fixed certificate import at control plane startup to also load system certs
* Fixed authz check for admin accessing tenant's applications endpoints
* Added support for OIDC providers that exposes multiple keys (before we were getting the first one instead of the one in the jwt header)
* Agent runtime wasn't using the service account of that tenant, therefore it was authenticating to the control plane with the role "default" - my testing was done using the "default" tenant 😞 