### PR TITLE
Fix python release action

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build Runtime
         run: |
           chmod +x mvnw
-          ./mvnw clean install -pl ":langstream-runtime-impl" -DskipTests -am 
+          ./mvnw clean install -DskipTests
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The `-am` flag is not enough as NAR files are needed.
To unblock, we install the full project for now.
In the future we should find a way to just have to build the python part.