### PR TITLE
Import DataStax Streaming AI code into LangStream

### DIFF
--- a/langstream-agents/langstream-ai-agents/pom.xml
+++ b/langstream-agents/langstream-ai-agents/pom.xml
@@ -169,11 +169,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-functions-api</artifactId>
       <scope>test</scope>

--- a/langstream-agents/langstream-ai-agents/pom.xml
+++ b/langstream-agents/langstream-ai-agents/pom.xml
@@ -48,21 +48,71 @@
     <dependency>
       <!-- Transform Function -->
       <groupId>org.apache.pulsar</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-original</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.datastax.oss</groupId>
-      <artifactId>streaming-ai</artifactId>
+      <groupId>ai.djl</groupId>
+      <artifactId>api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.djl.pytorch</groupId>
+      <artifactId>pytorch-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.djl.pytorch</groupId>
+      <artifactId>pytorch-jni</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.djl.pytorch</groupId>
+      <artifactId>pytorch-native-cpu</artifactId>
+      <!--classifier>osx-aarch64</classifier-->
+      <classifier>osx-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>ai.djl.pytorch</groupId>
+      <artifactId>pytorch-model-zoo</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.djl.huggingface</groupId>
+      <artifactId>tokenizers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-ai-openai</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>ai.langstream</groupId>
-          <artifactId>java-driver-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.datastax.oss</groupId>
-          <artifactId>pulsar-functions-api</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.samskivert</groupId>
+      <artifactId>jmustache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-el</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -93,11 +143,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
       <scope>test</scope>
@@ -111,6 +156,26 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-functions-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/CastStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/CastStep.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.attemptJsonConversion;
+
+import com.datastax.oss.streaming.ai.jstl.JstlTypeConverter;
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
+import lombok.Builder;
+
+@Builder
+public class CastStep implements TransformStep {
+    private final TransformSchemaType keySchemaType;
+    private final TransformSchemaType valueSchemaType;
+
+    private final boolean attemptJsonConversion;
+
+    @Override
+    public void process(TransformContext transformContext) {
+        if (transformContext.getKeySchemaType() != null
+                && keySchemaType != null
+                && transformContext.getKeySchemaType() != keySchemaType) {
+            Object value = convertValue(transformContext.getKeyObject(), keySchemaType);
+            transformContext.setKeySchemaType(keySchemaType);
+            transformContext.setKeyObject(value);
+        }
+        if (valueSchemaType != null && transformContext.getValueSchemaType() != valueSchemaType) {
+            Object value = convertValue(transformContext.getValueObject(), valueSchemaType);
+            transformContext.setValueSchemaType(valueSchemaType);
+            transformContext.setValueObject(value);
+        }
+    }
+
+    private Object convertValue(Object originalValue, TransformSchemaType schemaType) {
+        Object result =
+                JstlTypeConverter.INSTANCE.coerceToType(originalValue, getJavaType(schemaType));
+        return attemptJsonConversion ? attemptJsonConversion(result) : result;
+    }
+
+    private Class<?> getJavaType(TransformSchemaType type) {
+        switch (type) {
+            case STRING:
+                return String.class;
+            case INT8:
+                return Byte.class;
+            case INT16:
+                return Short.class;
+            case INT32:
+                return Integer.class;
+            case INT64:
+                return Long.class;
+            case FLOAT:
+                return Float.class;
+            case DOUBLE:
+                return Double.class;
+            case BOOLEAN:
+                return Boolean.class;
+            case DATE:
+                return Date.class;
+            case TIMESTAMP:
+                return Timestamp.class;
+            case TIME:
+                return Time.class;
+            case LOCAL_DATE_TIME:
+                return LocalDateTime.class;
+            case LOCAL_DATE:
+                return LocalDate.class;
+            case LOCAL_TIME:
+                return LocalTime.class;
+            case INSTANT:
+                return Instant.class;
+            case BYTES:
+                return byte[].class;
+            default:
+                throw new UnsupportedOperationException("Unsupported schema type: " + type);
+        }
+    }
+
+    public static class CastStepBuilder {
+        private TransformSchemaType keySchemaType;
+        private TransformSchemaType valueSchemaType;
+
+        public CastStepBuilder keySchemaType(TransformSchemaType keySchemaType) {
+            if (keySchemaType != null && keySchemaType.isStruct()) {
+                throw new IllegalArgumentException(
+                        "Unsupported key schema-type for Cast: " + keySchemaType);
+            }
+            this.keySchemaType = keySchemaType;
+            return this;
+        }
+
+        public CastStepBuilder valueSchemaType(TransformSchemaType valueSchemaType) {
+            if (valueSchemaType != null && valueSchemaType.isStruct()) {
+                throw new IllegalArgumentException(
+                        "Unsupported value schema-type for Cast: " + valueSchemaType);
+            }
+            this.valueSchemaType = valueSchemaType;
+            return this;
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ChatCompletionsStep.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.convertToMap;
+
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.datastax.oss.streaming.ai.completions.ChatCompletions;
+import com.datastax.oss.streaming.ai.completions.ChatMessage;
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.model.JsonRecord;
+import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+
+public class ChatCompletionsStep implements TransformStep {
+
+    private final CompletionsService completionsService;
+    private final ChatCompletionsConfig config;
+
+    private final Map<Schema, Schema> avroValueSchemaCache = new ConcurrentHashMap<>();
+
+    private final Map<Schema, Schema> avroKeySchemaCache = new ConcurrentHashMap<>();
+
+    private final Map<ChatMessage, Template> messageTemplates = new ConcurrentHashMap<>();
+
+    public ChatCompletionsStep(
+            CompletionsService completionsService, ChatCompletionsConfig config) {
+        this.completionsService = completionsService;
+        this.config = config;
+        config.getMessages()
+                .forEach(
+                        chatMessage ->
+                                messageTemplates.put(
+                                        chatMessage,
+                                        Mustache.compiler().compile(chatMessage.getContent())));
+    }
+
+    @Override
+    public void process(TransformContext transformContext) throws Exception {
+        JsonRecord jsonRecord = transformContext.toJsonRecord();
+
+        List<ChatMessage> messages =
+                config.getMessages().stream()
+                        .map(
+                                message ->
+                                        new ChatMessage(message.getRole())
+                                                .setContent(
+                                                        messageTemplates
+                                                                .get(message)
+                                                                .execute(jsonRecord)))
+                        .collect(Collectors.toList());
+
+        ChatCompletionsOptions chatCompletionsOptions =
+                new ChatCompletionsOptions(List.of())
+                        .setMaxTokens(config.getMaxTokens())
+                        .setTemperature(config.getTemperature())
+                        .setTopP(config.getTopP())
+                        .setLogitBias(config.getLogitBias())
+                        .setUser(config.getUser())
+                        .setStop(config.getStop())
+                        .setPresencePenalty(config.getPresencePenalty())
+                        .setFrequencyPenalty(config.getFrequencyPenalty());
+        Map<String, Object> options = convertToMap(chatCompletionsOptions);
+        options.put("model", config.getModel());
+        options.remove("messages");
+
+        ChatCompletions chatCompletions = completionsService.getChatCompletions(messages, options);
+
+        String content = chatCompletions.getChoices().get(0).getMessage().getContent();
+        String fieldName = config.getFieldName();
+        transformContext.setResultField(
+                content,
+                fieldName,
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
+                avroKeySchemaCache,
+                avroValueSchemaCache);
+
+        String logField = config.getLogField();
+        if (logField != null && !logField.isEmpty()) {
+            Map<String, Object> logMap = new HashMap<>();
+            logMap.put("model", config.getModel());
+            logMap.put("options", options);
+            logMap.put("messages", messages);
+            transformContext.setResultField(
+                    TransformContext.toJson(logMap),
+                    logField,
+                    org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
+                    avroKeySchemaCache,
+                    avroValueSchemaCache);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import com.datastax.oss.streaming.ai.model.JsonRecord;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.avro.Schema;
+
+/**
+ * Compute AI Embeddings from a template filled with the received message fields and metadata and
+ * put the value into a new or existing field.
+ */
+public class ComputeAIEmbeddingsStep implements TransformStep {
+
+    private final Template template;
+    private final String embeddingsFieldName;
+    private final EmbeddingsService embeddingsService;
+    private final Map<org.apache.avro.Schema, org.apache.avro.Schema> avroValueSchemaCache =
+            new ConcurrentHashMap<>();
+
+    private final Map<org.apache.avro.Schema, org.apache.avro.Schema> avroKeySchemaCache =
+            new ConcurrentHashMap<>();
+
+    public ComputeAIEmbeddingsStep(
+            String text, String embeddingsFieldName, EmbeddingsService embeddingsService) {
+        this.template = Mustache.compiler().compile(text);
+        this.embeddingsFieldName = embeddingsFieldName;
+        this.embeddingsService = embeddingsService;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (embeddingsService != null) {
+            embeddingsService.close();
+        }
+    }
+
+    @Override
+    public void process(TransformContext transformContext) {
+        JsonRecord jsonRecord = transformContext.toJsonRecord();
+        String text = template.execute(jsonRecord);
+
+        final List<Double> embeddings = embeddingsService.computeEmbeddings(List.of(text)).get(0);
+        transformContext.setResultField(
+                embeddings,
+                embeddingsFieldName,
+                Schema.createArray(Schema.create(Schema.Type.DOUBLE)),
+                avroKeySchemaCache,
+                avroValueSchemaCache);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
@@ -1,0 +1,521 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import com.datastax.oss.streaming.ai.jstl.JstlTypeConverter;
+import com.datastax.oss.streaming.ai.model.ComputeField;
+import com.datastax.oss.streaming.ai.model.ComputeFieldType;
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import com.datastax.oss.streaming.ai.util.AvroUtil;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+/** Computes a field dynamically based on JSTL expressions and adds it to the key or the value . */
+@Builder
+public class ComputeStep implements TransformStep {
+    public static final long MILLIS_PER_DAY = TimeUnit.DAYS.toMillis(1);
+    @Builder.Default private final List<ComputeField> fields = new ArrayList<>();
+    private final Map<org.apache.avro.Schema, org.apache.avro.Schema> keySchemaCache =
+            new ConcurrentHashMap<>();
+    private final Map<org.apache.avro.Schema, org.apache.avro.Schema> valueSchemaCache =
+            new ConcurrentHashMap<>();
+    private final Map<ComputeFieldType, org.apache.avro.Schema> fieldTypeToAvroSchemaCache =
+            new ConcurrentHashMap<>();
+
+    @Override
+    public void process(TransformContext transformContext) {
+        computePrimitiveField(
+                fields.stream()
+                        .filter(f -> "primitive".equals(f.getScope()))
+                        .collect(Collectors.toList()),
+                transformContext);
+        computeKeyFields(
+                fields.stream()
+                        .filter(f -> "key".equals(f.getScope()))
+                        .collect(Collectors.toList()),
+                transformContext);
+        computeValueFields(
+                fields.stream()
+                        .filter(f -> "value".equals(f.getScope()))
+                        .collect(Collectors.toList()),
+                transformContext);
+        computeHeaderFields(
+                fields.stream()
+                        .filter(f -> "header".equals(f.getScope()))
+                        .collect(Collectors.toList()),
+                transformContext);
+        computeHeaderPropertiesFields(
+                fields.stream()
+                        .filter(f -> "header.properties".equals(f.getScope()))
+                        .collect(Collectors.toList()),
+                transformContext);
+    }
+
+    public void computeValueFields(List<ComputeField> fields, TransformContext context) {
+        TransformSchemaType schemaType = context.getValueSchemaType();
+        if (context.getValueObject() instanceof Map) {
+            getEvaluatedFields(fields, context)
+                    .forEach(
+                            (field, value) ->
+                                    ((Map) context.getValueObject()).put(field.name(), value));
+        } else if (schemaType == TransformSchemaType.AVRO
+                || schemaType == TransformSchemaType.JSON) {
+            Map<Schema.Field, Object> evaluatedFields = getEvaluatedFields(fields, context);
+            context.addOrReplaceValueFields(evaluatedFields, valueSchemaCache);
+        }
+    }
+
+    public void computePrimitiveField(List<ComputeField> fields, TransformContext context) {
+        fields.stream()
+                .filter(f -> "key".equals(f.getName()))
+                .findFirst()
+                .ifPresent(
+                        field -> {
+                            if (context.getKeySchemaType() != null
+                                    && context.getKeySchemaType().isPrimitive()) {
+                                Object newKey = field.getEvaluator().evaluate(context);
+                                TransformSchemaType newSchema;
+                                if (field.getType() != null) {
+                                    newSchema = getPrimitiveSchema(field.getType());
+                                } else {
+                                    newSchema = getPrimitiveSchema(newKey);
+                                }
+                                context.setKeyObject(newKey);
+                                context.setKeySchemaType(newSchema);
+                            }
+                        });
+
+        fields.stream()
+                .filter(f -> "value".equals(f.getName()))
+                .findFirst()
+                .ifPresent(
+                        field -> {
+                            if (context.getValueSchemaType().isPrimitive()) {
+                                Object newValue = field.getEvaluator().evaluate(context);
+                                TransformSchemaType newSchema;
+                                if (field.getType() != null) {
+                                    newSchema = getPrimitiveSchema(field.getType());
+                                } else {
+                                    newSchema = getPrimitiveSchema(newValue);
+                                }
+                                context.setValueObject(newValue);
+                                context.setValueSchemaType(newSchema);
+                            }
+                        });
+    }
+
+    public void computeKeyFields(List<ComputeField> fields, TransformContext context) {
+        Object keyObject = context.getKeyObject();
+        if (keyObject != null) {
+            if (keyObject instanceof Map) {
+                getEvaluatedFields(fields, context)
+                        .forEach((field, value) -> ((Map) keyObject).put(field.name(), value));
+            } else {
+                TransformSchemaType schemaType = context.getKeySchemaType();
+                if (schemaType == TransformSchemaType.AVRO
+                        || schemaType == TransformSchemaType.JSON) {
+                    Map<Schema.Field, Object> evaluatedFields = getEvaluatedFields(fields, context);
+                    context.addOrReplaceKeyFields(evaluatedFields, keySchemaCache);
+                }
+            }
+        }
+    }
+
+    public void computeHeaderFields(List<ComputeField> fields, TransformContext context) {
+        fields.forEach(
+                field -> {
+                    switch (field.getName()) {
+                        case "destinationTopic":
+                            String topic = validateAndGetString(field, context);
+                            context.setOutputTopic(topic);
+                            break;
+                        case "messageKey":
+                            String key = validateAndGetString(field, context);
+                            context.setKey(key);
+                            break;
+                        default:
+                            throw new IllegalArgumentException(
+                                    "Invalid compute field name: " + field.getName());
+                    }
+                });
+    }
+
+    public void computeHeaderPropertiesFields(List<ComputeField> fields, TransformContext context) {
+        fields.forEach(
+                field ->
+                        context.setProperty(field.getName(), validateAndGetString(field, context)));
+    }
+
+    private String validateAndGetString(ComputeField field, TransformContext context) {
+        Object value = field.getEvaluator().evaluate(context);
+        if (value instanceof String) {
+            return (String) value;
+        }
+
+        throw new IllegalArgumentException(
+                String.format(
+                        "Invalid compute field type. " + "Name: %s, Type: %s, Expected Type: %s",
+                        field.getName(),
+                        value == null ? "null" : value.getClass().getSimpleName(),
+                        "String"));
+    }
+
+    private Map<Schema.Field, Object> getEvaluatedFields(
+            List<ComputeField> fields, TransformContext context) {
+        Map<Schema.Field, Object> evaluatedFields =
+                new LinkedHashMap<>(); // preserves the insertion order of keys
+        for (ComputeField field : fields) {
+            Object value = field.getEvaluator().evaluate(context);
+            ComputeFieldType type = field.getType() == null ? getFieldType(value) : field.getType();
+            Schema.Field avroField = createAvroField(field, type, value);
+            evaluatedFields.put(avroField, getAvroValue(avroField.schema(), value));
+        }
+        return evaluatedFields;
+    }
+
+    private Object getAvroValue(Schema schema, Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof byte[]) {
+            return ByteBuffer.wrap((byte[]) value);
+        }
+
+        if (value instanceof Byte || value instanceof Short) {
+            return ((Number) value).intValue();
+        }
+
+        LogicalType logicalType = AvroUtil.getLogicalType(schema);
+        if (logicalType == null) {
+            return value;
+        }
+
+        // Avro logical type conversion: https://avro.apache.org/docs/1.8.2/spec.html#Logical+Types
+        switch (logicalType.getName()) {
+            case "date":
+                return getAvroDate(value, schema.getLogicalType());
+            case "time-millis":
+                return getAvroTimeMillis(value, schema.getLogicalType());
+            case "timestamp-millis":
+                return getAvroTimestampMillis(value, schema.getLogicalType());
+            case "decimal":
+                return getAvroDecimal(value, schema.getLogicalType());
+        }
+
+        throw new IllegalArgumentException(
+                String.format(
+                        "Invalid logical type %s for value %s", schema.getLogicalType(), value));
+    }
+
+    private Long getAvroTimestampMillis(Object value, LogicalType logicalType) {
+        validateLogicalType(
+                value, logicalType, Instant.class, Timestamp.class, LocalDateTime.class);
+        return JstlTypeConverter.INSTANCE.coerceToType(value, Long.class);
+    }
+
+    private Integer getAvroDate(Object value, LogicalType logicalType) {
+        validateLogicalType(value, logicalType, Date.class, LocalDate.class);
+        return (value instanceof LocalDate)
+                ? Math.toIntExact(((LocalDate) value).toEpochDay())
+                : Math.toIntExact((((Date) value).getTime() / MILLIS_PER_DAY));
+    }
+
+    private Integer getAvroTimeMillis(Object value, LogicalType logicalType) {
+        validateLogicalType(value, logicalType, Time.class, LocalTime.class);
+        return JstlTypeConverter.INSTANCE.coerceToType(value, Integer.class);
+    }
+
+    private BigDecimal getAvroDecimal(Object value, LogicalType logicalType) {
+        validateLogicalType(value, logicalType, BigDecimal.class);
+        return JstlTypeConverter.INSTANCE.coerceToType(value, BigDecimal.class);
+    }
+
+    void validateLogicalType(Object value, LogicalType logicalType, Class<?>... expectedClasses) {
+        for (Class<?> clazz : expectedClasses) {
+            if ((value.getClass().equals(clazz))) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException(
+                String.format(
+                        "Invalid java type %s for logical type %s", value.getClass(), logicalType));
+    }
+
+    private Schema.Field createAvroField(ComputeField field, ComputeFieldType type, Object value) {
+        Schema avroSchema = getAvroSchema(type, value);
+        Object defaultValue = null;
+        if (field.isOptional()) {
+            avroSchema = SchemaBuilder.unionOf().nullType().and().type(avroSchema).endUnion();
+            defaultValue = Schema.Field.NULL_DEFAULT_VALUE;
+        }
+        return new Schema.Field(field.getName(), avroSchema, null, defaultValue);
+    }
+
+    private Schema getAvroSchema(ComputeFieldType type, Object value) {
+        Schema.Type schemaType;
+        switch (type) {
+            case STRING:
+                schemaType = Schema.Type.STRING;
+                break;
+            case INT8:
+            case INT16:
+            case INT32:
+            case DATE:
+            case LOCAL_DATE:
+            case TIME:
+            case LOCAL_TIME:
+                schemaType = Schema.Type.INT;
+                break;
+            case INT64:
+            case DATETIME:
+            case TIMESTAMP:
+            case INSTANT:
+            case LOCAL_DATE_TIME:
+                schemaType = Schema.Type.LONG;
+                break;
+            case FLOAT:
+                schemaType = Schema.Type.FLOAT;
+                break;
+            case DOUBLE:
+                schemaType = Schema.Type.DOUBLE;
+                break;
+            case BOOLEAN:
+                schemaType = Schema.Type.BOOLEAN;
+                break;
+            case BYTES:
+                schemaType = Schema.Type.BYTES;
+                break;
+            case ARRAY:
+                schemaType = Schema.Type.ARRAY;
+                break;
+            case DECIMAL:
+                // disable caching for decimal schema because the schema is different for each
+                // precision and
+                // scale combo and will result in an arbitrary numbers of schemas
+                // See: https://avro.apache.org/docs/1.10.2/spec.html#Decimal
+                BigDecimal decimal = (BigDecimal) value;
+                return LogicalTypes.decimal(decimal.precision(), decimal.scale())
+                        .addToSchema(Schema.create(Schema.Type.BYTES));
+            default:
+                throw new UnsupportedOperationException("Unsupported compute field type: " + type);
+        }
+
+        return fieldTypeToAvroSchemaCache.computeIfAbsent(
+                type,
+                key -> {
+                    if (schemaType == Schema.Type.ARRAY) {
+                        // we don't know the element type of the array, so we can't create a schema
+                        return Schema.createArray(
+                                Schema.createMap(Schema.create(Schema.Type.STRING)));
+                    }
+
+                    // Handle logical types:
+                    // https://avro.apache.org/docs/1.10.2/spec.html#Logical+Types
+                    Schema schema = Schema.create(schemaType);
+                    switch (key) {
+                        case DATE:
+                        case LOCAL_DATE:
+                            return LogicalTypes.date().addToSchema(schema);
+                        case TIME:
+                        case LOCAL_TIME:
+                            return LogicalTypes.timeMillis().addToSchema(schema);
+                        case DATETIME:
+                        case INSTANT:
+                        case TIMESTAMP:
+                        case LOCAL_DATE_TIME:
+                            return LogicalTypes.timestampMillis().addToSchema(schema);
+                        default:
+                            return schema;
+                    }
+                });
+    }
+
+    private TransformSchemaType getPrimitiveSchema(ComputeFieldType type) {
+        switch (type) {
+            case STRING:
+                return TransformSchemaType.STRING;
+            case INT8:
+                return TransformSchemaType.INT8;
+            case INT16:
+                return TransformSchemaType.INT16;
+            case INT32:
+                return TransformSchemaType.INT32;
+            case INT64:
+                return TransformSchemaType.INT64;
+            case FLOAT:
+                return TransformSchemaType.FLOAT;
+            case DOUBLE:
+                return TransformSchemaType.DOUBLE;
+            case BOOLEAN:
+                return TransformSchemaType.BOOLEAN;
+            case DATE:
+                return TransformSchemaType.DATE;
+            case LOCAL_DATE:
+                return TransformSchemaType.LOCAL_DATE;
+            case TIME:
+                return TransformSchemaType.TIME;
+            case LOCAL_TIME:
+                return TransformSchemaType.LOCAL_TIME;
+            case LOCAL_DATE_TIME:
+                return TransformSchemaType.LOCAL_DATE_TIME;
+            case DATETIME:
+            case INSTANT:
+                return TransformSchemaType.INSTANT;
+            case TIMESTAMP:
+                return TransformSchemaType.TIMESTAMP;
+            case BYTES:
+                return TransformSchemaType.BYTES;
+            default:
+                throw new UnsupportedOperationException("Unsupported compute field type: " + type);
+        }
+    }
+
+    private TransformSchemaType getPrimitiveSchema(Object value) {
+        if (value == null) {
+            throw new UnsupportedOperationException("Cannot get schema from null value");
+        }
+        if (value.getClass().equals(String.class)) {
+            return TransformSchemaType.STRING;
+        }
+        if (value.getClass().equals(byte[].class)) {
+            return TransformSchemaType.BYTES;
+        }
+        if (value.getClass().equals(Boolean.class)) {
+            return TransformSchemaType.BOOLEAN;
+        }
+        if (value.getClass().equals(Byte.class)) {
+            return TransformSchemaType.INT8;
+        }
+        if (value.getClass().equals(Short.class)) {
+            return TransformSchemaType.INT16;
+        }
+        if (value.getClass().equals(Integer.class)) {
+            return TransformSchemaType.INT32;
+        }
+        if (value.getClass().equals(Long.class)) {
+            return TransformSchemaType.INT64;
+        }
+        if (value.getClass().equals(Float.class)) {
+            return TransformSchemaType.FLOAT;
+        }
+        if (value.getClass().equals(Double.class)) {
+            return TransformSchemaType.DOUBLE;
+        }
+        if (value.getClass().equals(Date.class)) {
+            return TransformSchemaType.DATE;
+        }
+        if (value.getClass().equals(Timestamp.class)) {
+            return TransformSchemaType.TIMESTAMP;
+        }
+        if (value.getClass().equals(Time.class)) {
+            return TransformSchemaType.TIME;
+        }
+        if (value.getClass().equals(LocalDateTime.class)) {
+            return TransformSchemaType.LOCAL_DATE_TIME;
+        }
+        if (value.getClass().equals(LocalDate.class)) {
+            return TransformSchemaType.LOCAL_DATE;
+        }
+        if (value.getClass().equals(LocalTime.class)) {
+            return TransformSchemaType.LOCAL_TIME;
+        }
+        if (value.getClass().equals(Instant.class)) {
+            return TransformSchemaType.INSTANT;
+        }
+        throw new UnsupportedOperationException("Got an unsupported type: " + value.getClass());
+    }
+
+    private ComputeFieldType getFieldType(Object value) {
+        if (value == null) {
+            throw new UnsupportedOperationException("Cannot get field type from null value");
+        }
+        if (value instanceof CharSequence) {
+            return ComputeFieldType.STRING;
+        }
+        if (value instanceof ByteBuffer || value.getClass().equals(byte[].class)) {
+            return ComputeFieldType.BYTES;
+        }
+        if (value.getClass().equals(Boolean.class)) {
+            return ComputeFieldType.BOOLEAN;
+        }
+        if (value.getClass().equals(Byte.class)) {
+            return ComputeFieldType.INT8;
+        }
+        if (value.getClass().equals(Short.class)) {
+            return ComputeFieldType.INT16;
+        }
+        if (value.getClass().equals(Integer.class)) {
+            return ComputeFieldType.INT32;
+        }
+        if (value.getClass().equals(Long.class)) {
+            return ComputeFieldType.INT64;
+        }
+        if (value.getClass().equals(Float.class)) {
+            return ComputeFieldType.FLOAT;
+        }
+        if (value.getClass().equals(Double.class)) {
+            return ComputeFieldType.DOUBLE;
+        }
+        if (value.getClass().equals(Date.class)) {
+            return ComputeFieldType.DATE;
+        }
+        if (value.getClass().equals(Timestamp.class)) {
+            return ComputeFieldType.TIMESTAMP;
+        }
+        if (value.getClass().equals(Time.class)) {
+            return ComputeFieldType.TIME;
+        }
+        if (value.getClass().equals(LocalDateTime.class)) {
+            return ComputeFieldType.LOCAL_DATE_TIME;
+        }
+        if (value.getClass().equals(LocalDate.class)) {
+            return ComputeFieldType.LOCAL_DATE;
+        }
+        if (value.getClass().equals(LocalTime.class)) {
+            return ComputeFieldType.LOCAL_TIME;
+        }
+        if (value.getClass().equals(Instant.class)) {
+            return ComputeFieldType.INSTANT;
+        }
+        if (value.getClass().equals(BigDecimal.class)) {
+            return ComputeFieldType.DECIMAL;
+        }
+        if (List.class.isAssignableFrom(value.getClass())) {
+            return ComputeFieldType.ARRAY;
+        }
+        throw new UnsupportedOperationException("Got an unsupported type: " + value.getClass());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/DropFieldStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/DropFieldStep.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Builder;
+
+/** This function removes a "field" from a message. */
+@Builder
+public class DropFieldStep implements TransformStep {
+
+    @Builder.Default private final List<String> keyFields = new ArrayList<>();
+    @Builder.Default private final List<String> valueFields = new ArrayList<>();
+
+    private final Map<org.apache.avro.Schema, org.apache.avro.Schema> keySchemaCache =
+            new ConcurrentHashMap<>();
+    private final Map<org.apache.avro.Schema, org.apache.avro.Schema> valueSchemaCache =
+            new ConcurrentHashMap<>();
+
+    @Override
+    public void process(TransformContext transformContext) {
+        if (transformContext.getKeyObject() != null) {
+            transformContext.dropKeyFields(keyFields, keySchemaCache);
+        }
+        transformContext.dropValueFields(valueFields, valueSchemaCache);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/DropStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/DropStep.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+/**
+ * Drops a message from further processing. Works in conjunctions with predicates to selectively
+ * choose which messages to drop
+ */
+public class DropStep implements TransformStep {
+    @Override
+    public void process(TransformContext transformContext) throws Exception {
+        transformContext.setDropCurrentRecord(true);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/FlattenStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/FlattenStep.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+
+@Builder
+public class FlattenStep implements TransformStep {
+    // TODO: Cache schema to flattened schema
+    // TODO: Microbenchmark the flatten algorithm for performance optimization
+    // TODO: Validate flatten delimiter
+    // TODO: Add integration test
+
+    public static final String AVRO_READ_OFFSET_PROP = "__AVRO_READ_OFFSET__";
+
+    private static final String DEFAULT_DELIMITER = "_"; // '.' in not valid in AVRO field names
+
+    @Builder.Default private final String delimiter = DEFAULT_DELIMITER;
+    private final String part;
+
+    @Override
+    public void process(TransformContext transformContext) throws Exception {
+        if (part != null && !part.equals("key") && !part.equals("value")) {
+            throw new IllegalArgumentException("Unsupported part for Flatten: " + part);
+        }
+        if ("key".equals(part) || part == null) {
+            validateAvro(transformContext.getKeySchemaType());
+            GenericRecord flattenedKey =
+                    flattenGenericRecord((GenericRecord) transformContext.getKeyObject());
+            transformContext.setKeyObject(flattenedKey);
+            transformContext.setKeyNativeSchema(flattenedKey.getSchema());
+        }
+        if ("value".equals(part) || part == null) {
+            validateAvro(transformContext.getValueSchemaType());
+            GenericRecord flattenedValue =
+                    flattenGenericRecord((GenericRecord) transformContext.getValueObject());
+            transformContext.setValueObject(flattenedValue);
+            transformContext.setValueNativeSchema(flattenedValue.getSchema());
+        }
+    }
+
+    void validateAvro(TransformSchemaType schemaType) {
+        if (schemaType == null) {
+            throw new IllegalStateException("Flatten requires non-null schemas!");
+        }
+
+        if (schemaType != TransformSchemaType.AVRO) {
+            throw new IllegalStateException(
+                    "Unsupported schema type for Flatten: " + schemaType.name());
+        }
+    }
+
+    GenericRecord flattenGenericRecord(GenericRecord record) {
+        List<FieldValuePair> fieldValuePairs = buildFlattenedFields(record);
+        List<org.apache.avro.Schema.Field> fields =
+                fieldValuePairs.stream().map(FieldValuePair::getField).collect(Collectors.toList());
+        org.apache.avro.Schema modified = buildFlattenedSchema(record, fields);
+        GenericRecord newRecord = new GenericData.Record(modified);
+        fieldValuePairs.forEach(pair -> newRecord.put(pair.getField().name(), pair.getValue()));
+        return newRecord;
+    }
+
+    private List<FieldValuePair> buildFlattenedFields(GenericRecord record) {
+        List<FieldValuePair> flattenedFields = new ArrayList<>();
+        org.apache.avro.Schema originalSchema = record.getSchema();
+        for (org.apache.avro.Schema.Field field : originalSchema.getFields()) {
+            flattenedFields.addAll(
+                    flattenField(
+                            record, record.getSchema(), field, field.schema().isNullable(), ""));
+        }
+
+        return flattenedFields;
+    }
+
+    org.apache.avro.Schema buildFlattenedSchema(
+            GenericRecord record, List<org.apache.avro.Schema.Field> flattenedFields) {
+        org.apache.avro.Schema originalSchema = record.getSchema();
+        org.apache.avro.Schema flattenedSchema =
+                org.apache.avro.Schema.createRecord(
+                        originalSchema.getName(),
+                        originalSchema.getDoc(),
+                        originalSchema.getNamespace(),
+                        false,
+                        flattenedFields);
+        originalSchema.getObjectProps().entrySet().stream()
+                .filter(e -> !AVRO_READ_OFFSET_PROP.equals(e.getKey()))
+                .forEach(e -> flattenedSchema.addProp(e.getKey(), e.getValue()));
+        return flattenedSchema;
+    }
+
+    /**
+     * @param record the record that contains the field to be flattened. Each recursive call will
+     *     pass the record one level deeper. At any level, the field could become null.
+     * @param schema the schema of the record that contains the field to be flattened. Each
+     *     recursive call will pass the schema one level deeper. At any level, the schema should
+     *     exist.
+     * @param field the field to be flattened
+     * @param nullable true if the current field schema is nullable, this has to be passed all the
+     *     way to the last nested level because anytime one of the ancestors is null, the flattened
+     *     field schema could be null even if it is not nullable on the original schema
+     * @param flattenedFieldName the field name that is built incrementally with each recursive
+     *     call.
+     * @return flattened key/value pairs.
+     */
+    List<FieldValuePair> flattenField(
+            @Nullable GenericRecord record,
+            org.apache.avro.Schema schema,
+            org.apache.avro.Schema.Field field,
+            boolean nullable,
+            String flattenedFieldName) {
+        List<FieldValuePair> flattenedFields = new ArrayList<>();
+        // Because of UNION schemas, we cannot tell for sure if the current field is a record, so we
+        // have to use reflection
+        org.apache.avro.Schema recordSchema = getRecordSchema(schema, field.name());
+        if (recordSchema != null) {
+            for (org.apache.avro.Schema.Field nestedField : recordSchema.getFields()) {
+                GenericRecord genericRecord =
+                        record == null ? null : (GenericRecord) record.get(field.name());
+                flattenedFields.addAll(
+                        flattenField(
+                                genericRecord,
+                                recordSchema,
+                                nestedField,
+                                nullable || nestedField.schema().isNullable(),
+                                flattenedFieldName + field.name() + delimiter));
+            }
+
+            return flattenedFields;
+        }
+
+        org.apache.avro.Schema.Field flattenedField =
+                createField(field, flattenedFieldName + field.name(), nullable);
+        FieldValuePair fieldValuePair =
+                new FieldValuePair(
+                        flattenedField, record == null ? null : record.get(field.name()));
+        flattenedFields.add(fieldValuePair);
+
+        return flattenedFields;
+    }
+
+    private org.apache.avro.Schema getRecordSchema(org.apache.avro.Schema schema, String name) {
+        if (schema.getType() != org.apache.avro.Schema.Type.RECORD) {
+            return null;
+        }
+
+        org.apache.avro.Schema fieldSchema = schema.getField(name).schema();
+        if (fieldSchema.isUnion()) {
+            for (org.apache.avro.Schema s : fieldSchema.getTypes()) {
+                if (s.getType() == org.apache.avro.Schema.Type.RECORD) {
+                    return s;
+                }
+            }
+        }
+
+        return fieldSchema.getType() == org.apache.avro.Schema.Type.RECORD ? fieldSchema : null;
+    }
+
+    /**
+     * Creates a new Field instance with the same schema, doc, defaultValue, and order as field has
+     * with changing the name to the specified one. It also copies all the props and aliases.
+     */
+    org.apache.avro.Schema.Field createField(
+            org.apache.avro.Schema.Field field, String name, boolean nullable) {
+        org.apache.avro.Schema newSchema = field.schema();
+        if (nullable && !newSchema.isNullable()) {
+            newSchema = SchemaBuilder.unionOf().nullType().and().type(newSchema).endUnion();
+        }
+        org.apache.avro.Schema.Field newField =
+                new org.apache.avro.Schema.Field(
+                        name, newSchema, field.doc(), field.defaultVal(), field.order());
+        newField.putAll(field);
+        field.aliases().forEach(newField::addAlias);
+
+        return newField;
+    }
+
+    @Value
+    private static class FieldValuePair {
+        org.apache.avro.Schema.Field field;
+        Object value;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/JsonNodeSchema.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/JsonNodeSchema.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SchemaSerializationException;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+public final class JsonNodeSchema implements Schema<JsonNode> {
+    private static final ThreadLocal<ObjectMapper> JSON_MAPPER =
+            ThreadLocal.withInitial(
+                    () -> {
+                        ObjectMapper mapper = new ObjectMapper();
+                        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+                        return mapper;
+                    });
+    private final org.apache.avro.Schema nativeSchema;
+    private final SchemaInfo schemaInfo;
+
+    public JsonNodeSchema(org.apache.avro.Schema schema) {
+        if (schema == null) {
+            throw new IllegalArgumentException("Avro schema cannot be null");
+        }
+        this.nativeSchema = schema;
+        this.schemaInfo =
+                SchemaInfo.builder()
+                        .name("")
+                        .type(SchemaType.JSON)
+                        .schema(schema.toString().getBytes(StandardCharsets.UTF_8))
+                        .build();
+    }
+
+    @Override
+    public byte[] encode(JsonNode message) {
+        try {
+            return JSON_MAPPER.get().writeValueAsBytes(message);
+        } catch (JsonProcessingException e) {
+            throw new SchemaSerializationException(e);
+        }
+    }
+
+    @Override
+    public JsonNode decode(byte[] bytes, byte[] schemaVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SchemaInfo getSchemaInfo() {
+        return schemaInfo;
+    }
+
+    @Override
+    public Optional<Object> getNativeSchema() {
+        return Optional.of(this.nativeSchema);
+    }
+
+    @Override
+    public Schema clone() {
+        return new JsonNodeSchema(nativeSchema);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/MergeKeyValueStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/MergeKeyValueStep.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+
+public class MergeKeyValueStep implements TransformStep {
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final Map<org.apache.avro.Schema, Map<org.apache.avro.Schema, org.apache.avro.Schema>>
+            schemaCache = new ConcurrentHashMap<>();
+
+    @Override
+    public void process(TransformContext transformContext) {
+        TransformSchemaType keySchemaType = transformContext.getKeySchemaType();
+        if (keySchemaType == null) {
+            return;
+        }
+        Object keyObject = transformContext.getKeyObject();
+        Object valueObject = transformContext.getValueObject();
+        if (keyObject instanceof Map && valueObject instanceof Map) {
+            Map<Object, Object> value = (Map<Object, Object>) valueObject;
+            Map<String, Object> keyCopy =
+                    OBJECT_MAPPER.convertValue(keyObject, new TypeReference<>() {});
+            keyCopy.forEach(value::putIfAbsent);
+        } else if (keySchemaType == TransformSchemaType.AVRO
+                && transformContext.getValueSchemaType() == TransformSchemaType.AVRO) {
+            GenericRecord avroKeyRecord = (GenericRecord) keyObject;
+            org.apache.avro.Schema avroKeySchema = avroKeyRecord.getSchema();
+
+            GenericRecord avroValueRecord = (GenericRecord) valueObject;
+            org.apache.avro.Schema avroValueSchema = avroValueRecord.getSchema();
+
+            org.apache.avro.Schema mergedSchema = getMergedSchema(avroKeySchema, avroValueSchema);
+            GenericRecord newRecord = new GenericData.Record(mergedSchema);
+            avroValueSchema
+                    .getFields()
+                    .forEach(
+                            field ->
+                                    newRecord.put(field.name(), avroValueRecord.get(field.name())));
+            for (org.apache.avro.Schema.Field field : avroKeySchema.getFields()) {
+                if (avroValueSchema.getField(field.name()) == null) {
+                    newRecord.put(field.name(), avroKeyRecord.get(field.name()));
+                }
+            }
+            transformContext.setValueObject(newRecord);
+            transformContext.setValueNativeSchema(newRecord.getSchema());
+        } else if (keySchemaType == TransformSchemaType.JSON
+                && transformContext.getValueSchemaType() == TransformSchemaType.JSON) {
+            org.apache.avro.Schema avroKeySchema =
+                    (org.apache.avro.Schema) transformContext.getKeyNativeSchema();
+            org.apache.avro.Schema avroValueSchema =
+                    (org.apache.avro.Schema) transformContext.getValueNativeSchema();
+            if (avroValueSchema != null && avroKeySchema != null) {
+                org.apache.avro.Schema mergedSchema =
+                        getMergedSchema(avroKeySchema, avroValueSchema);
+                transformContext.setValueNativeSchema(mergedSchema);
+            } else {
+                transformContext.setValueNativeSchema(null);
+            }
+            ObjectNode newValue = ((ObjectNode) keyObject).deepCopy();
+            newValue.setAll(((ObjectNode) valueObject).deepCopy());
+            transformContext.setValueObject(newValue);
+        }
+    }
+
+    private org.apache.avro.Schema getMergedSchema(
+            org.apache.avro.Schema avroKeySchema, org.apache.avro.Schema avroValueSchema) {
+        List<org.apache.avro.Schema.Field> fields =
+                avroKeySchema.getFields().stream()
+                        .filter(field -> avroValueSchema.getField(field.name()) == null)
+                        .map(
+                                f ->
+                                        new org.apache.avro.Schema.Field(
+                                                f.name(),
+                                                f.schema(),
+                                                f.doc(),
+                                                f.defaultVal(),
+                                                f.order()))
+                        .collect(Collectors.toList());
+        fields.addAll(
+                avroValueSchema.getFields().stream()
+                        .map(
+                                f ->
+                                        new org.apache.avro.Schema.Field(
+                                                f.name(),
+                                                f.schema(),
+                                                f.doc(),
+                                                f.defaultVal(),
+                                                f.order()))
+                        .collect(Collectors.toList()));
+
+        Map<org.apache.avro.Schema, org.apache.avro.Schema> schemaCacheKey =
+                schemaCache.computeIfAbsent(avroKeySchema, s -> new ConcurrentHashMap<>());
+        return schemaCacheKey.computeIfAbsent(
+                avroValueSchema,
+                schema ->
+                        org.apache.avro.Schema.createRecord(
+                                avroValueSchema.getName(),
+                                null,
+                                avroValueSchema.getNamespace(),
+                                false,
+                                fields));
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/QueryStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/QueryStep.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+/**
+ * Compute AI Embeddings for one or more records fields and put the value into a new or existing
+ * field.
+ */
+@Builder
+@Slf4j
+public class QueryStep implements TransformStep {
+
+    @Builder.Default private final List<String> fields = new ArrayList<>();
+    private final String outputFieldName;
+    private final String query;
+    private final boolean onlyFirst;
+    private final QueryStepDataSource dataSource;
+    private final Map<Schema, Schema> avroValueSchemaCache = new ConcurrentHashMap<>();
+    private final Map<Schema, Schema> avroKeySchemaCache = new ConcurrentHashMap<>();
+
+    @Override
+    public void process(TransformContext transformContext) {
+        List<Object> params = new ArrayList<>();
+        fields.forEach(
+                field -> {
+                    if (field.equals("value")) {
+                        params.add(transformContext.getValueObject());
+                    } else if (field.equals("key")) {
+                        params.add(transformContext.getKeyObject());
+                    } else if (field.equals("messageKey")) {
+                        params.add(transformContext.getKey());
+                    } else if (field.startsWith("properties.")) {
+                        String propName = field.substring("properties.".length());
+                        params.add(transformContext.getProperties().get(propName));
+                    } else if (field.equals("destinationTopic")) {
+                        params.add(transformContext.getOutputTopic());
+                    } else if (field.equals("topicName")) {
+                        params.add(transformContext.getInputTopic());
+                    } else if (field.equals("eventTime")) {
+                        params.add(transformContext.getEventTime());
+                    } else if (field.startsWith("value.")) {
+                        params.add(
+                                getField(
+                                        "value",
+                                        field,
+                                        transformContext.getValueSchemaType(),
+                                        transformContext.getValueObject()));
+                    } else if (field.startsWith("key.")) {
+                        params.add(
+                                getField(
+                                        "key",
+                                        field,
+                                        transformContext.getKeySchemaType(),
+                                        transformContext.getKeyObject()));
+                    }
+                });
+
+        List<Map<String, String>> results = dataSource.fetchData(query, params);
+        if (results == null) {
+            results = List.of();
+        }
+        Object finalResult = results;
+        Schema schema;
+        if (onlyFirst) {
+            schema = Schema.createMap(Schema.create(Schema.Type.STRING));
+            if (results.isEmpty()) {
+                finalResult = Map.of();
+            } else {
+                finalResult = results.get(0);
+            }
+        } else {
+            schema = Schema.createArray(Schema.createMap(Schema.create(Schema.Type.STRING)));
+        }
+
+        transformContext.setResultField(
+                finalResult, outputFieldName, schema, avroKeySchemaCache, avroValueSchemaCache);
+    }
+
+    private Object getField(
+            String key, String field, TransformSchemaType keySchemaType, Object keyObject) {
+        String fieldName = field.substring((key.length() + 1));
+        if (keyObject instanceof Map) {
+            return ((Map<String, Object>) keyObject).get(fieldName);
+        }
+        switch (keySchemaType) {
+            case AVRO:
+                GenericRecord avroRecord = (GenericRecord) keyObject;
+                return getAvroField(fieldName, avroRecord);
+            case JSON:
+                JsonNode json = (JsonNode) keyObject;
+                return getJsonField(fieldName, json);
+            default:
+                throw new TransformFunctionException(
+                        String.format(
+                                "%s.* can only be used in query step with AVRO or JSON schema",
+                                key));
+        }
+    }
+
+    private static Object getJsonField(String fieldName, JsonNode json) {
+        JsonNode node = json.get(fieldName);
+        if (node != null && !node.isNull()) {
+            if (node.isArray()) {
+                List<Object> values = new ArrayList<>();
+                for (JsonNode elem : node) {
+                    values.add(jsonNodeToPrimitive(elem));
+                }
+                return values;
+            } else {
+                return jsonNodeToPrimitive(node);
+            }
+        } else {
+            throw new TransformFunctionException(
+                    String.format("Field %s is null in JSON record", fieldName));
+        }
+    }
+
+    private static Object jsonNodeToPrimitive(JsonNode node) {
+        if (node.isNumber()) {
+            return node.asDouble();
+        } else if (node.isBoolean()) {
+            return node.asBoolean();
+        } else {
+            return node.asText();
+        }
+    }
+
+    private static Object getAvroField(String fieldName, GenericRecord avroRecord) {
+        Object rawValue = avroRecord.get(fieldName);
+        if (rawValue != null) {
+            // TODO: handle numbers...
+            if (rawValue instanceof CharSequence) {
+                // AVRO utf8...
+                rawValue = rawValue.toString();
+            }
+        } else {
+            throw new TransformFunctionException(
+                    String.format("Field %s is null in AVRO record", fieldName));
+        }
+        return rawValue;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/TransformContext.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/TransformContext.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import com.datastax.oss.streaming.ai.model.JsonRecord;
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import com.datastax.oss.streaming.ai.util.AvroUtil;
+import com.datastax.oss.streaming.ai.util.JsonConverter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Conversions;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+
+@Slf4j
+@Data
+public class TransformContext {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private TransformSchemaType keySchemaType;
+    private Object keyNativeSchema;
+    private Object keyObject;
+    private TransformSchemaType valueSchemaType;
+    private Object valueNativeSchema;
+    private Object valueObject;
+    private String key;
+    private Map<String, String> properties;
+    private String inputTopic;
+    private String outputTopic;
+    private Long eventTime;
+    private boolean dropCurrentRecord;
+    Map<String, Object> customContext = new HashMap<>();
+    // only for fn:filter
+    private Object recordObject;
+
+    public void convertMapToStringOrBytes() throws JsonProcessingException {
+        if (valueObject instanceof Map) {
+            if (valueSchemaType == TransformSchemaType.STRING) {
+                valueObject = OBJECT_MAPPER.writeValueAsString(valueObject);
+            } else if (valueSchemaType == TransformSchemaType.BYTES) {
+                valueObject = OBJECT_MAPPER.writeValueAsBytes(valueObject);
+            }
+        }
+        if (keyObject instanceof Map) {
+            if (keySchemaType == TransformSchemaType.STRING) {
+                keyObject = OBJECT_MAPPER.writeValueAsString(keyObject);
+            } else if (keySchemaType == TransformSchemaType.BYTES) {
+                keyObject = OBJECT_MAPPER.writeValueAsBytes(keyObject);
+            }
+        }
+    }
+
+    public void convertAvroToBytes() throws IOException {
+        if (keySchemaType == TransformSchemaType.AVRO) {
+            keyObject = serializeGenericRecord((GenericRecord) keyObject);
+        }
+        if (valueSchemaType == TransformSchemaType.AVRO) {
+            valueObject = serializeGenericRecord((GenericRecord) valueObject);
+        }
+    }
+
+    public void setProperty(String key, String value) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.put(key, value);
+    }
+
+    public static byte[] serializeGenericRecord(GenericRecord record) throws IOException {
+        GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(record.getSchema());
+        // enable Decimal conversion, otherwise attempting to serialize java.math.BigDecimal will
+        // throw
+        // ClassCastException
+        writer.getData().addLogicalTypeConversion(new Conversions.DecimalConversion());
+        ByteArrayOutputStream oo = new ByteArrayOutputStream();
+        BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(oo, null);
+        writer.write(record, encoder);
+        return oo.toByteArray();
+    }
+
+    public void dropValueFields(Collection<String> fields, Map<Schema, Schema> schemaCache) {
+        if (valueObject instanceof Map) {
+            fields.forEach(((Map<?, ?>) valueObject)::remove);
+        } else if (valueSchemaType == TransformSchemaType.AVRO) {
+            dropAvroValueFields(fields, schemaCache);
+        } else if (valueSchemaType == TransformSchemaType.JSON) {
+            dropJsonValueFields(fields, schemaCache);
+        }
+    }
+
+    private void dropAvroValueFields(Collection<String> fields, Map<Schema, Schema> schemaCache) {
+        GenericRecord avroRecord = (GenericRecord) valueObject;
+        GenericRecord newRecord = AvroUtil.dropAvroRecordFields(avroRecord, fields, schemaCache);
+        valueNativeSchema = newRecord.getSchema();
+        valueObject = newRecord;
+    }
+
+    private void dropJsonValueFields(Collection<String> fields, Map<Schema, Schema> schemaCache) {
+        if (valueNativeSchema != null) {
+            valueNativeSchema =
+                    AvroUtil.dropAvroSchemaFields((Schema) valueNativeSchema, fields, schemaCache);
+        }
+        valueObject = ((ObjectNode) valueObject).remove(fields);
+    }
+
+    public void dropKeyFields(Collection<String> fields, Map<Schema, Schema> schemaCache) {
+        if (keyObject instanceof Map) {
+            fields.forEach(((Map<?, ?>) keyObject)::remove);
+        } else if (keySchemaType == TransformSchemaType.AVRO) {
+            dropAvroKeyFields(fields, schemaCache);
+        } else if (keySchemaType == TransformSchemaType.JSON) {
+            dropJsonKeyFields(fields, schemaCache);
+        }
+    }
+
+    private void dropAvroKeyFields(Collection<String> fields, Map<Schema, Schema> schemaCache) {
+        GenericRecord avroRecord = (GenericRecord) keyObject;
+        GenericRecord newRecord = AvroUtil.dropAvroRecordFields(avroRecord, fields, schemaCache);
+        keyNativeSchema = newRecord.getSchema();
+        keyObject = newRecord;
+    }
+
+    private void dropJsonKeyFields(Collection<String> fields, Map<Schema, Schema> schemaCache) {
+        if (keyNativeSchema != null) {
+            keyNativeSchema =
+                    AvroUtil.dropAvroSchemaFields((Schema) keyNativeSchema, fields, schemaCache);
+        }
+        keyObject = ((ObjectNode) keyObject).remove(fields);
+    }
+
+    public void addOrReplaceValueFields(
+            Map<Schema.Field, Object> newFields, Map<Schema, Schema> schemaCache) {
+        if (valueSchemaType == TransformSchemaType.AVRO) {
+            addOrReplaceAvroValueFields(newFields, schemaCache);
+        } else if (valueSchemaType == TransformSchemaType.JSON) {
+            addOrReplaceJsonValueFields(newFields, schemaCache);
+        }
+    }
+
+    private void addOrReplaceAvroValueFields(
+            Map<Schema.Field, Object> newFields, Map<Schema, Schema> schemaCache) {
+        GenericRecord avroRecord = (GenericRecord) valueObject;
+        GenericRecord newRecord =
+                AvroUtil.addOrReplaceAvroRecordFields(avroRecord, newFields, schemaCache);
+        valueNativeSchema = newRecord.getSchema();
+        valueObject = newRecord;
+    }
+
+    private void addOrReplaceJsonValueFields(
+            Map<Schema.Field, Object> newFields, Map<Schema, Schema> schemaCache) {
+        if (valueNativeSchema != null) {
+            valueNativeSchema =
+                    AvroUtil.addOrReplaceAvroSchemaFields(
+                            (Schema) valueNativeSchema, newFields.keySet(), schemaCache);
+        }
+        ObjectNode json = (ObjectNode) valueObject;
+        newFields.forEach(
+                (field, value) -> json.set(field.name(), OBJECT_MAPPER.valueToTree(value)));
+        valueObject = json;
+    }
+
+    public void addOrReplaceKeyFields(
+            Map<Schema.Field, Object> newFields, Map<Schema, Schema> schemaCache) {
+        if (keySchemaType == TransformSchemaType.AVRO) {
+            addOrReplaceAvroKeyFields(newFields, schemaCache);
+        } else if (keySchemaType == TransformSchemaType.JSON) {
+            addOrReplaceJsonKeyFields(newFields, schemaCache);
+        }
+    }
+
+    private void addOrReplaceAvroKeyFields(
+            Map<Schema.Field, Object> newFields, Map<Schema, Schema> schemaCache) {
+        GenericRecord avroRecord = (GenericRecord) keyObject;
+        GenericRecord newRecord =
+                AvroUtil.addOrReplaceAvroRecordFields(avroRecord, newFields, schemaCache);
+        keyNativeSchema = newRecord.getSchema();
+        keyObject = newRecord;
+    }
+
+    private void addOrReplaceJsonKeyFields(
+            Map<Schema.Field, Object> newFields, Map<Schema, Schema> schemaCache) {
+        if (keyNativeSchema != null) {
+            keyNativeSchema =
+                    AvroUtil.addOrReplaceAvroSchemaFields(
+                            (Schema) keyNativeSchema, newFields.keySet(), schemaCache);
+        }
+        ObjectNode json = (ObjectNode) keyObject;
+        newFields.forEach(
+                (field, value) -> json.set(field.name(), OBJECT_MAPPER.valueToTree(value)));
+        keyObject = json;
+    }
+
+    public JsonRecord toJsonRecord() {
+        JsonRecord jsonRecord = new JsonRecord();
+        if (keySchemaType != null) {
+            jsonRecord.setKey(toJsonSerializable(keySchemaType, keyObject));
+        } else {
+            jsonRecord.setKey(key);
+        }
+        jsonRecord.setValue(toJsonSerializable(valueSchemaType, valueObject));
+        jsonRecord.setDestinationTopic(outputTopic);
+
+        jsonRecord.setProperties(properties);
+        jsonRecord.setEventTime(eventTime);
+        jsonRecord.setTopicName(inputTopic);
+        return jsonRecord;
+    }
+
+    private static Object toJsonSerializable(TransformSchemaType schemaType, Object val) {
+        if (schemaType == null || schemaType.isPrimitive()) {
+            return val;
+        }
+        switch (schemaType) {
+            case AVRO:
+                // TODO: do better than the double conversion AVRO -> JsonNode -> Map
+                return OBJECT_MAPPER.convertValue(
+                        JsonConverter.toJson((GenericRecord) val),
+                        new TypeReference<Map<String, Object>>() {});
+            case JSON:
+                return OBJECT_MAPPER.convertValue(val, new TypeReference<Map<String, Object>>() {});
+            default:
+                throw new UnsupportedOperationException("Unsupported schemaType " + schemaType);
+        }
+    }
+
+    public static String toJson(Object object) throws JsonProcessingException {
+        return OBJECT_MAPPER.writeValueAsString(object);
+    }
+
+    public void setResultField(
+            Object content,
+            String fieldName,
+            Schema fieldSchema,
+            Map<Schema, Schema> avroKeySchemaCache,
+            Map<Schema, Schema> avroValueSchemaCache) {
+        if (fieldName == null || fieldName.equals("value")) {
+            valueSchemaType = TransformSchemaType.STRING;
+            valueObject = content;
+        } else if (fieldName.equals("key")) {
+            keySchemaType = TransformSchemaType.STRING;
+            keyObject = content;
+        } else if (fieldName.equals("destinationTopic")) {
+            outputTopic = content.toString();
+        } else if (fieldName.equals("messageKey")) {
+            key = content.toString();
+        } else if (fieldName.startsWith("properties.")) {
+            String propertyKey = fieldName.substring("properties.".length());
+            setProperty(propertyKey, content.toString());
+        } else if (fieldName.startsWith("value.")) {
+            String valueFieldName = fieldName.substring("value.".length());
+            if (valueObject instanceof Map) {
+                ((Map<String, Object>) valueObject).put(valueFieldName, content);
+            } else {
+                Schema.Field fieldSchemaField =
+                        new Schema.Field(valueFieldName, fieldSchema, null, null);
+                addOrReplaceValueFields(Map.of(fieldSchemaField, content), avroValueSchemaCache);
+            }
+        } else if (fieldName.startsWith("key.")) {
+            String keyFieldName = fieldName.substring("key.".length());
+            if (keyObject instanceof Map) {
+                ((Map<String, Object>) keyObject).put(keyFieldName, content);
+            } else {
+                Schema.Field fieldSchemaField =
+                        new Schema.Field(keyFieldName, fieldSchema, null, null);
+                addOrReplaceKeyFields(Map.of(fieldSchemaField, content), avroKeySchemaCache);
+            }
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/TransformFunctionException.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/TransformFunctionException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+public class TransformFunctionException extends RuntimeException {
+    public TransformFunctionException(String message) {
+        super(message);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/TransformStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/TransformStep.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+public interface TransformStep extends AutoCloseable {
+    default void close() throws Exception {}
+
+    void process(TransformContext transformContext) throws Exception;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/UnwrapKeyValueStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/UnwrapKeyValueStep.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+public class UnwrapKeyValueStep implements TransformStep {
+
+    private final boolean unwrapKey;
+
+    public UnwrapKeyValueStep(boolean unwrapKey) {
+        this.unwrapKey = unwrapKey;
+    }
+
+    @Override
+    public void process(TransformContext transformContext) throws Exception {
+        if (transformContext.getKeySchemaType() != null) {
+            if (unwrapKey) {
+                transformContext.setValueSchemaType(transformContext.getKeySchemaType());
+                transformContext.setValueNativeSchema(transformContext.getKeyNativeSchema());
+                transformContext.setValueObject(transformContext.getKeyObject());
+            }
+            transformContext.setKeySchemaType(null);
+            transformContext.setKeyNativeSchema(null);
+            transformContext.setKeyObject(null);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/ChatChoice.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/ChatChoice.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.completions;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatChoice {
+    private ChatMessage message;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/ChatCompletions.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/ChatCompletions.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.completions;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class ChatCompletions {
+    List<ChatChoice> choices;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/ChatMessage.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/ChatMessage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.completions;
+
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@NoArgsConstructor
+public class ChatMessage {
+    private String role;
+    private String content;
+
+    public ChatMessage(String role, String content) {
+        this.role = role;
+        this.content = content;
+    }
+
+    public ChatMessage(String role) {
+        this.role = role;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public ChatMessage setRole(String role) {
+        this.role = role;
+        return this;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public ChatMessage setContent(String content) {
+        this.content = content;
+        return this;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/CompletionsService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.completions;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CompletionsService {
+    ChatCompletions getChatCompletions(List<ChatMessage> message, Map<String, Object> options);
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/completions/OpenAICompletionService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.completions;
+
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getDouble;
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getInteger;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.azure.ai.openai.models.ChatRole;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class OpenAICompletionService implements CompletionsService {
+
+    private OpenAIClient client;
+
+    public OpenAICompletionService(OpenAIClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public ChatCompletions getChatCompletions(
+            List<ChatMessage> messages, Map<String, Object> options) {
+        ChatCompletionsOptions chatCompletionsOptions =
+                new ChatCompletionsOptions(
+                                messages.stream()
+                                        .map(
+                                                message ->
+                                                        new com.azure.ai.openai.models.ChatMessage(
+                                                                        ChatRole.fromString(
+                                                                                message.getRole()))
+                                                                .setContent(message.getContent()))
+                                        .collect(Collectors.toList()))
+                        .setMaxTokens(getInteger("max-tokens", options))
+                        .setTemperature(getDouble("temperature", options))
+                        .setTopP(getDouble("top-p", options))
+                        .setLogitBias((Map<String, Integer>) options.get("logit-bias"))
+                        .setUser((String) options.get("user"))
+                        .setStop((List<String>) options.get("stop"))
+                        .setPresencePenalty(getDouble("presence-penalty", options))
+                        .setFrequencyPenalty(getDouble("frequency-penalty", options));
+        com.azure.ai.openai.models.ChatCompletions chatCompletions =
+                client.getChatCompletions((String) options.get("model"), chatCompletionsOptions);
+        ChatCompletions result = new ChatCompletions();
+        result.setChoices(
+                chatCompletions.getChoices().stream()
+                        .map(c -> new ChatChoice(convertMessage(c)))
+                        .collect(Collectors.toList()));
+        return result;
+    }
+
+    private static ChatMessage convertMessage(com.azure.ai.openai.models.ChatChoice c) {
+        com.azure.ai.openai.models.ChatMessage message = c.getMessage();
+        return new ChatMessage(
+                message.getRole() != null ? message.getRole().toString() : null,
+                message.getContent());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSource.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.datasource;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.data.CqlVector;
+import com.datastax.oss.driver.api.core.type.CqlVectorType;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.internal.core.type.codec.CqlVectorCodec;
+import com.datastax.oss.driver.internal.core.type.codec.registry.DefaultCodecRegistry;
+import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AstraDBDataSource implements QueryStepDataSource {
+
+    CqlSession session;
+    Map<String, PreparedStatement> statements = new ConcurrentHashMap<>();
+
+    private static final DefaultCodecRegistry CODEC_REGISTRY =
+            new DefaultCodecRegistry("default-registry") {
+
+                protected TypeCodec<?> createCodec(
+                        @Nullable DataType cqlType,
+                        @Nullable GenericType<?> javaType,
+                        boolean isJavaCovariant) {
+                    if (cqlType instanceof CqlVectorType) {
+                        log.info("Automatically Registering codec for CqlVectorType {}", cqlType);
+                        CqlVectorType vectorType = (CqlVectorType) cqlType;
+                        return new CqlVectorCodec<>(vectorType, codecFor(vectorType.getSubtype()));
+                    }
+                    return super.createCodec(cqlType, javaType, isJavaCovariant);
+                }
+            };
+
+    @Override
+    public void initialize(DataSourceConfig dataSourceConfig) {
+        log.info("Initializing AstraDBDataSource with config {}", dataSourceConfig);
+        this.session =
+                buildCqlSession(
+                        dataSourceConfig.getUsername(),
+                        dataSourceConfig.getPassword(),
+                        dataSourceConfig.getSecureBundle());
+    }
+
+    @Override
+    public void close() {
+        if (session != null) {
+            session.close();
+        }
+    }
+
+    @Override
+    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Executing query {} with params {} ({})",
+                    query,
+                    params,
+                    params.stream()
+                            .map(v -> v == null ? "null" : v.getClass().toString())
+                            .collect(Collectors.joining(",")));
+        }
+        PreparedStatement preparedStatement =
+                statements.computeIfAbsent(query, q -> session.prepare(q));
+
+        ColumnDefinitions variableDefinitions = preparedStatement.getVariableDefinitions();
+        List<Object> adaptedParameters = new ArrayList<>();
+        for (int i = 0; i < variableDefinitions.size(); i++) {
+            Object value = params.get(i);
+            ColumnDefinition columnDefinition = variableDefinitions.get(i);
+            if (columnDefinition.getType() instanceof CqlVectorType && value instanceof List) {
+                CqlVectorType vectorType = (CqlVectorType) columnDefinition.getType();
+                if (vectorType.getSubtype() != DataTypes.FLOAT) {
+                    throw new IllegalArgumentException("Only VECTOR<FLOAT,x> is supported");
+                }
+                CqlVector.Builder<Float> builder = CqlVector.builder();
+                for (Object v : (List<Object>) value) {
+                    if (v instanceof Number) {
+                        builder.add(((Number) v).floatValue());
+                    } else {
+                        builder.add(Float.parseFloat(v + ""));
+                    }
+                }
+                value = builder.build();
+            }
+            adaptedParameters.add(value);
+        }
+
+        BoundStatement bind = preparedStatement.bind(adaptedParameters.toArray(new Object[0]));
+
+        List<Row> all = session.execute(bind).all();
+        return all.stream()
+                .map(
+                        r -> {
+                            Map<String, String> result = new HashMap<>();
+                            ColumnDefinitions columnDefinitions = r.getColumnDefinitions();
+                            for (int i = 0; i < columnDefinitions.size(); i++) {
+                                String name = columnDefinitions.get(i).getName().toString();
+                                Object object = r.getObject(i);
+                                if (log.isTraceEnabled()) {
+                                    log.trace(
+                                            "Column {} is of type {} and value {}",
+                                            name,
+                                            object != null ? object.getClass().toString() : "null",
+                                            object);
+                                }
+                                result.put(name, object != null ? object.toString() : null);
+                            }
+                            return result;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    public CqlSession buildCqlSession(String username, String password, String secureBundle) {
+
+        // Remove the base64: prefix if present
+        if (secureBundle.startsWith("base64:")) {
+            secureBundle = secureBundle.substring("base64:".length());
+        }
+
+        byte[] secureBundleDecoded = Base64.getDecoder().decode(secureBundle);
+        CqlSessionBuilder builder =
+                new CqlSessionBuilder()
+                        .withCodecRegistry(CODEC_REGISTRY)
+                        .withCloudSecureConnectBundle(new ByteArrayInputStream(secureBundleDecoded))
+                        .withAuthCredentials(username, password);
+        return builder.build();
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/QueryStepDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/QueryStepDataSource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.datasource;
+
+import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public interface QueryStepDataSource {
+
+    default void initialize(DataSourceConfig config) {}
+
+    default List<Map<String, String>> fetchData(String query, List<Object> params) {
+        return Collections.emptyList();
+    }
+
+    default void close() {}
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/AbstractHuggingFaceEmbeddingService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/AbstractHuggingFaceEmbeddingService.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import ai.djl.MalformedModelException;
+import ai.djl.huggingface.translator.TextEmbeddingTranslatorFactory;
+import ai.djl.inference.Predictor;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ModelNotFoundException;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.translate.TranslateException;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractHuggingFaceEmbeddingService<IN, OUT>
+        implements EmbeddingsService, AutoCloseable {
+    /**
+     * comma-separated list of allowed url prefixes, like
+     * file://,s3://,djl://,https://models.datastax.com/
+     */
+    public static final String URL_PREFIXES_SYSTEM_PROP = "ALLOWED_HF_URLS";
+
+    public static final String DLJ_BASE_URL = "djl://ai.djl.huggingface.pytorch";
+
+    public static final Set<String> allowedUrlPrefixes = getHuggingFaceAllowedUrlPrefixes();
+
+    private static Set<String> getHuggingFaceAllowedUrlPrefixes() {
+        String prop = System.getenv(URL_PREFIXES_SYSTEM_PROP);
+        if (prop == null || prop.isEmpty()) {
+            prop = System.getProperty(URL_PREFIXES_SYSTEM_PROP);
+        }
+        if (prop == null || prop.isEmpty()) {
+            prop = "file://," + DLJ_BASE_URL;
+        }
+        return Set.of(prop.split(","));
+    }
+
+    @Override
+    public void close() throws Exception {
+        while (!predictorList.isEmpty()) {
+            Predictor<?, ?> p = predictorList.poll();
+            if (p != null) {
+                p.close();
+            }
+        }
+
+        if (model != null) {
+            model.close();
+        }
+    }
+
+    @Data
+    @Builder
+    public static class HuggingFaceConfig {
+        @Builder.Default String engine = "PyTorch";
+
+        @Builder.Default Map<String, String> options = Map.of();
+
+        @Builder.Default Map<String, String> arguments = Map.of();
+
+        String modelUrl;
+
+        String modelName;
+    }
+
+    // thread safety:
+    // http://djl.ai/docs/development/inference_performance_optimization.html#multithreading-support
+    ZooModel<IN, OUT> model;
+
+    private static final ThreadLocal<Predictor<?, ?>> predictorThreadLocal = new ThreadLocal<>();
+    private static final ConcurrentLinkedQueue<Predictor<?, ?>> predictorList =
+            new ConcurrentLinkedQueue<>();
+
+    public AbstractHuggingFaceEmbeddingService(HuggingFaceConfig conf)
+            throws IOException,
+                    ModelNotFoundException,
+                    MalformedModelException,
+                    IllegalAccessException {
+        Objects.requireNonNull(conf);
+        Objects.requireNonNull(conf.modelName);
+
+        checkIfUrlIsAllowed(conf.modelUrl);
+
+        // https://stackoverflow.com/a/1901275/2237794
+        // https://github.com/deepjavalibrary/djl/blob/master/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/TextEmbeddingTranslatorTest.java
+        Class<IN> inClass =
+                (Class<IN>)
+                        ((ParameterizedType) getClass().getGenericSuperclass())
+                                .getActualTypeArguments()[0];
+        Class<OUT> outClass =
+                (Class<OUT>)
+                        ((ParameterizedType) getClass().getGenericSuperclass())
+                                .getActualTypeArguments()[1];
+
+        Criteria.Builder<IN, OUT> builder = Criteria.builder().setTypes(inClass, outClass);
+
+        builder.optModelUrls(conf.modelUrl);
+        log.info("Loading model from {}", conf.modelUrl);
+
+        if (conf.modelName != null) {
+            builder.optModelName(conf.modelName);
+        }
+
+        if (conf.engine != null) {
+            builder.optEngine(conf.engine);
+        } else {
+            builder.optEngine("PyTorch");
+        }
+
+        if (conf.options != null && !conf.options.isEmpty()) {
+            conf.options.forEach(builder::optOption);
+        }
+        if (conf.arguments != null && !conf.arguments.isEmpty()) {
+            conf.arguments.forEach(builder::optArgument);
+        }
+
+        // for getting embeddings
+        builder.optTranslatorFactory(new TextEmbeddingTranslatorFactory());
+
+        Criteria<IN, OUT> criteria = builder.build();
+
+        model = criteria.loadModel();
+    }
+
+    private void checkIfUrlIsAllowed(String modelUrl) throws IllegalAccessException {
+        for (String prefix : allowedUrlPrefixes) {
+            if (modelUrl.startsWith(prefix)) {
+                return;
+            }
+        }
+        throw new IllegalAccessException("modelUrl is not allowed: " + modelUrl);
+    }
+
+    public List<OUT> compute(List<IN> texts) throws TranslateException {
+        Predictor<IN, OUT> predictor = (Predictor<IN, OUT>) predictorThreadLocal.get();
+        if (predictor == null) {
+            predictor = model.newPredictor();
+            predictorThreadLocal.set(predictor);
+            predictorList.add(predictor);
+        }
+
+        return predictor.batchPredict(texts);
+    }
+
+    abstract List<IN> convertInput(List<String> texts);
+
+    abstract List<List<Double>> convertOutput(List<OUT> result);
+
+    @Override
+    public List<List<Double>> computeEmbeddings(List<String> texts) {
+        try {
+            List<OUT> results = compute(convertInput(texts));
+            return convertOutput(results);
+        } catch (TranslateException e) {
+            log.error("failed to run compute", e);
+            throw new RuntimeException("failed to run compute", e);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/EmbeddingsService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/EmbeddingsService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+
+public interface EmbeddingsService extends AutoCloseable {
+
+    static ObjectMapper createObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return mapper;
+    }
+
+    default void close() throws Exception {}
+
+    List<List<Double>> computeEmbeddings(List<String> texts);
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import ai.djl.MalformedModelException;
+import ai.djl.repository.zoo.ModelNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * EmbeddingsService implementation using HuggingFace models adapted for use in the DJL. Thread safe
+ * (but uses predictor per thread).
+ *
+ * <p>The model requested there should be trained for "sentence similarity" task. See
+ * https://github.com/deepjavalibrary/djl/blob/master/extensions/tokenizers/README.md for model
+ * conversion steps. E.g.:
+ *
+ * <p>python3 -m pip install -r ./extensions/tokenizers/src/main/python/requirements.txt python3
+ * ./extensions/tokenizers/src/main/python/model_zoo_importer.py -m kmariunas/bert-uncased-triplet50
+ * find . | grep /bert-uncased-triplet50.zip
+ */
+public class HuggingFaceEmbeddingService
+        extends AbstractHuggingFaceEmbeddingService<String, float[]> {
+    public HuggingFaceEmbeddingService(HuggingFaceConfig conf)
+            throws IOException,
+                    ModelNotFoundException,
+                    MalformedModelException,
+                    IllegalAccessException {
+        super(conf);
+    }
+
+    @Override
+    List<String> convertInput(List<String> texts) {
+        return texts;
+    }
+
+    @Override
+    List<List<Double>> convertOutput(List<float[]> result) {
+        List<List<Double>> out = new ArrayList<>(result.size());
+        for (float[] floats : result) {
+            List<Double> l = new ArrayList<>(floats.length);
+            for (float aFloat : floats) {
+                l.add((double) aFloat);
+            }
+            out.add(l);
+        }
+        return out;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceRestEmbeddingService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceRestEmbeddingService.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * EmbeddingsService implementation using HuggingFace REST API.
+ *
+ * <p>The model requested there should be trained for "sentence similarity" task.
+ */
+@Slf4j
+public class HuggingFaceRestEmbeddingService implements EmbeddingsService {
+
+    // https://huggingface.co/docs/api-inference/detailed_parameters#feature-extraction-task
+    @Data
+    @Builder
+    public static class HuggingFaceApiConfig {
+        public String accessKey;
+        public String model;
+
+        @Builder.Default public String hfUrl = HF_URL;
+
+        @Builder.Default public String hfCheckUrl = HF_CHECK_URL;
+
+        @Builder.Default public Map<String, String> options = Map.of("wait_for_model", "true");
+    }
+
+    private static final String HF_URL =
+            "https://api-inference.huggingface.co/pipeline/feature-extraction/";
+    private static final String HF_CHECK_URL = "https://huggingface.co/api/models/";
+
+    private static final ObjectMapper om = EmbeddingsService.createObjectMapper();
+
+    private final HuggingFaceApiConfig conf;
+    private final String model;
+    private final String token;
+
+    private final URL modelUrl;
+    private final URL checkUrl;
+
+    private final HttpClient httpClient;
+
+    @Data
+    @Builder
+    public static class HuggingPojo {
+        @JsonAlias("inputs")
+        public List<String> inputs;
+
+        @JsonAlias("options")
+        public Map<String, String> options;
+    }
+
+    public HuggingFaceRestEmbeddingService(HuggingFaceApiConfig conf) throws MalformedURLException {
+        this.conf = conf;
+        this.model = conf.model;
+        this.token = conf.accessKey;
+        this.checkUrl = new URL(conf.hfCheckUrl + model);
+        this.modelUrl = new URL(conf.hfUrl + model);
+
+        this.httpClient = HttpClient.newHttpClient();
+
+        try {
+            HttpRequest request =
+                    HttpRequest.newBuilder()
+                            .uri(checkUrl.toURI())
+                            .header("Authorization", "Bearer " + token)
+                            .GET()
+                            .build();
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Model {} check http response is {} {}", model, response, response.body());
+            }
+            if (response.statusCode() != 200) {
+                log.warn("Model {} check http response is {} {}", model, response, response.body());
+                throw new IllegalArgumentException("Model " + model + " is not found");
+            }
+
+            Map check = om.readValue(response.body(), Map.class);
+            log.info("Model {} check response is {}", model, check);
+            if (check == null) {
+                throw new IllegalArgumentException("Model " + model + " is not found");
+            }
+            if (!check.get("modelId").equals(model)) {
+                throw new IllegalArgumentException("Model " + model + " is not found");
+            }
+            Set<String> tags = new HashSet<>((List) check.get("tags"));
+            if (!tags.contains("sentence-transformers")) {
+                throw new IllegalArgumentException(
+                        "Model "
+                                + model
+                                + " is not a sentence-transformers model and not suitable for embeddings");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<List<Double>> computeEmbeddings(List<String> texts) {
+        HuggingPojo pojo = HuggingPojo.builder().inputs(texts).options(conf.options).build();
+
+        try {
+            String jsonContent = om.writeValueAsString(pojo);
+
+            String body = query(jsonContent);
+
+            Object result = om.readValue(body, Object.class);
+            return (List<List<Double>>) result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String query(String jsonPayload) throws Exception {
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(modelUrl.toURI())
+                        .header("Authorization", "Bearer " + token)
+                        .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                        .build();
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (log.isDebugEnabled()) {
+            log.debug("Model {} query response is {} {}", model, response, response.body());
+        }
+
+        if (response.statusCode() != 200) {
+            log.warn("Model {} query failed with {} {}", model, response, response.body());
+            throw new RuntimeException(
+                    "Model " + model + " query failed with status " + response.statusCode());
+        }
+
+        return response.body();
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.models.Embeddings;
+import com.azure.ai.openai.models.EmbeddingsOptions;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OpenAIEmbeddingsService implements EmbeddingsService {
+
+    private final OpenAIClient openAIClient;
+    private final String model;
+
+    public OpenAIEmbeddingsService(OpenAIClient openAIClient, String model) {
+        this.openAIClient = openAIClient;
+        this.model = model;
+    }
+
+    @Override
+    public List<List<Double>> computeEmbeddings(List<String> texts) {
+        EmbeddingsOptions embeddingsOptions = new EmbeddingsOptions(texts);
+        Embeddings embeddings = openAIClient.getEmbeddings(model, embeddingsOptions);
+        return embeddings.getData().stream()
+                .map(embedding -> embedding.getEmbedding())
+                .collect(Collectors.toList());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/DisabledInvocationBeanResolver.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/DisabledInvocationBeanResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import jakarta.el.BeanELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.MethodNotFoundException;
+
+/**
+ * The purpose of this BeanELResolver is to disable methods invocations. By default, the EL
+ * implementation allows for invoking JDK methods on beans like ${value.toString()}. We prefer to
+ * disable such invocation for two reasons:
+ *
+ * <ul>
+ *   <li>Have more controls over the transformations API and provide utility methods instead under
+ *       the "fn:" prefix. Otherwise, it hard to guarantee the availability of the API as the JDK
+ *       evolves.
+ *   <li>Security reasons as users may get access to internal methods that have unintended side
+ *       effects.
+ * </ul>
+ */
+public class DisabledInvocationBeanResolver extends BeanELResolver {
+    @Override
+    public Object invoke(
+            ELContext context, Object base, Object method, Class<?>[] paramTypes, Object[] params) {
+        throw new MethodNotFoundException("Method invocations are disabled: " + method);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluator.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluator.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import jakarta.el.ELContext;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.ValueExpression;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.el.ExpressionFactoryImpl;
+
+public class JstlEvaluator<T> {
+
+    private static final ExpressionFactory FACTORY = new ExpressionFactoryImpl();
+    private final ValueExpression valueExpression;
+    private final ELContext expressionContext;
+
+    public JstlEvaluator(String expression, Class<? extends T> type) {
+        this.expressionContext = new StandardContext(FACTORY);
+        registerFunctions();
+        this.valueExpression = FACTORY.createValueExpression(expressionContext, expression, type);
+    }
+
+    @SneakyThrows
+    private void registerFunctions() {
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction("fn", "toJson", JstlFunctions.class.getMethod("toJson", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn", "fromJson", JstlFunctions.class.getMethod("fromJson", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "split",
+                        JstlFunctions.class.getMethod("split", Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "unpack",
+                        JstlFunctions.class.getMethod("unpack", Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "uppercase",
+                        JstlFunctions.class.getMethod("uppercase", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "lowercase",
+                        JstlFunctions.class.getMethod("lowercase", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "contains",
+                        JstlFunctions.class.getMethod("contains", Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction("fn", "trim", JstlFunctions.class.getMethod("trim", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "concat",
+                        JstlFunctions.class.getMethod("concat", Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "coalesce",
+                        JstlFunctions.class.getMethod("coalesce", Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction("fn", "str", JstlFunctions.class.getMethod("toString", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn", "toDouble", JstlFunctions.class.getMethod("toDouble", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "filter",
+                        JstlFunctions.class.getMethod("filter", Object.class, String.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction("fn", "toInt", JstlFunctions.class.getMethod("toInt", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "replace",
+                        JstlFunctions.class.getMethod(
+                                "replace", Object.class, Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction("fn", "now", JstlFunctions.class.getMethod("now"));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "timestampAdd",
+                        JstlFunctions.class.getMethod(
+                                "timestampAdd", Object.class, Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "decimalFromUnscaled",
+                        JstlFunctions.class.getMethod("toBigDecimal", Object.class, Object.class));
+
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "decimalFromNumber",
+                        JstlFunctions.class.getMethod("toBigDecimal", Object.class));
+
+        // Deprecated
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "dateadd",
+                        JstlFunctions.class.getMethod(
+                                "dateadd", Object.class, Object.class, Object.class));
+    }
+
+    public T evaluate(TransformContext transformContext) {
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+        FACTORY.createValueExpression(expressionContext, "${key}", Object.class)
+                .setValue(expressionContext, adapter.getKey());
+        FACTORY.createValueExpression(expressionContext, "${value}", Object.class)
+                .setValue(expressionContext, adapter.adaptValue());
+
+        // this is only for fn:filter
+        FACTORY.createValueExpression(expressionContext, "${record}", Object.class)
+                .setValue(expressionContext, adapter.adaptRecord());
+
+        // Register message headers as top level fields
+        FACTORY.createValueExpression(expressionContext, "${messageKey}", String.class)
+                .setValue(expressionContext, adapter.getHeader().get("messageKey"));
+        FACTORY.createValueExpression(expressionContext, "${topicName}", String.class)
+                .setValue(expressionContext, adapter.getHeader().get("topicName"));
+        FACTORY.createValueExpression(expressionContext, "${destinationTopic}", String.class)
+                .setValue(expressionContext, adapter.getHeader().get("destinationTopic"));
+        FACTORY.createValueExpression(expressionContext, "${eventTime}", Long.class)
+                .setValue(expressionContext, adapter.getHeader().get("eventTime"));
+        FACTORY.createValueExpression(expressionContext, "${properties}", Map.class)
+                .setValue(expressionContext, adapter.getHeader().get("properties"));
+        return this.valueExpression.getValue(expressionContext);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlFunctions.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlFunctions.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.jstl.predicate.JstlPredicate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.el.ELException;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.el.util.MessageFactory;
+
+/** Provides convenience methods to use in jstl expression. All functions should be static. */
+@Slf4j
+public class JstlFunctions {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Setter private static Clock clock = Clock.systemUTC();
+
+    public static String uppercase(Object input) {
+        return input == null ? null : toString(input).toUpperCase();
+    }
+
+    public static String lowercase(Object input) {
+        return input == null ? null : toString(input).toLowerCase();
+    }
+
+    public static String toJson(Object input) throws Exception {
+        return MAPPER.writeValueAsString(input);
+    }
+
+    public static Object fromJson(Object input) throws Exception {
+        if (input == null) {
+            return null;
+        }
+        String s = toString(input);
+        if (s.isEmpty()) {
+            return null;
+        }
+        return MAPPER.readValue(s, Object.class);
+    }
+
+    public static Object toDouble(Object input) {
+        if (input == null) {
+            return null;
+        }
+        return JstlTypeConverter.INSTANCE.coerceToDouble(input);
+    }
+
+    public static Object toInt(Object input) {
+        if (input == null) {
+            return null;
+        }
+        return JstlTypeConverter.INSTANCE.coerceToInteger(input);
+    }
+
+    public static List<String> split(Object input, Object separatorExpression) {
+        if (input == null) {
+            return null;
+        }
+        String s = toString(input);
+        if (s.isEmpty()) {
+            // special case, split would return a list with an empty string
+            return List.of();
+        }
+        String separator = toString(separatorExpression);
+        return Stream.of(s.split(separator)).collect(Collectors.toList());
+    }
+
+    public static Map<String, Object> unpack(Object input, Object fieldsExpression) {
+        if (input == null) {
+            return null;
+        }
+        String fields = toString(fieldsExpression);
+        Map<String, Object> result = new HashMap<>();
+        List<Object> values;
+        if (input instanceof String) {
+            String s = (String) input;
+            if (s.isEmpty()) {
+                values = List.of();
+            } else {
+                values = Stream.of(s.split(",")).collect(Collectors.toList());
+            }
+        } else if (input instanceof List) {
+            values = (List<Object>) input;
+        } else if (input instanceof Collection) {
+            values = new ArrayList<>((Collection<Object>) input);
+        } else if (input.getClass().isArray()) {
+            values = new ArrayList<>(Array.getLength(input));
+            for (int i = 0; i < Array.getLength(input); i++) {
+                values.add(Array.get(input, i));
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "fn:unpack cannot unpack object of type " + input.getClass().getName());
+        }
+        List<String> headers = Stream.of(fields.split(",")).collect(Collectors.toList());
+        for (int i = 0; i < headers.size(); i++) {
+            String header = headers.get(i);
+            if (i < values.size()) {
+                result.put(header, values.get(i));
+            } else {
+                result.put(header, null);
+            }
+        }
+        return result;
+    }
+
+    public static List<Object> filter(Object input, String expression) {
+        if (input == null) {
+            return null;
+        }
+        List<Object> source;
+        if (input instanceof List) {
+            source = (List<Object>) input;
+        } else if (input instanceof Collection) {
+            source = new ArrayList<>((Collection<?>) input);
+        } else if (input.getClass().isArray()) {
+            source = new ArrayList<>(Array.getLength(input));
+            for (int i = 0; i < Array.getLength(input); i++) {
+                source.add(Array.get(input, i));
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "fn:filter cannot filter object of type " + input.getClass().getName());
+        }
+        List<Object> result = new ArrayList<>();
+        JstlPredicate predicate = new JstlPredicate(expression);
+        for (Object o : source) {
+            if (log.isDebugEnabled()) {
+                log.info("Filtering object {}", o);
+            }
+            // nulls are always filtered out
+            if (o != null) {
+                TransformContext context = new TransformContext();
+                context.setRecordObject(o);
+                boolean evaluate = predicate.test(context);
+                if (log.isDebugEnabled()) {
+                    log.debug("Result of evaluation is {}", evaluate);
+                }
+                if (evaluate) {
+                    result.add(o);
+                }
+            }
+        }
+        return result;
+    }
+
+    public static boolean contains(Object input, Object value) {
+        if (input == null || value == null) {
+            return false;
+        }
+        return toString(input).contains(toString(value));
+    }
+
+    public static String trim(Object input) {
+        return input == null ? null : toString(input).trim();
+    }
+
+    public static String concat(Object first, Object second) {
+        return toString(first) + toString(second);
+    }
+
+    public static Object coalesce(Object value, Object valueIfNull) {
+        return value == null ? valueIfNull : value;
+    }
+
+    public static String replace(Object input, Object regex, Object replacement) {
+        if (input == null) {
+            return null;
+        }
+        if (regex == null || replacement == null) {
+            return input.toString();
+        }
+        return toString(input).replaceAll(toString(regex), toString(replacement));
+    }
+
+    public static String toString(Object input) {
+        return JstlTypeConverter.INSTANCE.coerceToString(input);
+    }
+
+    public static BigDecimal toBigDecimal(Object value, Object scale) {
+        final BigInteger bigInteger = JstlTypeConverter.INSTANCE.coerceToBigInteger(value);
+        final int scaleInteger = JstlTypeConverter.INSTANCE.coerceToInteger(scale);
+        return new BigDecimal(bigInteger, scaleInteger);
+    }
+
+    public static BigDecimal toBigDecimal(Object value) {
+        final double d = JstlTypeConverter.INSTANCE.coerceToDouble(value);
+        return BigDecimal.valueOf(d);
+    }
+
+    public static Instant now() {
+        return Instant.now(clock);
+    }
+
+    public static Instant timestampAdd(Object input, Object delta, Object unit) {
+        if (input == null || unit == null) {
+            throw new ELException(MessageFactory.get("error.method.notypes"));
+        }
+
+        ChronoUnit chronoUnit;
+        switch (JstlTypeConverter.INSTANCE.coerceToString(unit)) {
+            case "years":
+                chronoUnit = ChronoUnit.YEARS;
+                break;
+            case "months":
+                chronoUnit = ChronoUnit.MONTHS;
+                break;
+            case "days":
+                chronoUnit = ChronoUnit.DAYS;
+                break;
+            case "hours":
+                chronoUnit = ChronoUnit.HOURS;
+                break;
+            case "minutes":
+                chronoUnit = ChronoUnit.MINUTES;
+                break;
+            case "seconds":
+                chronoUnit = ChronoUnit.SECONDS;
+                break;
+            case "millis":
+                chronoUnit = ChronoUnit.MILLIS;
+                break;
+            case "nanos":
+                chronoUnit = ChronoUnit.NANOS;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Invalid unit: "
+                                + unit
+                                + ". Should be one of [years, months, days, hours, minutes, seconds, millis]");
+        }
+        if (chronoUnit == ChronoUnit.MONTHS || chronoUnit == ChronoUnit.YEARS) {
+            return JstlTypeConverter.INSTANCE
+                    .coerceToOffsetDateTime(input)
+                    .plus(JstlTypeConverter.INSTANCE.coerceToLong(delta), chronoUnit)
+                    .toInstant();
+        }
+        return JstlTypeConverter.INSTANCE
+                .coerceToInstant(input)
+                .plus(JstlTypeConverter.INSTANCE.coerceToLong(delta), chronoUnit);
+    }
+
+    @Deprecated
+    public static long dateadd(Object input, Object delta, Object unit) {
+        return timestampAdd(input, delta, unit).toEpochMilli();
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapter.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapter.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.util.AvroUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.map.LazyMap;
+
+/**
+ * A java bean that adapts the underlying {@link TransformContext} to be ready for jstl expression
+ * language binding.
+ */
+public class JstlTransformContextAdapter {
+    private TransformContext transformContext;
+
+    /**
+     * A key transformer backing the lazy key map. It transforms top level key fields to either a
+     * value or another lazy map for nested evaluation.
+     */
+    private final Transformer<String, Object> keyTransformer =
+            (fieldName) -> {
+                Object keyObject = this.transformContext.getKeyObject();
+                if (keyObject instanceof GenericRecord) {
+                    GenericRecord genericRecord = (GenericRecord) keyObject;
+                    GenericRecordTransformer transformer =
+                            new GenericRecordTransformer(genericRecord);
+                    return transformer.transform(fieldName);
+                }
+                if (keyObject instanceof JsonNode) {
+                    JsonNode jsonNode = (JsonNode) keyObject;
+                    Schema schema = (Schema) this.transformContext.getKeyNativeSchema();
+                    JsonNodeTransformer transformer = new JsonNodeTransformer(jsonNode, schema);
+                    return transformer.transform(fieldName);
+                }
+                return null;
+            };
+
+    private final Map<String, Object> lazyKey = LazyMap.lazyMap(new HashMap<>(), keyTransformer);
+
+    /**
+     * A value transformer backing the lazy value map. It transforms top level value fields to
+     * either a value or another lazy map for nested evaluation.
+     */
+    private final Transformer<String, Object> valueTransformer =
+            (fieldName) -> {
+                Object valueObject = this.transformContext.getValueObject();
+                if (valueObject instanceof GenericRecord) {
+                    GenericRecord genericRecord = (GenericRecord) valueObject;
+                    GenericRecordTransformer transformer =
+                            new GenericRecordTransformer(genericRecord);
+                    return transformer.transform(fieldName);
+                }
+                if (valueObject instanceof JsonNode) {
+                    JsonNode jsonNode = (JsonNode) valueObject;
+                    Schema schema = (Schema) this.transformContext.getValueNativeSchema();
+                    JsonNodeTransformer transformer = new JsonNodeTransformer(jsonNode, schema);
+                    return transformer.transform(fieldName);
+                }
+                return null;
+            };
+
+    private final Map<String, Object> lazyValue =
+            LazyMap.lazyMap(new HashMap<>(), valueTransformer);
+
+    /** A header transformer to return message headers the user is allowed to filter on. */
+    private final Transformer<String, Object> headerTransformer =
+            (fieldName) -> {
+                // Allow list message headers in the expression
+                switch (fieldName) {
+                    case "messageKey":
+                        return transformContext.getKey();
+                    case "topicName":
+                        return transformContext.getInputTopic();
+                    case "destinationTopic":
+                        return transformContext.getOutputTopic();
+                    case "eventTime":
+                        return transformContext.getEventTime();
+                    case "properties":
+                        return transformContext.getProperties();
+                    default:
+                        return null;
+                }
+            };
+
+    private final Map<String, Object> lazyHeader =
+            LazyMap.lazyMap(new HashMap<>(), headerTransformer);
+
+    public JstlTransformContextAdapter(TransformContext transformContext) {
+        this.transformContext = transformContext;
+    }
+
+    /**
+     * @return either a lazily evaluated map to access top-level and nested fields on a generic
+     *     object, or the primitive type itself.
+     */
+    public Object getKey() {
+        Object keyObject = this.transformContext.getKeyObject();
+        if (keyObject == null) {
+            return transformContext.getKey();
+        }
+        return keyObject instanceof GenericRecord || keyObject instanceof JsonNode
+                ? lazyKey
+                : keyObject;
+    }
+
+    /**
+     * @return either a lazily evaluated map to access top-level and nested fields on a generic
+     *     object, or the primitive type itself.
+     */
+    public Object adaptValue() {
+        Object valueObject = this.transformContext.getValueObject();
+        return valueObject instanceof GenericRecord || valueObject instanceof JsonNode
+                ? lazyValue
+                : valueObject;
+    }
+
+    public Object adaptRecord() {
+        return transformContext.getRecordObject();
+    }
+
+    public Map<String, Object> getHeader() {
+        return lazyHeader;
+    }
+
+    /** Enables {@link LazyMap} lookup on {@link GenericRecord}. */
+    static class GenericRecordTransformer implements Transformer<String, Object> {
+
+        private final GenericRecord genericRecord;
+
+        public GenericRecordTransformer(GenericRecord genericRecord) {
+            this.genericRecord = genericRecord;
+        }
+
+        @Override
+        public Object transform(String key) {
+            if (!genericRecord.hasField(key)) {
+                return null;
+            }
+            Object value = genericRecord.get(key);
+            if (value instanceof GenericRecord) {
+                return LazyMap.lazyMap(
+                        new HashMap<>(), new GenericRecordTransformer((GenericRecord) value));
+            }
+            return adaptValue(genericRecord.getSchema(), key, value);
+        }
+    }
+
+    static class JsonNodeTransformer implements Transformer<String, Object> {
+
+        public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+        private final JsonNode jsonNode;
+        private final org.apache.avro.Schema schema;
+
+        public JsonNodeTransformer(JsonNode jsonNode, org.apache.avro.Schema schema) {
+            this.jsonNode = jsonNode;
+            this.schema = schema;
+        }
+
+        @Override
+        public Object transform(String key) {
+            if (!jsonNode.has(key)) {
+                return null;
+            }
+            JsonNode node = jsonNode.get(key);
+
+            if (node instanceof ObjectNode) {
+                return LazyMap.lazyMap(
+                        new HashMap<>(),
+                        new JsonNodeTransformer(
+                                node, schema != null ? schema.getField(key).schema() : null));
+            }
+            try {
+                Object value = OBJECT_MAPPER.treeToValue(node, Object.class);
+                return adaptValue(schema, key, value);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static Object adaptValue(Schema schema, String key, Object value) {
+        if (schema == null) {
+            return value;
+        }
+        LogicalType logicalType = AvroUtil.getLogicalType(schema.getField(key).schema());
+        if (LogicalTypes.date().equals(logicalType)) {
+            return LocalDate.ofEpochDay((int) value);
+        } else if (LogicalTypes.timestampMillis().equals(logicalType)) {
+            return Instant.ofEpochMilli((long) value);
+        } else if (LogicalTypes.timestampMicros().equals(logicalType)) {
+            long micros = (long) value;
+            return Instant.ofEpochSecond(micros / 1_000_000, (micros % 1_000_000) * 1000);
+        } else if (LogicalTypes.timeMillis().equals(logicalType)) {
+            return LocalTime.ofNanoOfDay((int) value * 1_000_000L);
+        } else if (LogicalTypes.timeMicros().equals(logicalType)) {
+            return LocalTime.ofNanoOfDay((long) value * 1_000);
+        } else if (LogicalTypes.localTimestampMillis().equals(logicalType)) {
+            long millis = (long) value;
+            return LocalDateTime.ofEpochSecond(
+                    millis / 1_000, (int) ((millis % 1_000) * 1_000_000), ZoneOffset.UTC);
+        } else if (LogicalTypes.localTimestampMicros().equals(logicalType)) {
+            long micros = (long) value;
+            return LocalDateTime.ofEpochSecond(
+                    micros / 1_000_000, (int) ((micros % 1_000_000) * 1_000), ZoneOffset.UTC);
+        }
+        return value;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverter.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverter.java
@@ -1,0 +1,523 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.TypeConverter;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.Date;
+import java.util.Map;
+import org.apache.avro.util.Utf8;
+import org.apache.el.lang.ELSupport;
+import org.apache.el.util.MessageFactory;
+import org.apache.pulsar.client.api.Schema;
+
+/**
+ * Overrides the default TypeConverter coerce to support null values and non-EL coercions (e.g.
+ * date/time types) schemas.
+ */
+public class JstlTypeConverter extends TypeConverter {
+    public static final JstlTypeConverter INSTANCE = new JstlTypeConverter();
+
+    @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
+    protected Boolean coerceToBoolean(Object value) {
+        if (value instanceof byte[]) {
+            return Schema.BOOL.decode((byte[]) value);
+        }
+        return ELSupport.coerceToBoolean(null, value, false);
+    }
+
+    protected Double coerceToDouble(Object value) {
+        if (value instanceof LocalTime) {
+            return (double) ((LocalTime) value).toNanoOfDay() / 1_000_000;
+        }
+        if (value instanceof Time) {
+            return (double) ((Time) value).toLocalTime().toNanoOfDay() / 1_000_000;
+        }
+        if (value instanceof Timestamp) {
+            return (((Timestamp) value).getTime() / 1_000) * 1000
+                    + (double) ((Timestamp) value).getNanos() / 1_000_000_000;
+        }
+        if (value instanceof Date) {
+            return (double) (((Date) value).getTime());
+        }
+        if (value instanceof byte[]) {
+            return Schema.DOUBLE.decode((byte[]) value);
+        }
+        if (value instanceof LocalDate) {
+            return (double) (((LocalDate) value).toEpochDay());
+        }
+        if (value instanceof TemporalAccessor) {
+            Instant instant = coerceToInstant(value);
+            return (double) instant.getEpochSecond() * 1000
+                    + (double) instant.getNano() / 1_000_000;
+        }
+        return ELSupport.coerceToNumber(null, value, Double.class).doubleValue();
+    }
+
+    protected Float coerceToFloat(Object value) {
+        if (value instanceof byte[]) {
+            return Schema.FLOAT.decode((byte[]) value);
+        }
+        if (value instanceof LocalDate) {
+            return (float) (((LocalDate) value).toEpochDay());
+        }
+        return ELSupport.coerceToNumber(null, value, Double.class).floatValue();
+    }
+
+    protected Long coerceToLong(Object value) {
+        if (value instanceof LocalTime) {
+            return ((LocalTime) value).toNanoOfDay() / 1_000_000;
+        }
+        if (value instanceof Time) {
+            return ((Time) value).toLocalTime().toNanoOfDay() / 1_000_000;
+        }
+        if (value instanceof Date) {
+            return ((Date) value).getTime();
+        }
+        if (value instanceof byte[]) {
+            return Schema.INT64.decode((byte[]) value);
+        }
+        if (value instanceof LocalDate) {
+            return ((LocalDate) value).toEpochDay();
+        }
+        if (value instanceof TemporalAccessor) {
+            return coerceToInstant(value).toEpochMilli();
+        }
+        return ELSupport.coerceToNumber(null, value, Double.class).longValue();
+    }
+
+    protected Integer coerceToInteger(Object value) {
+        if (value instanceof LocalTime) {
+            return (int) (((LocalTime) value).toNanoOfDay() / 1_000_000);
+        }
+        if (value instanceof Time) {
+            return (int) (((Time) value).toLocalTime().toNanoOfDay() / 1_000_000);
+        }
+        if (value instanceof byte[]) {
+            return Schema.INT32.decode((byte[]) value);
+        }
+        if (value instanceof LocalDate) {
+            return Math.toIntExact(((LocalDate) value).toEpochDay());
+        }
+        return ELSupport.coerceToNumber(null, value, Double.class).intValue();
+    }
+
+    protected Short coerceToShort(Object value) {
+        if (value instanceof byte[]) {
+            return Schema.INT16.decode((byte[]) value);
+        }
+        return ELSupport.coerceToNumber(null, value, Double.class).shortValue();
+    }
+
+    protected Byte coerceToByte(Object value) {
+        if (value instanceof byte[]) {
+            return Schema.INT8.decode((byte[]) value);
+        }
+        return ELSupport.coerceToType(null, value, Byte.class);
+    }
+
+    protected String coerceToString(Object value) {
+        if (value instanceof Time) {
+            return DateTimeFormatter.ISO_LOCAL_TIME.format(((Time) value).toLocalTime());
+        }
+        if (value instanceof Date) {
+            return DateTimeFormatter.ISO_INSTANT.format(((Date) value).toInstant());
+        }
+        if (value instanceof byte[]) {
+            return Schema.STRING.decode((byte[]) value);
+        }
+        return ELSupport.coerceToString(null, value);
+    }
+
+    public <T> T coerceToType(Object value, Class<T> type) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Utf8) {
+            return coerceToType(value.toString(), type);
+        }
+        if (type == Boolean.class) {
+            return (T) coerceToBoolean(value);
+        }
+        if (type == Double.class) {
+            return (T) coerceToDouble(value);
+        }
+        if (type == Float.class) {
+            return (T) coerceToFloat(value);
+        }
+        if (type == Long.class) {
+            return (T) coerceToLong(value);
+        }
+        if (type == Short.class) {
+            return (T) coerceToShort(value);
+        }
+        if (type == Integer.class) {
+            return (T) coerceToInteger(value);
+        }
+        if (type == Byte.class) {
+            return (T) coerceToByte(value);
+        }
+        if (type == String.class) {
+            return (T) coerceToString(value);
+        }
+        if (type == byte[].class) {
+            return (T) coerceToBytes(value);
+        }
+        if (type == Timestamp.class) {
+            return (T) coerceToTimestamp(value);
+        }
+        if (type == Time.class) {
+            return (T) coerceToTime(value);
+        }
+        if (type == Date.class) {
+            return (T) coerceToDate(value);
+        }
+        if (type == LocalDateTime.class) {
+            return (T) coerceToLocalDateTime(value);
+        }
+        if (type == LocalDate.class) {
+            return (T) coerceToLocalDate(value);
+        }
+        if (type == LocalTime.class) {
+            return (T) coerceToLocalTime(value);
+        }
+        if (type == Instant.class) {
+            return (T) coerceToInstant(value);
+        }
+        if (type == OffsetDateTime.class) {
+            return (T) coerceToOffsetDateTime(value);
+        }
+        if (type == BigInteger.class) {
+            return (T) coerceToBigInteger(value);
+        }
+        if (type == BigDecimal.class) {
+            return (T) coerceToBigDecimal(value);
+        }
+        return null;
+    }
+
+    private static final Map<Class<?>, Schema<?>> SCHEMAS =
+            Map.ofEntries(
+                    Map.entry(String.class, Schema.STRING),
+                    Map.entry(Boolean.class, Schema.BOOL),
+                    Map.entry(Byte.class, Schema.INT8),
+                    Map.entry(Short.class, Schema.INT16),
+                    Map.entry(Integer.class, Schema.INT32),
+                    Map.entry(Long.class, Schema.INT64),
+                    Map.entry(Float.class, Schema.FLOAT),
+                    Map.entry(Double.class, Schema.DOUBLE),
+                    Map.entry(Date.class, Schema.DATE),
+                    Map.entry(Timestamp.class, Schema.TIMESTAMP),
+                    Map.entry(Time.class, Schema.TIME),
+                    Map.entry(LocalDate.class, Schema.LOCAL_DATE),
+                    Map.entry(LocalTime.class, Schema.LOCAL_TIME),
+                    Map.entry(LocalDateTime.class, Schema.LOCAL_DATE_TIME),
+                    Map.entry(Instant.class, Schema.INSTANT));
+
+    protected byte[] coerceToBytes(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof byte[]) {
+            return (byte[]) value;
+        }
+        if (value instanceof OffsetDateTime) {
+            return coerceToBytes(((OffsetDateTime) value).toInstant());
+        }
+        if (SCHEMAS.containsKey(value.getClass())) {
+            return ((Schema<Object>) SCHEMAS.get(value.getClass())).encode(value);
+        }
+        throw new IllegalArgumentException(
+                "Cannot convert type " + value.getClass().getName() + " to byte[]");
+    }
+
+    protected Date coerceToDate(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Timestamp) {
+            return new Date(((Timestamp) value).getTime());
+        }
+        if (value instanceof Date && !(value instanceof Time)) {
+            return (Date) value;
+        }
+        if (value instanceof Long || value instanceof Double) {
+            return new Date(((Number) value).longValue());
+        }
+        if (value instanceof byte[]) {
+            return Schema.DATE.decode((byte[]) value);
+        }
+        if (value instanceof TemporalAccessor || value instanceof CharSequence) {
+            return Date.from(coerceToInstant(value));
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), Date.class));
+    }
+
+    protected Timestamp coerceToTimestamp(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Timestamp) {
+            return (Timestamp) value;
+        }
+        if (value instanceof Date && !(value instanceof Time)) {
+            return new Timestamp(((Date) value).getTime());
+        }
+        if (value instanceof Long || value instanceof Double) {
+            return new Timestamp(((Number) value).longValue());
+        }
+        if (value instanceof byte[]) {
+            return Schema.TIMESTAMP.decode((byte[]) value);
+        }
+        if (value instanceof TemporalAccessor || value instanceof CharSequence) {
+            return Timestamp.from(coerceToInstant(value));
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), Timestamp.class));
+    }
+
+    protected Time coerceToTime(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Time) {
+            return (Time) value;
+        }
+        if (value instanceof Long || value instanceof Double) {
+            return new Time(((Number) value).longValue());
+        }
+        if (value instanceof LocalTime) {
+            return Time.valueOf((LocalTime) value);
+        }
+        if (value instanceof byte[]) {
+            return Schema.TIME.decode((byte[]) value);
+        }
+        if (value instanceof CharSequence) {
+            return Time.valueOf(LocalTime.parse((CharSequence) value));
+        }
+        if (value instanceof TemporalAccessor || value instanceof Date) {
+            return new Time(coerceToInstant(value).toEpochMilli());
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), Time.class));
+    }
+
+    protected LocalTime coerceToLocalTime(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalTime) {
+            return (LocalTime) value;
+        }
+        if (value instanceof Time) {
+            return ((Time) value).toLocalTime();
+        }
+        if (value instanceof byte[]) {
+            return Schema.LOCAL_TIME.decode((byte[]) value);
+        }
+        if (value instanceof CharSequence) {
+            return LocalTime.parse((CharSequence) value);
+        }
+        if (value instanceof TemporalAccessor || value instanceof Number || value instanceof Date) {
+            return LocalTime.ofInstant(coerceToInstant(value), ZoneOffset.UTC);
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), LocalTime.class));
+    }
+
+    protected LocalDate coerceToLocalDate(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDate) {
+            return (LocalDate) value;
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).toLocalDate();
+        }
+        if (value instanceof byte[]) {
+            return Schema.LOCAL_DATE.decode((byte[]) value);
+        }
+        if (value instanceof CharSequence) {
+            return LocalDate.parse((CharSequence) value);
+        }
+        if (value instanceof Number) {
+            return LocalDate.ofEpochDay(((Number) value).longValue());
+        }
+        if (value instanceof TemporalAccessor || value instanceof Date) {
+            return LocalDate.ofInstant(coerceToInstant(value), ZoneOffset.UTC);
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), LocalDate.class));
+    }
+
+    protected LocalDateTime coerceToLocalDateTime(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDateTime) {
+            return (LocalDateTime) value;
+        }
+        if (value instanceof LocalDate) {
+            return ((LocalDate) value).atStartOfDay();
+        }
+        if (value instanceof byte[]) {
+            return Schema.LOCAL_DATE_TIME.decode((byte[]) value);
+        }
+        if (value instanceof CharSequence) {
+            return LocalDateTime.parse((CharSequence) value);
+        }
+        if (value instanceof TemporalAccessor || value instanceof Number || value instanceof Date) {
+            return LocalDateTime.ofInstant(coerceToInstant(value), ZoneOffset.UTC);
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), LocalDateTime.class));
+    }
+
+    protected Instant coerceToInstant(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Instant) {
+            return (Instant) value;
+        }
+        if (value instanceof Date && !(value instanceof Time)) {
+            return ((Date) value).toInstant();
+        }
+        if (value instanceof Long) {
+            return Instant.ofEpochMilli(((Number) value).longValue());
+        }
+        if (value instanceof Double) {
+            long seconds = (long) ((double) value / 1000);
+            long nanos = Math.round(((double) value - seconds * 1000) * 1_000_000);
+            return Instant.ofEpochSecond(seconds, nanos);
+        }
+        if (value instanceof byte[]) {
+            return Schema.INSTANT.decode((byte[]) value);
+        }
+        if (value instanceof TemporalAccessor || value instanceof CharSequence) {
+            return coerceToOffsetDateTime(value).toInstant();
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), Instant.class));
+    }
+
+    protected OffsetDateTime coerceToOffsetDateTime(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof OffsetDateTime) {
+            return (OffsetDateTime) value;
+        }
+        if (value instanceof LocalDate) {
+            return ((LocalDate) value).atStartOfDay().atOffset(ZoneOffset.UTC);
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).atOffset(ZoneOffset.UTC);
+        }
+        if (value instanceof Instant) {
+            return ((Instant) value).atOffset(ZoneOffset.UTC);
+        }
+        if (value instanceof CharSequence) {
+            if (((CharSequence) value).length() == 10) {
+                LocalDate localDate =
+                        DateTimeFormatter.ISO_LOCAL_DATE.parse(
+                                (CharSequence) value, LocalDate::from);
+                return localDate.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
+            }
+            return DateTimeFormatter.ISO_DATE_TIME.parse(
+                    (CharSequence) value, OffsetDateTime::from);
+        }
+        if (value instanceof Number || value instanceof Date || value instanceof byte[]) {
+            return coerceToInstant(value).atOffset(ZoneOffset.UTC);
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), OffsetDateTime.class));
+    }
+
+    protected BigInteger coerceToBigInteger(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof BigInteger) {
+            return (BigInteger) value;
+        }
+        if (value instanceof String) {
+            return new BigInteger((String) value);
+        }
+        if (value instanceof byte[]) {
+            return new BigInteger((byte[]) value);
+        }
+        if (value instanceof ByteBuffer) {
+            ByteBuffer bb = (ByteBuffer) value;
+            byte[] bytes = new byte[bb.remaining()];
+            bb.duplicate().get(bytes);
+            return new BigInteger(bytes);
+        }
+        if (value instanceof Integer || value instanceof Long) {
+            return BigInteger.valueOf(((Number) value).longValue());
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), BigInteger.class));
+    }
+
+    protected BigDecimal coerceToBigDecimal(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof String) {
+            return new BigDecimal((String) value);
+        }
+        if (value instanceof Integer || value instanceof Long) {
+            return BigDecimal.valueOf(((Number) value).longValue());
+        }
+        if (value instanceof Float || value instanceof Double) {
+            return BigDecimal.valueOf(((Number) value).doubleValue());
+        }
+        throw new ELException(
+                MessageFactory.get("error.convert", value, value.getClass(), BigDecimal.class));
+    }
+
+    @Override
+    public <T> T convertToType(ELContext elContext, Object value, Class<T> type) {
+        if (value == null) {
+            elContext.setPropertyResolved(true);
+            return null;
+        }
+        T coercedValue = coerceToType(value, type);
+        elContext.setPropertyResolved(coercedValue != null);
+        return (T) coercedValue;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/StandardContext.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/StandardContext.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import jakarta.el.ArrayELResolver;
+import jakarta.el.BeanNameELResolver;
+import jakarta.el.BeanNameResolver;
+import jakarta.el.CompositeELResolver;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.ListELResolver;
+import jakarta.el.MapELResolver;
+import jakarta.el.PropertyNotWritableException;
+import jakarta.el.ResourceBundleELResolver;
+import jakarta.el.StandardELContext;
+import jakarta.el.StaticFieldELResolver;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A standard context that mirrors {@link jakarta.el.StandardELContext} with the exception that it
+ * registers a custom beans resolver that disables invocations.
+ */
+public class StandardContext extends StandardELContext {
+    private final CompositeELResolver standardResolver;
+
+    public StandardContext(ExpressionFactory factory) {
+        super(factory);
+        this.standardResolver = new CompositeELResolver();
+        ELResolver streamResolver = factory.getStreamELResolver();
+        this.standardResolver.add(new BeanNameELResolver(new StandardBeanNameResolver()));
+        if (streamResolver != null) {
+            this.standardResolver.add(streamResolver);
+        }
+        this.standardResolver.add(JstlTypeConverter.INSTANCE);
+
+        this.standardResolver.add(new StaticFieldELResolver());
+        this.standardResolver.add(new MapELResolver());
+        this.standardResolver.add(new ResourceBundleELResolver());
+        this.standardResolver.add(new ListELResolver());
+        this.standardResolver.add(new ArrayELResolver());
+        this.standardResolver.add(new DisabledInvocationBeanResolver());
+    }
+
+    public ELResolver getELResolver() {
+        return this.standardResolver;
+    }
+
+    private static class StandardBeanNameResolver extends BeanNameResolver {
+        private final Map<String, Object> beans = new HashMap<>();
+
+        public boolean isNameResolved(String beanName) {
+            return this.beans.containsKey(beanName);
+        }
+
+        public Object getBean(String beanName) {
+            return this.beans.get(beanName);
+        }
+
+        public void setBeanValue(String beanName, Object value)
+                throws PropertyNotWritableException {
+            this.beans.put(beanName, value);
+        }
+
+        public boolean isReadOnly(String beanName) {
+            return false;
+        }
+
+        public boolean canCreateBean(String beanName) {
+            return true;
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/predicate/JstlPredicate.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/predicate/JstlPredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl.predicate;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.jstl.JstlEvaluator;
+import jakarta.el.ELException;
+import jakarta.el.PropertyNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+
+/** A {@link TransformPredicate} implementation based on the Uniform Transform Language. */
+@Slf4j
+public class JstlPredicate implements TransformPredicate {
+    private final JstlEvaluator<Boolean> evaluator;
+
+    public JstlPredicate(String when) {
+        try {
+            final String expression = String.format("${%s}", when);
+            this.evaluator = new JstlEvaluator<>(expression, boolean.class);
+        } catch (ELException ex) {
+            throw new IllegalArgumentException("invalid when: " + when, ex);
+        }
+    }
+
+    @Override
+    public boolean test(TransformContext transformContext) {
+        try {
+            return this.evaluator.evaluate(transformContext);
+        } catch (PropertyNotFoundException ex) {
+            log.warn("a property in the when expression was not found in the message", ex);
+            return false;
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/predicate/StepPredicatePair.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/predicate/StepPredicatePair.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl.predicate;
+
+import com.datastax.oss.streaming.ai.TransformStep;
+import lombok.Data;
+
+/**
+ * A convenience class to group a step and its predicate together. A convenience class to group a
+ * step and its predicate together.
+ */
+@Data
+public class StepPredicatePair {
+    /** The candidate transform step to be invoked. */
+    private final TransformStep transformStep;
+
+    /** A predicate that decides whether the transform step should be invoked or not. */
+    private final TransformPredicate predicate;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/predicate/TransformPredicate.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/predicate/TransformPredicate.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl.predicate;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import java.util.function.Predicate;
+
+/**
+ * A predicate functional interface that applies to {@link TransformContext}. Implementations of
+ * this interface should respect the current record encapsulated in the {@link TransformContext}
+ * when evaluating the predicate.
+ */
+@FunctionalInterface
+public interface TransformPredicate extends Predicate<TransformContext> {}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/ComputeField.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/ComputeField.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model;
+
+import com.datastax.oss.streaming.ai.jstl.JstlEvaluator;
+import jakarta.el.ELException;
+import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ComputeField {
+    /**
+     * Full field name in the following format: "value.fieldName", "key.fieldName" or "headerName".
+     */
+    @Getter(AccessLevel.NONE)
+    private final String scopedName;
+
+    private final ComputeFieldType type;
+
+    /** The name of the field without the prefix. */
+    private String name;
+
+    /**
+     * The scope of the message where the computed field will be applied. Could be "key", "value" or
+     * "header"
+     */
+    private String scope;
+
+    private JstlEvaluator<?> evaluator;
+    private final boolean optional;
+    private static final Set<String> validComputeHeaders = Set.of("destinationTopic", "messageKey");
+
+    @Builder
+    private ComputeField(String scopedName, ComputeFieldType type, boolean optional) {
+        this.scopedName = scopedName;
+        this.type = type;
+        this.optional = optional;
+    }
+
+    private ComputeField(
+            String name,
+            JstlEvaluator<?> evaluator,
+            ComputeFieldType type,
+            String scope,
+            boolean optional) {
+        this(name, type, optional);
+        this.evaluator = evaluator;
+        this.scope = scope;
+        this.name = name;
+    }
+
+    public static class ComputeFieldBuilder {
+        private String expression;
+        private JstlEvaluator<?> evaluator;
+        private String scope;
+        private String name;
+
+        public ComputeFieldBuilder expression(String expression) {
+            this.expression = expression;
+            return this;
+        }
+
+        public ComputeField build() {
+            // Compile the jstl evaluator to validate the expression syntax early on.
+            try {
+                this.validateAndParseScopedName();
+                this.evaluator =
+                        new JstlEvaluator<>(String.format("${%s}", this.expression), getJavaType());
+            } catch (ELException ex) {
+                throw new IllegalArgumentException("invalid expression: " + "expression", ex);
+            }
+            return new ComputeField(name, evaluator, type, scope, optional);
+        }
+
+        private void validateAndParseScopedName() {
+            if (this.scopedName.equals("value")) {
+                this.scope = "primitive";
+                this.name = "value";
+            } else if (this.scopedName.equals("key")) {
+                this.scope = "primitive";
+                this.name = "key";
+            } else if (this.scopedName.startsWith("key.") || this.scopedName.startsWith("value.")) {
+                String[] nameParts = this.scopedName.split("\\.", 2);
+                this.scope = nameParts[0];
+                this.name = nameParts[1];
+            } else if (this.scopedName.startsWith("properties.")) {
+                String[] nameParts = this.scopedName.split("\\.", 2);
+                this.scope = "header.properties";
+                this.name = nameParts[1];
+            } else if (validComputeHeaders.contains(this.scopedName)) {
+                this.scope = "header";
+                this.name = this.scopedName;
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Invalid compute field name: %s. "
+                                        + "It should be prefixed with 'key.' or 'value.' or 'properties.' or be one of "
+                                        + "[key, value, destinationTopic, messageKey]",
+                                this.scopedName));
+            }
+        }
+
+        private Class<?> getJavaType() {
+            if (this.type == null) {
+                return Object.class;
+            }
+            switch (this.type) {
+                case STRING:
+                    return String.class;
+                case INT8:
+                    return Byte.class;
+                case INT16:
+                    return short.class;
+                case INT32:
+                    return Integer.class;
+                case INT64:
+                    return Long.class;
+                case FLOAT:
+                    return Float.class;
+                case DOUBLE:
+                    return Double.class;
+                case BOOLEAN:
+                    return Boolean.class;
+                case DATE:
+                case LOCAL_DATE:
+                    return LocalDate.class;
+                case TIME:
+                    return Time.class;
+                case LOCAL_TIME:
+                    return LocalTime.class;
+                case LOCAL_DATE_TIME:
+                    return LocalDateTime.class;
+                case DATETIME:
+                case INSTANT:
+                    return Instant.class;
+                case TIMESTAMP:
+                    return Timestamp.class;
+                case BYTES:
+                    return byte[].class;
+                case DECIMAL:
+                    return BigDecimal.class;
+                default:
+                    throw new UnsupportedOperationException(
+                            "Unsupported compute field type: " + type);
+            }
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/ComputeFieldType.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/ComputeFieldType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model;
+
+public enum ComputeFieldType {
+    STRING,
+    INT8,
+    INT16,
+    INT32,
+    INT64,
+    FLOAT,
+    DOUBLE,
+    BOOLEAN,
+    DATE,
+    TIME,
+    TIMESTAMP,
+    INSTANT,
+    LOCAL_DATE,
+    LOCAL_TIME,
+    LOCAL_DATE_TIME,
+
+    /**
+     * @deprecated Use TIMESTAMP, INSTANT or LOCAL_DATE_TIME instead to represent a date-time value.
+     */
+    @Deprecated
+    DATETIME,
+    BYTES,
+    DECIMAL,
+    ARRAY
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/JsonRecord.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/JsonRecord.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model;
+
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class JsonRecord {
+    String topicName;
+    String destinationTopic;
+    Object key;
+    Object value;
+    Map<String, String> properties;
+    Long eventTime;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/TransformSchemaType.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/TransformSchemaType.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model;
+
+public enum TransformSchemaType {
+    STRING,
+    INT8,
+    INT16,
+    INT32,
+    INT64,
+    FLOAT,
+    DOUBLE,
+    BOOLEAN,
+    DATE,
+    TIME,
+    TIMESTAMP,
+    INSTANT,
+    LOCAL_DATE,
+    LOCAL_TIME,
+    LOCAL_DATE_TIME,
+    BYTES,
+    AVRO,
+    JSON,
+    PROTOBUF;
+
+    public boolean isPrimitive() {
+        return isPrimitiveType(this);
+    }
+
+    public boolean isStruct() {
+        return isStructType(this);
+    }
+
+    public static boolean isPrimitiveType(TransformSchemaType type) {
+        switch (type) {
+            case STRING:
+            case BOOLEAN:
+            case INT8:
+            case INT16:
+            case INT32:
+            case INT64:
+            case FLOAT:
+            case DOUBLE:
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case BYTES:
+            case INSTANT:
+            case LOCAL_DATE:
+            case LOCAL_TIME:
+            case LOCAL_DATE_TIME:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static boolean isStructType(TransformSchemaType type) {
+        switch (type) {
+            case AVRO:
+            case JSON:
+            case PROTOBUF:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/CastConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/CastConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class CastConfig extends StepConfig {
+    @JsonProperty(value = "schema-type", required = true)
+    private String schemaType;
+
+    @JsonProperty private String part;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ChatCompletionsConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ChatCompletionsConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.datastax.oss.streaming.ai.completions.ChatMessage;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class ChatCompletionsConfig extends StepConfig {
+
+    @JsonProperty(required = true)
+    private String model;
+
+    @JsonProperty(value = "messages", required = true)
+    private List<ChatMessage> messages;
+
+    @JsonProperty(value = "completion-field")
+    private String fieldName;
+
+    @JsonProperty(value = "log-field")
+    private String logField;
+
+    @JsonProperty(value = "max-tokens")
+    private Integer maxTokens;
+
+    @JsonProperty(value = "temperature")
+    private Double temperature;
+
+    @JsonProperty(value = "top-p")
+    private Double topP;
+
+    @JsonProperty(value = "logit-bias")
+    private Map<String, Integer> logitBias;
+
+    @JsonProperty(value = "user")
+    private String user;
+
+    @JsonProperty(value = "stop")
+    private List<String> stop;
+
+    @JsonProperty(value = "presence-penalty")
+    private Double presencePenalty;
+
+    @JsonProperty(value = "frequency-penalty")
+    private Double frequencyPenalty;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeAIEmbeddingsConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeAIEmbeddingsConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ComputeAIEmbeddingsConfig extends StepConfig {
+
+    public enum SupportedServices {
+        OPENAI,
+        HUGGINGFACE
+    }
+
+    @JsonProperty(required = true)
+    private String model;
+
+    @JsonProperty(required = true)
+    private String text;
+
+    @JsonProperty(value = "embeddings-field", required = true)
+    private String embeddingsFieldName;
+
+    @Deprecated
+    @JsonProperty(value = "compute-service")
+    private String service;
+
+    @JsonProperty Map<String, String> options;
+
+    @JsonProperty Map<String, String> arguments;
+
+    @JsonProperty(value = "model-url")
+    String modelUrl;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.datastax.oss.streaming.ai.model.ComputeFieldType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ComputeConfig extends StepConfig {
+    @JsonProperty(required = true)
+    private List<ComputeField> fields;
+
+    @Getter
+    public static class ComputeField {
+        @JsonProperty(required = true)
+        private String name;
+
+        @JsonProperty(required = true)
+        private String expression;
+
+        @JsonProperty(required = true)
+        private ComputeFieldType type;
+
+        @JsonProperty private boolean optional = true;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ComputeProvider {
+    @JsonProperty("local")
+    LOCAL,
+    @JsonProperty("api")
+    API
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/DataSourceConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/DataSourceConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DataSourceConfig {
+
+    @JsonProperty private String service = "astra";
+
+    @JsonProperty private String username;
+
+    @JsonProperty private String password;
+
+    @JsonProperty private String secureBundle;
+
+    @Override
+    public String toString() {
+        return "DataSourceConfig{"
+                                + "service='"
+                                + service
+                                + '\''
+                                + ", username='"
+                                + username
+                                + '\''
+                                +
+                                // hide password from logs
+                                ", password='"
+                                + password
+                        != null
+                ? "xxx"
+                : "" + '\'' + ", secureBundle='" + secureBundle != null ? "xxx" : "" + '\'' + '}';
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/DropConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/DropConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class DropConfig extends StepConfig {
+    @JsonProperty(required = true)
+    private List<String> fields;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/DropFieldsConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/DropFieldsConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class DropFieldsConfig extends StepConfig {
+    @JsonProperty(required = true)
+    private List<String> fields;
+
+    @JsonProperty private String part;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/FlattenConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/FlattenConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class FlattenConfig extends StepConfig {
+    @JsonProperty private String delimiter;
+
+    @JsonProperty private String part;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/HuggingFaceConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/HuggingFaceConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class HuggingFaceConfig {
+    // for API compute provider
+    @JsonProperty(
+            value = "api-url",
+            defaultValue = "https://api-inference.huggingface.co/pipeline/feature-extraction/")
+    private String apiUrl = "https://api-inference.huggingface.co/pipeline/feature-extraction/";
+
+    @JsonProperty(value = "model-check-url", defaultValue = "https://huggingface.co/api/models/")
+    private String modelUrl = "https://huggingface.co/api/models/";
+
+    // for API compute provider
+    @JsonProperty(value = "access-key")
+    private String accessKey;
+
+    @JsonProperty ComputeProvider provider;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/MergeKeyValueConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/MergeKeyValueConfig.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+public class MergeKeyValueConfig extends StepConfig {}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/OpenAIConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/OpenAIConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class OpenAIConfig {
+    @JsonProperty private String url;
+
+    @JsonProperty(value = "access-key", required = true)
+    private String accessKey;
+
+    @JsonProperty OpenAIProvider provider = OpenAIProvider.OPENAI;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/OpenAIProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/OpenAIProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum OpenAIProvider {
+    @JsonProperty("openai")
+    OPENAI,
+    @JsonProperty("azure")
+    AZURE
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/QueryConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/QueryConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class QueryConfig extends StepConfig {
+    @JsonProperty(value = "query", required = true)
+    private String query;
+
+    @JsonProperty(value = "fields", required = false)
+    private List<String> fields;
+
+    @JsonProperty(value = "output-field", required = true)
+    private String outputField;
+
+    @JsonProperty(value = "only-first", required = false)
+    private boolean onlyFirst;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/StepConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/StepConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Getter;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes(
+        value = {
+            @JsonSubTypes.Type(value = DropFieldsConfig.class, name = "drop-fields"),
+            @JsonSubTypes.Type(value = UnwrapKeyValueConfig.class, name = "unwrap-key-value"),
+            @JsonSubTypes.Type(value = MergeKeyValueConfig.class, name = "merge-key-value"),
+            @JsonSubTypes.Type(value = CastConfig.class, name = "cast"),
+            @JsonSubTypes.Type(value = DropConfig.class, name = "drop"),
+            @JsonSubTypes.Type(value = FlattenConfig.class, name = "flatten"),
+            @JsonSubTypes.Type(value = ComputeConfig.class, name = "compute"),
+            @JsonSubTypes.Type(
+                    value = ComputeAIEmbeddingsConfig.class,
+                    name = "compute-ai-embeddings"),
+            @JsonSubTypes.Type(value = ChatCompletionsConfig.class, name = "ai-chat-completions"),
+            @JsonSubTypes.Type(value = QueryConfig.class, name = "query")
+        })
+@Getter
+public abstract class StepConfig {
+    @JsonProperty(required = true)
+    private String type;
+
+    @JsonProperty private String when;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/TransformStepConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/TransformStepConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class TransformStepConfig {
+    @JsonProperty(required = true)
+    private List<StepConfig> steps;
+
+    @JsonProperty private OpenAIConfig openai;
+
+    @JsonProperty private HuggingFaceConfig huggingface;
+
+    @JsonProperty private DataSourceConfig datasource;
+
+    @JsonProperty private boolean attemptJsonConversion = true;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/UnwrapKeyValueConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/UnwrapKeyValueConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class UnwrapKeyValueConfig extends StepConfig {
+    @JsonProperty(value = "schema-type", required = true)
+    private String schemaType;
+
+    @JsonProperty("unwrap-key")
+    private boolean unwrapKey;
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/package-info.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/HuggingFaceServiceProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.services;
+
+import static com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService.DLJ_BASE_URL;
+
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.embeddings.AbstractHuggingFaceEmbeddingService;
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import com.datastax.oss.streaming.ai.embeddings.HuggingFaceEmbeddingService;
+import com.datastax.oss.streaming.ai.embeddings.HuggingFaceRestEmbeddingService;
+import com.datastax.oss.streaming.ai.model.config.ComputeProvider;
+import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HuggingFaceServiceProvider implements ServiceProvider {
+
+    private final Map<String, Object> providerConfiguration;
+
+    public HuggingFaceServiceProvider(Map<String, Object> providerConfiguration) {
+        this.providerConfiguration = providerConfiguration;
+    }
+
+    public HuggingFaceServiceProvider(TransformStepConfig tranformConfiguration) {
+        this.providerConfiguration =
+                new ObjectMapper().convertValue(tranformConfiguration.getHuggingface(), Map.class);
+    }
+
+    @Override
+    public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+        throw new IllegalArgumentException("Completions is still not available for HuggingFace");
+    }
+
+    @Override
+    public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration)
+            throws Exception {
+        String provider =
+                additionalConfiguration
+                        .getOrDefault("provider", ComputeProvider.API.name())
+                        .toString()
+                        .toUpperCase();
+        String modelUrl = (String) additionalConfiguration.get("modelUrl");
+        String model = (String) additionalConfiguration.get("model");
+        Map<String, String> options = (Map<String, String>) additionalConfiguration.get("options");
+        Map<String, String> arguments =
+                (Map<String, String>) additionalConfiguration.get("arguments");
+        switch (provider) {
+            case "LOCAL":
+                AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.HuggingFaceConfigBuilder
+                        builder =
+                                AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
+                                        .options(options)
+                                        .arguments(arguments);
+                if (model != null && !model.isEmpty()) {
+                    builder.modelName(model);
+
+                    // automatically build the model URL if not provided
+                    if (modelUrl == null || modelUrl.isEmpty()) {
+                        modelUrl = DLJ_BASE_URL + model;
+                        log.info("Automatically computed model URL {}", modelUrl);
+                    }
+                }
+                builder.modelUrl(modelUrl);
+
+                return new HuggingFaceEmbeddingService(builder.build());
+            case "API":
+                Objects.requireNonNull(model, "model name is required");
+                HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.HuggingFaceApiConfigBuilder
+                        apiBuilder =
+                                HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.builder()
+                                        .accessKey((String) providerConfiguration.get("access-key"))
+                                        .model(model);
+
+                String apiUurl = (String) providerConfiguration.get("api-url");
+                if (apiUurl != null && !apiUurl.isEmpty()) {
+                    apiBuilder.hfUrl(apiUurl);
+                }
+                String modelCheckUrl = (String) providerConfiguration.get("model-check-url");
+                if (modelCheckUrl != null && !modelCheckUrl.isEmpty()) {
+                    apiBuilder.hfCheckUrl(modelCheckUrl);
+                }
+                if (options != null && !options.isEmpty()) {
+                    apiBuilder.options(options);
+                } else {
+                    apiBuilder.options(Map.of("wait_for_model", "true"));
+                }
+
+                return new HuggingFaceRestEmbeddingService(apiBuilder.build());
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported HuggingFace service type: " + provider);
+        }
+    }
+
+    @Override
+    public void close() {}
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.services;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.completions.OpenAICompletionService;
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import com.datastax.oss.streaming.ai.embeddings.OpenAIEmbeddingsService;
+import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
+import java.util.Map;
+
+public class OpenAIServiceProvider implements ServiceProvider {
+
+    private final OpenAIClient client;
+
+    public OpenAIServiceProvider(TransformStepConfig config) {
+        client = TransformFunctionUtil.buildOpenAIClient(config.getOpenai());
+    }
+
+    public OpenAIServiceProvider(OpenAIClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration) {
+        return new OpenAICompletionService(client);
+    }
+
+    @Override
+    public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
+        String model = (String) additionalConfiguration.get("model");
+        return new OpenAIEmbeddingsService(client, model);
+    }
+
+    @Override
+    public void close() {}
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/ServiceProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.services;
+
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import java.util.List;
+import java.util.Map;
+
+public interface ServiceProvider extends AutoCloseable {
+    CompletionsService getCompletionsService(Map<String, Object> additionalConfiguration)
+            throws Exception;
+
+    EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration)
+            throws Exception;
+
+    void close();
+
+    public static class NoopServiceProvider implements ServiceProvider {
+        @Override
+        public CompletionsService getCompletionsService(
+                Map<String, Object> additionalConfiguration) {
+            throw new IllegalArgumentException("please configure an AI service");
+        }
+
+        @Override
+        public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
+            return new EmbeddingsService() {
+                @Override
+                public List<List<Double>> computeEmbeddings(List<String> texts) {
+                    return List.of();
+                }
+            };
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/AvroUtil.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/AvroUtil.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+public class AvroUtil {
+
+    /**
+     * Returns the logical type of the schema. If the schema is a union, it will return the logical
+     * type of any of the union types.
+     */
+    public static LogicalType getLogicalType(Schema schema) {
+        if (!schema.isUnion()) {
+            return schema.getLogicalType();
+        }
+
+        return schema.getTypes().stream()
+                .map(Schema::getLogicalType)
+                .filter(Objects::nonNull)
+                .findAny()
+                .orElse(null);
+    }
+
+    public static GenericRecord dropAvroRecordFields(
+            GenericRecord record,
+            Collection<String> fields,
+            Map<org.apache.avro.Schema, org.apache.avro.Schema> schemaCache) {
+        org.apache.avro.Schema avroSchema = record.getSchema();
+        if (schemaCache.get(avroSchema) != null
+                || fields.stream().anyMatch(field -> avroSchema.getField(field) != null)) {
+            org.apache.avro.Schema modified = dropAvroSchemaFields(avroSchema, fields, schemaCache);
+            GenericRecord newRecord = new GenericData.Record(modified);
+            for (org.apache.avro.Schema.Field field : modified.getFields()) {
+                newRecord.put(field.name(), record.get(field.name()));
+            }
+            return newRecord;
+        }
+        return record;
+    }
+
+    public static Schema dropAvroSchemaFields(
+            Schema avroSchema, Collection<String> fields, Map<Schema, Schema> schemaCache) {
+        return schemaCache.computeIfAbsent(
+                avroSchema,
+                schema ->
+                        Schema.createRecord(
+                                avroSchema.getName(),
+                                avroSchema.getDoc(),
+                                avroSchema.getNamespace(),
+                                avroSchema.isError(),
+                                avroSchema.getFields().stream()
+                                        .filter(f -> !fields.contains(f.name()))
+                                        .map(
+                                                f ->
+                                                        new Schema.Field(
+                                                                f.name(),
+                                                                f.schema(),
+                                                                f.doc(),
+                                                                f.defaultVal(),
+                                                                f.order()))
+                                        .collect(Collectors.toList())));
+    }
+
+    public static GenericData.Record addOrReplaceAvroRecordFields(
+            GenericRecord record,
+            Map<Schema.Field, Object> newFields,
+            Map<Schema, Schema> schemaCache) {
+        Schema newSchema =
+                addOrReplaceAvroSchemaFields(record.getSchema(), newFields.keySet(), schemaCache);
+        GenericRecordBuilder newRecordBuilder = new GenericRecordBuilder(newSchema);
+        for (Schema.Field f : newSchema.getFields()) {
+            if (newFields.containsKey(f)) {
+                Object value = newFields.get(f);
+                if ((value instanceof Collection) && !(value instanceof GenericArray)) {
+                    value = new GenericData.Array<>(f.schema(), (Collection<Object>) value);
+                }
+                newRecordBuilder.set(f.name(), value);
+            } else {
+                newRecordBuilder.set(f.name(), record.get(f.name()));
+            }
+        }
+        return newRecordBuilder.build();
+    }
+
+    public static Schema addOrReplaceAvroSchemaFields(
+            Schema avroSchema,
+            Collection<Schema.Field> newFields,
+            Map<Schema, Schema> schemaCache) {
+        Map<String, Schema.Field> newFieldsByName = new LinkedHashMap<>();
+        newFields.forEach(k -> newFieldsByName.put(k.name(), k));
+
+        // allFields is the intersection between existing fields and computed fields. Computed
+        // fields
+        // take precedence.
+        List<Schema.Field> allFields = new ArrayList<>();
+        for (Schema.Field f : avroSchema.getFields()) {
+            if (newFieldsByName.containsKey(f.name())) {
+                allFields.add(newFieldsByName.get(f.name()));
+                newFieldsByName.remove(f.name());
+            } else {
+                allFields.add(
+                        new Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal(), f.order()));
+            }
+        }
+        allFields.addAll(newFieldsByName.values());
+        return schemaCache.computeIfAbsent(
+                avroSchema,
+                schema ->
+                        Schema.createRecord(
+                                avroSchema.getName(),
+                                avroSchema.getDoc(),
+                                avroSchema.getNamespace(),
+                                avroSchema.isError(),
+                                allFields));
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/JsonConverter.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/JsonConverter.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.util;
+
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getBytes;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.avro.Conversion;
+import org.apache.avro.Conversions;
+import org.apache.avro.Schema;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+
+/** Convert an AVRO GenericRecord to a JsonNode. */
+public class JsonConverter {
+
+    private static final Map<String, LogicalTypeConverter<?>> logicalTypeConverters =
+            new HashMap<>();
+    private static final JsonNodeFactory jsonNodeFactory =
+            JsonNodeFactory.withExactBigDecimals(true);
+
+    public static JsonNode toJson(GenericRecord genericRecord) {
+        if (genericRecord == null) {
+            return null;
+        }
+        ObjectNode objectNode = jsonNodeFactory.objectNode();
+        for (Schema.Field field : genericRecord.getSchema().getFields()) {
+            objectNode.set(field.name(), toJson(field.schema(), genericRecord.get(field.name())));
+        }
+        return objectNode;
+    }
+
+    public static JsonNode toJson(Schema schema, Object value) {
+        if (schema.getLogicalType() != null
+                && logicalTypeConverters.containsKey(schema.getLogicalType().getName())) {
+            return logicalTypeConverters
+                    .get(schema.getLogicalType().getName())
+                    .toJson(schema, value);
+        }
+        if (value == null) {
+            return jsonNodeFactory.nullNode();
+        }
+        switch (schema.getType()) {
+            case NULL: // this should not happen
+                return jsonNodeFactory.nullNode();
+            case INT:
+                return jsonNodeFactory.numberNode((Integer) value);
+            case LONG:
+                return jsonNodeFactory.numberNode((Long) value);
+            case DOUBLE:
+                return jsonNodeFactory.numberNode((Double) value);
+            case FLOAT:
+                return jsonNodeFactory.numberNode((Float) value);
+            case BOOLEAN:
+                return jsonNodeFactory.booleanNode((Boolean) value);
+            case BYTES:
+                byte[] bytes;
+                if (value instanceof byte[]) {
+                    bytes = (byte[]) value;
+                } else if (value instanceof ByteBuffer) {
+                    bytes = getBytes((ByteBuffer) value);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Invalid type for field of type BYTES, expected byte[] or ByteBuffer but was "
+                                    + value.getClass());
+                }
+                return jsonNodeFactory.binaryNode(bytes);
+            case FIXED:
+                return jsonNodeFactory.binaryNode(((GenericFixed) value).bytes());
+            case ENUM: // GenericEnumSymbol
+            case STRING:
+                return jsonNodeFactory.textNode(
+                        value.toString()); // can be a String or org.apache.avro.util.Utf8
+            case ARRAY:
+                {
+                    Schema elementSchema = schema.getElementType();
+                    ArrayNode arrayNode = jsonNodeFactory.arrayNode();
+                    Object[] iterable;
+                    if (value instanceof GenericData.Array) {
+                        iterable = ((GenericData.Array) value).toArray();
+                    } else {
+                        iterable = (Object[]) value;
+                    }
+                    for (Object elem : iterable) {
+                        JsonNode fieldValue = toJson(elementSchema, elem);
+                        arrayNode.add(fieldValue);
+                    }
+                    return arrayNode;
+                }
+            case MAP:
+                {
+                    Map<Object, Object> map = (Map<Object, Object>) value;
+                    ObjectNode objectNode = jsonNodeFactory.objectNode();
+                    for (Map.Entry<Object, Object> entry : map.entrySet()) {
+                        JsonNode jsonNode = toJson(schema.getValueType(), entry.getValue());
+                        // can be a String or org.apache.avro.util.Utf8
+                        final String entryKey =
+                                entry.getKey() == null ? null : entry.getKey().toString();
+                        objectNode.set(entryKey, jsonNode);
+                    }
+                    return objectNode;
+                }
+            case RECORD:
+                return toJson((GenericRecord) value);
+            case UNION:
+                for (Schema s : schema.getTypes()) {
+                    if (s.getType() == Schema.Type.NULL) {
+                        continue;
+                    }
+                    return toJson(s, value);
+                }
+                // this case should not happen
+                return jsonNodeFactory.textNode(value.toString());
+            default:
+                throw new UnsupportedOperationException(
+                        "Unknown AVRO schema type=" + schema.getType());
+        }
+    }
+
+    abstract static class LogicalTypeConverter<T> {
+        final Conversion<T> conversion;
+
+        public LogicalTypeConverter(Conversion<T> conversion) {
+            this.conversion = conversion;
+        }
+
+        abstract JsonNode toJson(Schema schema, Object value);
+    }
+
+    static {
+        logicalTypeConverters.put(
+                "decimal",
+                new LogicalTypeConverter<BigDecimal>(new Conversions.DecimalConversion()) {
+                    @Override
+                    JsonNode toJson(Schema schema, Object value) {
+                        if (!(value instanceof BigDecimal)) {
+                            throw new IllegalArgumentException(
+                                    "Invalid type for Decimal, expected BigDecimal but was "
+                                            + value.getClass());
+                        }
+                        BigDecimal decimal = (BigDecimal) value;
+                        return jsonNodeFactory.numberNode(decimal);
+                    }
+                });
+        logicalTypeConverters.put(
+                "date",
+                new LogicalTypeConverter<LocalDate>(new TimeConversions.DateConversion()) {
+                    @Override
+                    JsonNode toJson(Schema schema, Object value) {
+                        if (!(value instanceof Integer)) {
+                            throw new IllegalArgumentException(
+                                    "Invalid type for date, expected Integer but was "
+                                            + value.getClass());
+                        }
+                        Integer daysFromEpoch = (Integer) value;
+                        return jsonNodeFactory.numberNode(daysFromEpoch);
+                    }
+                });
+        logicalTypeConverters.put(
+                "time-millis",
+                new LogicalTypeConverter<LocalTime>(new TimeConversions.TimeMillisConversion()) {
+                    @Override
+                    JsonNode toJson(Schema schema, Object value) {
+                        if (!(value instanceof Integer)) {
+                            throw new IllegalArgumentException(
+                                    "Invalid type for time-millis, expected Integer but was "
+                                            + value.getClass());
+                        }
+                        Integer timeMillis = (Integer) value;
+                        return jsonNodeFactory.numberNode(timeMillis);
+                    }
+                });
+        logicalTypeConverters.put(
+                "time-micros",
+                new LogicalTypeConverter<LocalTime>(new TimeConversions.TimeMicrosConversion()) {
+                    @Override
+                    JsonNode toJson(Schema schema, Object value) {
+                        if (!(value instanceof Long)) {
+                            throw new IllegalArgumentException(
+                                    "Invalid type for time-micros, expected Long but was "
+                                            + value.getClass());
+                        }
+                        Long timeMicro = (Long) value;
+                        return jsonNodeFactory.numberNode(timeMicro);
+                    }
+                });
+        logicalTypeConverters.put(
+                "timestamp-millis",
+                new LogicalTypeConverter<Instant>(new TimeConversions.TimestampMillisConversion()) {
+                    @Override
+                    JsonNode toJson(Schema schema, Object value) {
+                        if (!(value instanceof Long)) {
+                            throw new IllegalArgumentException(
+                                    "Invalid type for timestamp-millis, expected Long but was "
+                                            + value.getClass());
+                        }
+                        Long epochMillis = (Long) value;
+                        return jsonNodeFactory.numberNode(epochMillis);
+                    }
+                });
+        logicalTypeConverters.put(
+                "timestamp-micros",
+                new LogicalTypeConverter<Instant>(new TimeConversions.TimestampMicrosConversion()) {
+                    @Override
+                    JsonNode toJson(Schema schema, Object value) {
+                        if (!(value instanceof Long)) {
+                            throw new IllegalArgumentException(
+                                    "Invalid type for timestamp-micros, expected Long but was "
+                                            + value.getClass());
+                        }
+                        Long epochMillis = (Long) value;
+                        return jsonNodeFactory.numberNode(epochMillis);
+                    }
+                });
+        logicalTypeConverters.put(
+                "uuid",
+                new LogicalTypeConverter<UUID>(new Conversions.UUIDConversion()) {
+                    @Override
+                    JsonNode toJson(Schema schema, Object value) {
+                        return jsonNodeFactory.textNode(value == null ? null : value.toString());
+                    }
+                });
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.util;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.OpenAIClientBuilder;
+import com.azure.ai.openai.models.NonAzureOpenAIKeyCredential;
+import com.azure.core.credential.AzureKeyCredential;
+import com.datastax.oss.streaming.ai.CastStep;
+import com.datastax.oss.streaming.ai.ChatCompletionsStep;
+import com.datastax.oss.streaming.ai.ComputeAIEmbeddingsStep;
+import com.datastax.oss.streaming.ai.ComputeStep;
+import com.datastax.oss.streaming.ai.DropFieldStep;
+import com.datastax.oss.streaming.ai.DropStep;
+import com.datastax.oss.streaming.ai.FlattenStep;
+import com.datastax.oss.streaming.ai.MergeKeyValueStep;
+import com.datastax.oss.streaming.ai.QueryStep;
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.TransformStep;
+import com.datastax.oss.streaming.ai.UnwrapKeyValueStep;
+import com.datastax.oss.streaming.ai.completions.CompletionsService;
+import com.datastax.oss.streaming.ai.datasource.AstraDBDataSource;
+import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
+import com.datastax.oss.streaming.ai.jstl.predicate.JstlPredicate;
+import com.datastax.oss.streaming.ai.jstl.predicate.StepPredicatePair;
+import com.datastax.oss.streaming.ai.model.ComputeField;
+import com.datastax.oss.streaming.ai.model.ComputeFieldType;
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import com.datastax.oss.streaming.ai.model.config.CastConfig;
+import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
+import com.datastax.oss.streaming.ai.model.config.ComputeAIEmbeddingsConfig;
+import com.datastax.oss.streaming.ai.model.config.ComputeConfig;
+import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import com.datastax.oss.streaming.ai.model.config.DropFieldsConfig;
+import com.datastax.oss.streaming.ai.model.config.FlattenConfig;
+import com.datastax.oss.streaming.ai.model.config.OpenAIConfig;
+import com.datastax.oss.streaming.ai.model.config.OpenAIProvider;
+import com.datastax.oss.streaming.ai.model.config.QueryConfig;
+import com.datastax.oss.streaming.ai.model.config.StepConfig;
+import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.datastax.oss.streaming.ai.model.config.UnwrapKeyValueConfig;
+import com.datastax.oss.streaming.ai.services.ServiceProvider;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TransformFunctionUtil {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final List<String> FIELD_NAMES =
+            Arrays.asList(
+                    "value", "key", "destinationTopic", "messageKey", "topicName", "eventTime");
+
+    public static OpenAIClient buildOpenAIClient(OpenAIConfig openAIConfig) {
+        if (openAIConfig == null) {
+            return null;
+        }
+        OpenAIClientBuilder openAIClientBuilder = new OpenAIClientBuilder();
+        if (openAIConfig.getProvider() == OpenAIProvider.AZURE) {
+            openAIClientBuilder.credential(new AzureKeyCredential(openAIConfig.getAccessKey()));
+        } else {
+            openAIClientBuilder.credential(
+                    new NonAzureOpenAIKeyCredential(openAIConfig.getAccessKey()));
+        }
+        if (openAIConfig.getUrl() != null) {
+            openAIClientBuilder.endpoint(openAIConfig.getUrl());
+        }
+        return openAIClientBuilder.buildClient();
+    }
+
+    public static QueryStepDataSource buildDataSource(DataSourceConfig dataSourceConfig) {
+        if (dataSourceConfig == null) {
+            return new QueryStepDataSource() {};
+        }
+        QueryStepDataSource dataSource;
+        switch (dataSourceConfig.getService() + "") {
+            case "astra":
+                dataSource = new AstraDBDataSource();
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Invalid service type " + dataSourceConfig.getService());
+        }
+        dataSource.initialize(dataSourceConfig);
+        return dataSource;
+    }
+
+    public static List<StepPredicatePair> getTransformSteps(
+            TransformStepConfig transformConfig,
+            ServiceProvider serviceProvider,
+            QueryStepDataSource dataSource)
+            throws Exception {
+        TransformStep transformStep;
+        List<StepPredicatePair> steps = new ArrayList<>();
+        for (StepConfig step : transformConfig.getSteps()) {
+            switch (step.getType()) {
+                case "drop-fields":
+                    transformStep = newRemoveFieldFunction((DropFieldsConfig) step);
+                    break;
+                case "cast":
+                    transformStep =
+                            newCastFunction(
+                                    (CastConfig) step, transformConfig.isAttemptJsonConversion());
+                    break;
+                case "merge-key-value":
+                    transformStep = new MergeKeyValueStep();
+                    break;
+                case "unwrap-key-value":
+                    transformStep = newUnwrapKeyValueFunction((UnwrapKeyValueConfig) step);
+                    break;
+                case "flatten":
+                    transformStep = newFlattenFunction((FlattenConfig) step);
+                    break;
+                case "drop":
+                    transformStep = new DropStep();
+                    break;
+                case "compute":
+                    transformStep = newComputeFieldFunction((ComputeConfig) step);
+                    break;
+                case "compute-ai-embeddings":
+                    transformStep =
+                            newComputeAIEmbeddings(
+                                    (ComputeAIEmbeddingsConfig) step, serviceProvider);
+                    break;
+                case "ai-chat-completions":
+                    transformStep =
+                            newChatCompletionsFunction(
+                                    (ChatCompletionsConfig) step, serviceProvider);
+                    break;
+                case "query":
+                    transformStep = newQuery((QueryConfig) step, dataSource);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid step type: " + step.getType());
+            }
+            steps.add(
+                    new StepPredicatePair(
+                            transformStep,
+                            step.getWhen() == null ? null : new JstlPredicate(step.getWhen())));
+        }
+        return steps;
+    }
+
+    public static DropFieldStep newRemoveFieldFunction(DropFieldsConfig config) {
+        DropFieldStep.DropFieldStepBuilder builder = DropFieldStep.builder();
+        if (config.getPart() != null) {
+            if (config.getPart().equals("key")) {
+                builder.keyFields(config.getFields());
+            } else {
+                builder.valueFields(config.getFields());
+            }
+        } else {
+            builder.keyFields(config.getFields()).valueFields(config.getFields());
+        }
+        return builder.build();
+    }
+
+    public static CastStep newCastFunction(CastConfig config, boolean attemptJsonConversion) {
+        String schemaTypeParam = config.getSchemaType();
+        TransformSchemaType schemaType = TransformSchemaType.valueOf(schemaTypeParam);
+        CastStep.CastStepBuilder builder =
+                CastStep.builder().attemptJsonConversion(attemptJsonConversion);
+        if (config.getPart() != null) {
+            if (config.getPart().equals("key")) {
+                builder.keySchemaType(schemaType);
+            } else {
+                builder.valueSchemaType(schemaType);
+            }
+        } else {
+            builder.keySchemaType(schemaType).valueSchemaType(schemaType);
+        }
+        return builder.build();
+    }
+
+    public static FlattenStep newFlattenFunction(FlattenConfig config) {
+        FlattenStep.FlattenStepBuilder builder = FlattenStep.builder();
+        if (config.getPart() != null) {
+            builder.part(config.getPart());
+        }
+        if (config.getDelimiter() != null) {
+            builder.delimiter(config.getDelimiter());
+        }
+        return builder.build();
+    }
+
+    public static TransformStep newComputeFieldFunction(ComputeConfig config) {
+        List<ComputeField> fieldList = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        config.getFields()
+                .forEach(
+                        field -> {
+                            if (seen.contains(field.getName())) {
+                                throw new IllegalArgumentException(
+                                        "Duplicate compute field name detected: "
+                                                + field.getName());
+                            }
+                            if (field.getType() == ComputeFieldType.DATE
+                                    && ("value".equals(field.getName())
+                                            || "key".equals(field.getName()))) {
+                                throw new IllegalArgumentException(
+                                        "The compute operation cannot apply the type DATE to the message value or key. "
+                                                + "Please consider using the types TIMESTAMP or INSTANT instead and follow with a 'cast' "
+                                                + "to SchemaType.DATE operation.");
+                            }
+                            seen.add(field.getName());
+                            ComputeFieldType type =
+                                    "destinationTopic".equals(field.getName())
+                                                    || "messageKey".equals(field.getName())
+                                                    || field.getName().startsWith("properties.")
+                                            ? ComputeFieldType.STRING
+                                            : field.getType();
+                            fieldList.add(
+                                    ComputeField.builder()
+                                            .scopedName(field.getName())
+                                            .expression(field.getExpression())
+                                            .type(type)
+                                            .optional(field.isOptional())
+                                            .build());
+                        });
+        return ComputeStep.builder().fields(fieldList).build();
+    }
+
+    @SneakyThrows
+    public static TransformStep newComputeAIEmbeddings(
+            ComputeAIEmbeddingsConfig config, ServiceProvider provider) {
+        EmbeddingsService embeddingsService = provider.getEmbeddingsService(convertToMap(config));
+        return new ComputeAIEmbeddingsStep(
+                config.getText(), config.getEmbeddingsFieldName(), embeddingsService);
+    }
+
+    public static UnwrapKeyValueStep newUnwrapKeyValueFunction(UnwrapKeyValueConfig config) {
+        return new UnwrapKeyValueStep(config.isUnwrapKey());
+    }
+
+    public static Map<String, Object> convertToMap(Object object) {
+        return new ObjectMapper().convertValue(object, Map.class);
+    }
+
+    public static <T> T convertFromMap(Map<String, Object> map, Class<T> type) {
+        return new ObjectMapper().convertValue(map, type);
+    }
+
+    public static TransformStep newChatCompletionsFunction(
+            ChatCompletionsConfig config, ServiceProvider serviceProvider) throws Exception {
+        CompletionsService completionsService =
+                serviceProvider.getCompletionsService(convertToMap(config));
+        return new ChatCompletionsStep(completionsService, config);
+    }
+
+    public static TransformStep newQuery(QueryConfig config, QueryStepDataSource dataSource) {
+        config.getFields()
+                .forEach(
+                        field -> {
+                            if (!FIELD_NAMES.contains(field)
+                                    && !field.startsWith("value.")
+                                    && !field.startsWith("key.")
+                                    && !field.startsWith("properties")) {
+                                throw new IllegalArgumentException(
+                                        String.format(
+                                                "Invalid field name for query step: %s", field));
+                            }
+                        });
+        return QueryStep.builder()
+                .outputFieldName(config.getOutputField())
+                .query(config.getQuery())
+                .onlyFirst(config.isOnlyFirst())
+                .fields(config.getFields())
+                .dataSource(dataSource)
+                .build();
+    }
+
+    public static void processTransformSteps(
+            TransformContext transformContext, Collection<StepPredicatePair> steps)
+            throws Exception {
+        for (StepPredicatePair pair : steps) {
+            TransformStep step = pair.getTransformStep();
+            Predicate<TransformContext> predicate = pair.getPredicate();
+            if (predicate == null || predicate.test(transformContext)) {
+                step.process(transformContext);
+            }
+        }
+    }
+
+    public static Object attemptJsonConversion(Object value) {
+        try {
+            if (value instanceof String) {
+                return OBJECT_MAPPER.readValue(
+                        (String) value, new TypeReference<Map<String, Object>>() {});
+            } else if (value instanceof byte[]) {
+                return OBJECT_MAPPER.readValue(
+                        (byte[]) value, new TypeReference<Map<String, Object>>() {});
+            }
+        } catch (IOException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cannot convert value to json", e);
+            }
+        }
+        return value;
+    }
+
+    public static Double getDouble(String name, Map<String, Object> options) {
+        Object o = options.get(name);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof Number) {
+            return ((Number) o).doubleValue();
+        }
+        return Double.parseDouble(o.toString());
+    }
+
+    public static Integer getInteger(String name, Map<String, Object> options) {
+        Object o = options.get(name);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof Number) {
+            return ((Number) o).intValue();
+        }
+        return Integer.parseInt(o.toString());
+    }
+
+    public static byte[] getBytes(ByteBuffer byteBuffer) {
+        if (byteBuffer == null) {
+            return null;
+        }
+        if (byteBuffer.hasArray()
+                && byteBuffer.arrayOffset() == 0
+                && byteBuffer.array().length == byteBuffer.remaining()) {
+            return byteBuffer.array();
+        }
+        // Direct buffer is not backed by array and it needs to be read from direct memory
+        byte[] array = new byte[byteBuffer.remaining()];
+        byteBuffer.get(array);
+        return array;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/resources/config-schema.yaml
+++ b/langstream-agents/langstream-ai-agents/src/main/resources/config-schema.yaml
@@ -1,0 +1,472 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+"$schema": http://json-schema.org/draft-04/schema#
+components:
+  schemas:
+    Part:
+      type: object
+      properties:
+        part:
+          type:
+            - string
+            - 'null'
+          description: |
+            When used with KeyValue data, defines if the transformation is done on the `key` or on the `value`.
+            If `null` or absent the transformation applies to both the key and the value.
+          enum:
+            - key
+            - value
+            - null
+    Step:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: The type of transformation step.
+        when:
+          type:
+            - string
+            - 'null'
+          description: The transformation only applies if the 'when' clause evaluates to true.
+          minLength: 1
+      message:
+        minLength: "'when' field must not be empty"
+      discriminator:
+        propertyName: type
+        mapping:
+          drop-fields: "#/components/schemas/DropFields"
+          cast: "#/components/schemas/Cast"
+          merge-key-value: "#/components/schemas/MergeKeyValue"
+          unwrap-key-value: "#/components/schemas/UnwrapKeyValue"
+          flatten: "#/components/schemas/Flatten"
+          drop: "#/components/schemas/Drop"
+          compute: "#/components/schemas/Compute"
+          compute-ai-embeddings: "#/components/schemas/ComputeAiEmbeddings"
+          ai-chat-completions: "#/components/schemas/AiChatCompletions"
+          query: "#/components/schemas/Query"
+    DropFields:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: Drops fields of structured data (Currently only AVRO is supported).
+          properties:
+            type:
+              type: string
+              enum:
+                - drop-fields
+            fields:
+              type: [array, 'null']
+              items:
+                type:
+                  - string
+                minLength: 1
+              description: The list of fields to drop separated by commas `,`
+              message:
+                minLength: "field name in 'fields' must not be empty"
+          required:
+            - type
+            - fields
+        - "$ref": "#/components/schemas/Part"
+    Cast:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - cast
+            schema-type:
+              type:
+                - string
+                - 'null'
+              description: The target schema type.
+              enum:
+                - BYTES
+                - STRING
+                - INT8
+                - INT16
+                - INT32
+                - INT64
+                - FLOAT
+                - DOUBLE
+                - BOOLEAN
+                - DATE
+                - TIMESTAMP
+                - TIME
+                - LOCAL_DATE_TIME
+                - LOCAL_DATE
+                - LOCAL_TIME
+                - INSTANT
+                - null
+          required:
+            - schema-type
+        - "$ref": "#/components/schemas/Part"
+    UnwrapKeyValue:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: |
+            If the record value is a KeyValue, extracts the KeyValue's key or value and make it the record value.
+          properties:
+            type:
+              type: string
+              enum:
+                - unwrap-key-value
+            unwrap-key:
+              type:
+                - boolean
+                - 'null'
+              description: By default, the value is unwrapped. Set this parameter to `true` to unwrap the key instead.
+    MergeKeyValue:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: |
+            Merges the fields of KeyValue records where both the key and value are structured types of the same
+            schema type. (Currently only AVRO is supported).
+          properties:
+            type:
+              type: string
+              enum:
+                - merge-key-value
+    Drop:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: Drops the record.
+          properties:
+            type:
+              type: string
+              enum:
+                - drop
+    Flatten:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: |
+            Converts structured nested data into a new single-hierarchy-level structured data.
+            The names of the new fields are built by concatenating the intermediate level field names.
+          properties:
+            type:
+              type: string
+              enum:
+                - flatten
+            delimiter:
+              type:
+                - string
+                - 'null'
+              description: The delimiter to use when concatenating the field names.
+              default: _
+        - "$ref": "#/components/schemas/Part"
+    Compute:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: Adds or updates fields dynamically based on an expression (Currently only AVRO is supported).
+          properties:
+            type:
+              type: string
+              enum:
+                - compute
+            fields:
+              type: array
+              minItems: 1
+              items:
+                type:
+                  - object
+                properties:
+                  name:
+                    type: string
+                    description: | 
+                      The name of the field to compute. If the field name already exist, it will be overwritten. 
+                      Field names can be either prefixed by 'value.' or 'key.' or can be one of the following 
+                      header values [destinationTopic].
+                    minLength: 1
+                  expression:
+                    type: string
+                    description: An EL-like expression to compute the field value. It can refer to other attributes in the record.
+                    minLength: 1
+                  type:
+                    type:
+                      - string
+                      - 'null'
+                    description: The data type of the computed fields. It should match with the output of the expression.
+                    enum:
+                      - STRING
+                      - INT8
+                      - INT16
+                      - INT32
+                      - INT64
+                      - FLOAT
+                      - DOUBLE
+                      - BOOLEAN
+                      - DATE
+                      - LOCAL_DATE
+                      - TIME
+                      - LOCAL_TIME
+                      - INSTANT
+                      - TIMESTAMP
+                      - LOCAL_DATE_TIME
+                      - DATETIME
+                      - BYTES
+                      - DECIMAL
+                      - null
+                  optional:
+                    type: boolean
+                    description: If true, the generated schema for the computed field will allow for null values.
+                    default: true
+                description: The list of fields to compute
+                required:
+                  - name
+                  - expression
+          required:
+            - type
+            - fields
+        - "$ref": "#/components/schemas/Part"
+    ComputeAiEmbeddings:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: |
+            Compute AI Embeddings for one or more records fields and put the value into a new or existing field.
+          properties:
+            type:
+              type: string
+              enum:
+                - compute-ai-embeddings
+            model:
+              type:
+                - string
+              description: The OpenAI embeddings model to use.
+            embeddings-field:
+              type:
+                - string
+              description: The record field where to inject the computed embeddings value. If the field already exists, it will be used. Note that the field must be a representation of a double's array.
+            compute-service:
+              type:
+                - string
+              description: Service type to use to compute the embeddings. Currently only OpenAI and HuggingFace are supported.
+            model-url:
+              type:
+                - string
+              description: URL of the Hugging Face Model to use. Only used if `compute-service` is set to `huggingface`.
+            text:
+              type:
+                - string
+              description: The text to use to compute the embeddings. Fields and metadata from the message can be used using mustache placeholders.
+          required:
+            - type
+            - model
+            - embeddings-field
+            - text
+        - "$ref": "#/components/schemas/Part"
+    AiChatCompletions:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - ai-chat-completions
+            model:
+              description: ID of the model to use. See the [model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
+              example: "gpt-3.5-turbo"
+              type: string
+            messages:
+              description: A list of messages comprising the conversation so far. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb).
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/ChatMessage'
+            temperature:
+              type: number
+              minimum: 0
+              maximum: 2
+              default: 1
+              example: 1
+              nullable: true
+              description: |
+                What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+
+                We generally recommend altering this or `top_p` but not both.
+            top-p:
+              type: number
+              minimum: 0
+              maximum: 1
+              default: 1
+              example: 1
+              nullable: true
+              description: |
+                An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+
+                We generally recommend altering this or `temperature` but not both.
+            stop:
+              description: |
+                Up to 4 sequences where the API will stop generating further tokens.
+              default: null
+              type: array
+              minItems: 1
+              maxItems: 4
+              items:
+                type: string
+            max-tokens:
+              description: |
+                The maximum number of [tokens](https://platform.openai.com/tokenizer) to generate in the chat completion.
+                
+                The total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.
+              default: inf
+              type: integer
+            presence-penalty:
+              type: number
+              default: 0
+              minimum: -2
+              maximum: 2
+              nullable: true
+              description: |
+                Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.
+
+                [See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)
+            frequency-penalty:
+              type: number
+              default: 0
+              minimum: -2
+              maximum: 2
+              nullable: true
+              description: |
+                Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
+
+                [See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)
+            logit-bias:
+              type: object
+              default: null
+              nullable: true
+              description: |
+                Modify the likelihood of specified tokens appearing in the completion.
+                
+                Accepts a json object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.
+            user:
+              type: string
+              example: user-1234
+              description: |
+                A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
+          required:
+            - model
+            - messages
+
+    ChatMessage:
+      type: object
+      properties:
+        role:
+          type: string
+          enum: [ "system", "user", "assistant" ]
+          description: The role of the messages author. One of `system`, `user` or `assistant`.
+        content:
+          type: string
+          description: The contents of the message.
+      required:
+        - role
+        - content
+
+    Query:
+      allOf:
+        - "$ref": "#/components/schemas/Step"
+        - type: object
+          description: |
+            Execute a Query and put the result into a new or existing field.
+                - query
+        - properties:
+            type:
+              type: string
+              enum:
+                - query
+            query:
+              type:
+                - string
+              description: The query.
+            only-first:
+              type:
+                - boolean
+              description: Instead of returning a list of results, keep only the first record or null in case of empty resultset.
+            output-field:
+              type:
+                - string
+              description: The record field where to inject the computed value. If the field already exists, it will be used. Note that the field must be a representation of an array.
+            fields:
+              type: array
+              items:
+                type:
+                  - string
+              description: The record fields to pass as query parameters.
+        - "$ref": "#/components/schemas/Part"
+
+type: object
+properties:
+  steps:
+    type: array
+    description: The transformation steps executed in order.
+    items:
+      oneOf:
+        - "$ref": "#/components/schemas/DropFields"
+        - "$ref": "#/components/schemas/Cast"
+        - "$ref": "#/components/schemas/UnwrapKeyValue"
+        - "$ref": "#/components/schemas/MergeKeyValue"
+        - "$ref": "#/components/schemas/Drop"
+        - "$ref": "#/components/schemas/Flatten"
+        - "$ref": "#/components/schemas/Compute"
+        - "$ref": "#/components/schemas/ComputeAiEmbeddings"
+        - "$ref": "#/components/schemas/AiChatCompletions"
+        - "$ref": "#/components/schemas/Query"
+  attemptJsonConversion:
+    type: boolean
+    description: |
+      If true, the transformation will attempt to convert internally the record to JSON when the schema is 
+      STRING or BYTES before applying the steps. 
+      The schema will still be STRING or BYTES after the transformation. 
+      This allows to use references to fields in the steps with STRING and BYTES schema payloads.
+      Defaults is true. Use this parameter to disable the JSON conversion for performance reason if you don't need it.
+    default: true
+  openai:
+    type: object
+    description: The OpenAI configuration.
+    properties:
+      url:
+        type:
+          - string
+          - 'null'
+        description: The URL of the OpenAI API. Required if the provider is `azure`.
+      access-key:
+        type: string
+        description: The access key for authentication.
+      provider:
+        type:
+          - string
+          - 'null'
+        description: The provider of the API.
+        enum:
+          - openai
+          - azure
+          - null
+        default: openai
+    required:
+      - access-key
+required:
+  - steps

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.models.ChatCompletions;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Record;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class AIToolsTest {
+
+    @DataProvider(name = "validConfigs")
+    public static Object[][] validConfigs() {
+        return new Object[][] {
+            {
+                "{'steps': [], 'openai': {'access-key': 'qwerty', 'url': 'some-url', 'provider': 'azure'}}"
+            },
+            {"{'steps': [], 'openai': {'access-key': 'qwerty'}}"},
+            {
+                "{'steps': [], 'openai': {'access-key': 'qwerty'}, 'huggingface': {'access-key': 'asdf', 'provider': 'api'} }"
+            },
+            {
+                "{'steps': [], 'openai': {'access-key': 'qwerty'}, 'huggingface': {'provider': 'local'} }"
+            },
+            {
+                "{'steps': [{'type': 'compute-ai-embeddings', 'text': '{{ value }}', 'embeddings-field': 'emb', 'model': 'the-new-model'}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute-ai-embeddings', 'text': '{{ value }}', 'embeddings-field': 'emb', 'model': 'ConGen-BERT-Mini'"
+                        + ", 'compute-service': 'huggingface', 'model-url': 'jar:///ConGen-BERT-Mini.zip'"
+                        + "}],"
+                        + " 'openai': {'access-key': 'qwerty'}, 'huggingface': {'provider': 'local'}}"
+            },
+            {
+                "{"
+                        + "'steps': ["
+                        + "  {"
+                        + "    'type': 'ai-chat-completions',"
+                        + "    'model': 'example_model',"
+                        + "    'messages': ["
+                        + "      {"
+                        + "        'role': 'user',"
+                        + "        'content': 'Hello'"
+                        + "      }"
+                        + "    ],"
+                        + "    'max-tokens': 100,"
+                        + "    'temperature': 0.8,"
+                        + "    'top-p': 0.9,"
+                        + "    'logit-bias': {"
+                        + "      'negative': -1"
+                        + "    },"
+                        + "    'user': 'John',"
+                        + "    'stop': ['bye', 'stop'],"
+                        + "    'presence-penalty': 0.5,"
+                        + "    'frequency-penalty': 0.2"
+                        + "  }"
+                        + "],"
+                        + "'openai': {'access-key': 'qwerty'}"
+                        + "}"
+            },
+            {
+                "{'steps': [{'type': 'ai-chat-completions', 'model': 'example_model', 'messages': [{'role': 'user','content': 'Hello'}]}], 'openai': {'access-key': 'qwerty'}}"
+            }
+        };
+    }
+
+    @Test(dataProvider = "validConfigs")
+    void testValidConfig(String validConfig) {
+        System.setProperty("ALLOWED_HF_URLS", "jar://");
+        log.info("testing valid config: {}", validConfig);
+        String userConfig = validConfig.replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        Context context = new Utils.TestContext(null, config);
+        TransformFunction transformFunction = new TransformFunction();
+        transformFunction.initialize(context);
+    }
+
+    @DataProvider(name = "invalidConfigs")
+    public static Object[][] invalidConfigs() {
+        return new Object[][] {
+            {"{'steps': [], 'openai': {'url': 'some-url'}}"},
+            {"{'steps': [], 'openai': {'provider': 'invalid'}}"},
+            {
+                "{'steps': [{'type': 'compute-ai-embeddings', 'text': '{{ value }}', 'embeddings-field': 'emb'}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute-ai-embeddings', 'text': '{{ value }}', 'model': 'the-new-model'}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute-ai-embeddings', 'embeddings-field': 'emb', 'model': 'the-new-model'}]}"
+            },
+            {
+                "{'steps': [{'type': 'ai-chat-completions', 'model': 'example_model', 'messages': [{'role': 'user','content': 'Hello'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'ai-chat-completions', 'messages': [{'role': 'user','content': 'Hello'}]}], 'openai': {'access-key': 'qwerty'}}"
+            },
+            {
+                "{'steps': [{'type': 'ai-chat-completions', 'model': 'example_model'}], 'openai': {'access-key': 'qwerty'}}"
+            },
+            {
+                "{'steps': [{'type': 'ai-chat-completions', 'model': 'example_model', 'messages': [{'role': 'invalid','content': 'Hello'}]}], 'openai': {'access-key': 'qwerty'}}"
+            },
+            {
+                "{'steps': [{'type': 'ai-chat-completions', 'model': 'example_model', 'messages': [{'content': 'Hello'}]}], 'openai': {'access-key': 'qwerty'}}"
+            }
+        };
+    }
+
+    @Test(dataProvider = "invalidConfigs")
+    void testInvalidConfig(String invalidConfig) {
+
+        String userConfig = invalidConfig.replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        Context context = new Utils.TestContext(null, config);
+        TransformFunction transformFunction = new TransformFunction();
+        assertThrows(IllegalArgumentException.class, () -> transformFunction.initialize(context));
+    }
+
+    @Test
+    void testChatCompletions() throws Exception {
+        String userConfig =
+                (""
+                                + "{"
+                                + "  'steps': ["
+                                + "    {"
+                                + "      'type': 'ai-chat-completions',"
+                                + "      'model': 'test-model',"
+                                + "      'messages': ["
+                                + "        {"
+                                + "          'role': 'user',"
+                                + "          'content': '{{ value.valueField1 }} {{ key.keyField2 }}'"
+                                + "        }"
+                                + "      ]"
+                                + "    }"
+                                + "  ]"
+                                + "}")
+                        .replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = spy(new TransformFunction());
+
+        OpenAIClient client = mock(OpenAIClient.class);
+
+        String completion =
+                (""
+                                + "{"
+                                + "  'choices': ["
+                                + "    {"
+                                + "      'message': {"
+                                + "        'content': 'result',"
+                                + "        'role': 'user'"
+                                + "      }"
+                                + "    }"
+                                + "  ]"
+                                + "}")
+                        .replace("'", "\"");
+        when(client.getChatCompletions(eq("test-model"), any()))
+                .thenReturn(new ObjectMapper().readValue(completion, ChatCompletions.class));
+        when(transformFunction.buildServiceProvider(any()))
+                .thenReturn(new OpenAIServiceProvider(client));
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        transformFunction.process(record.getValue(), context);
+
+        ArgumentCaptor<ChatCompletionsOptions> captor =
+                ArgumentCaptor.forClass(ChatCompletionsOptions.class);
+        verify(client).getChatCompletions(eq("test-model"), captor.capture());
+
+        assertEquals(captor.getValue().getMessages().get(0).getContent(), "value1 key2");
+    }
+
+    @Test
+    void testChatCompletionsWithLogField() throws Exception {
+        String userConfig =
+                (""
+                                + "{"
+                                + "  'steps': ["
+                                + "    {"
+                                + "      'type': 'ai-chat-completions',"
+                                + "      'model': 'test-model',"
+                                + "      'completion-field': 'value.completion',"
+                                + "      'log-field': 'value.log',"
+                                + "      'messages': ["
+                                + "        {"
+                                + "          'role': 'user',"
+                                + "          'content': '{{ value.valueField1 }} {{ key.keyField2 }}'"
+                                + "        }"
+                                + "      ]"
+                                + "    }"
+                                + "  ]"
+                                + "}")
+                        .replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = spy(new TransformFunction());
+
+        OpenAIClient client = mock(OpenAIClient.class);
+
+        String completion =
+                (""
+                                + "{"
+                                + "  'choices': ["
+                                + "    {"
+                                + "      'message': {"
+                                + "        'content': 'result',"
+                                + "        'role': 'user'"
+                                + "      }"
+                                + "    }"
+                                + "  ]"
+                                + "}")
+                        .replace("'", "\"");
+        when(client.getChatCompletions(eq("test-model"), any()))
+                .thenReturn(new ObjectMapper().readValue(completion, ChatCompletions.class));
+        when(transformFunction.buildServiceProvider(any()))
+                .thenReturn(new OpenAIServiceProvider(client));
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals("result", valueAvroRecord.get("completion").toString());
+        assertEquals(
+                valueAvroRecord.get("log").toString(),
+                "{\"options\":{\"max_tokens\":null,\"temperature\":null,\"top_p\":null,\"logit_bias\":null,\"user\":null,\"n\":null,\"stop\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"stream\":null,\"model\":\"test-model\"},\"messages\":[{\"role\":\"user\",\"content\":\"value1 key2\"}],\"model\":\"test-model\"}");
+    }
+
+    @Test
+    void testQuery() throws Exception {
+        String userConfig =
+                (""
+                                + "{'datasource': {'service': 'mock','username': 'test','password': 'testpwd', 'secureBundle':'xx'},"
+                                + "   'steps': ["
+                                + "    {'type': 'query', 'fields': ['key.keyField1'], 'query':'select * from products where description like ?', 'output-field':'value.results'}"
+                                + "]}")
+                        .replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction =
+                new TransformFunction() {
+                    @Override
+                    protected QueryStepDataSource buildDataSource(
+                            DataSourceConfig dataSourceConfig) {
+                        assertEquals(dataSourceConfig.getService(), "mock");
+                        assertEquals(dataSourceConfig.getUsername(), "test");
+                        assertEquals(dataSourceConfig.getPassword(), "testpwd");
+                        assertEquals(dataSourceConfig.getSecureBundle(), "xx");
+
+                        return new QueryStepDataSource() {
+                            @Override
+                            public List<Map<String, String>> fetchData(
+                                    String query, List<Object> params) {
+                                assertEquals(
+                                        "select * from products where description like ?", query);
+                                assertEquals(params.size(), 1);
+                                assertEquals(params.get(0), "key1");
+
+                                return List.of(
+                                        Map.of("productId", "1", "name", "Product1"),
+                                        Map.of("productId", "2", "name", "Product2"));
+                            }
+                        };
+                    }
+                };
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        Object results = valueAvroRecord.get("results");
+        assertNotNull(results);
+        GenericArray array = (GenericArray) results;
+        assertEquals(2, array.size());
+        assertEquals(
+                Map.of(
+                        new Utf8("productId"),
+                        new Utf8("1"),
+                        new Utf8("name"),
+                        new Utf8("Product1")),
+                array.get(0));
+        assertEquals(
+                Map.of(
+                        new Utf8("productId"),
+                        new Utf8("2"),
+                        new Utf8("name"),
+                        new Utf8("Product2")),
+                array.get(1));
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/AIToolsTest.java
@@ -15,15 +15,15 @@
  */
 package com.datastax.oss.pulsar.functions.transforms;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
@@ -45,14 +45,14 @@ import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Record;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 @Slf4j
 public class AIToolsTest {
 
-    @DataProvider(name = "validConfigs")
     public static Object[][] validConfigs() {
         return new Object[][] {
             {
@@ -107,7 +107,9 @@ public class AIToolsTest {
         };
     }
 
-    @Test(dataProvider = "validConfigs")
+
+    @ParameterizedTest
+    @MethodSource("validConfigs")
     void testValidConfig(String validConfig) {
         System.setProperty("ALLOWED_HF_URLS", "jar://");
         log.info("testing valid config: {}", validConfig);
@@ -119,7 +121,8 @@ public class AIToolsTest {
         transformFunction.initialize(context);
     }
 
-    @DataProvider(name = "invalidConfigs")
+    @ParameterizedTest
+    @MethodSource("invalidConfigs")
     public static Object[][] invalidConfigs() {
         return new Object[][] {
             {"{'steps': [], 'openai': {'url': 'some-url'}}"},
@@ -151,7 +154,8 @@ public class AIToolsTest {
         };
     }
 
-    @Test(dataProvider = "invalidConfigs")
+    @ParameterizedTest
+    @MethodSource("invalidConfigs")
     void testInvalidConfig(String invalidConfig) {
 
         String userConfig = invalidConfig.replace("'", "\"");

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/GenAITest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/GenAITest.java
@@ -16,14 +16,14 @@
 package com.datastax.oss.pulsar.functions.transforms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
@@ -45,13 +45,13 @@ import org.apache.pulsar.client.api.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Record;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class AIToolsTest {
+public class GenAITest {
 
     public static Object[][] validConfigs() {
         return new Object[][] {
@@ -107,7 +107,6 @@ public class AIToolsTest {
         };
     }
 
-
     @ParameterizedTest
     @MethodSource("validConfigs")
     void testValidConfig(String validConfig) {
@@ -121,8 +120,6 @@ public class AIToolsTest {
         transformFunction.initialize(context);
     }
 
-    @ParameterizedTest
-    @MethodSource("invalidConfigs")
     public static Object[][] invalidConfigs() {
         return new Object[][] {
             {"{'steps': [], 'openai': {'url': 'some-url'}}"},

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.getTransformSteps;
+
+import com.datastax.oss.streaming.ai.JsonNodeSchema;
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.TransformStep;
+import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import com.datastax.oss.streaming.ai.jstl.predicate.StepPredicatePair;
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import com.datastax.oss.streaming.ai.model.config.TransformStepConfig;
+import com.datastax.oss.streaming.ai.services.HuggingFaceServiceProvider;
+import com.datastax.oss.streaming.ai.services.OpenAIServiceProvider;
+import com.datastax.oss.streaming.ai.services.ServiceProvider;
+import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.urn.URNFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Function;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.utils.FunctionRecord;
+
+/**
+ * <code>TransformFunction</code> is a {@link Function} that provides an easy way to apply a set of
+ * usual basic transformations to the data.
+ *
+ * <p>It provides the following transformations:
+ *
+ * <ul>
+ *   <li><code>cast</code>: modifies the key or value schema to a target compatible schema passed in
+ *       the <code>schema-type</code> argument. This PR only enables <code>STRING</code>
+ *       schema-type. The <code>part</code> argument allows to choose on which part to apply between
+ *       <code>key</code> and <code>value</code>. If <code>part</code> is null or absent the
+ *       transformations applies to both the key and value.
+ *   <li><code>drop-fields</code>: drops fields given as a string list in parameter <code>fields
+ *       </code>. The <code>part</code> argument allows to choose on which part to apply between
+ *       <code>key</code> and <code>value</code>. If <code>part</code> is null or absent the
+ *       transformations applies to both the key and value. Currently only AVRO is supported.
+ *   <li><code>merge-key-value</code>: merges the fields of KeyValue records where both the key and
+ *       value are structured types of the same schema type. Currently only AVRO is supported.
+ *   <li><code>unwrap-key-value</code>: if the record is a KeyValue, extract the KeyValue's value
+ *       and make it the record value. If parameter <code>unwrapKey</code> is present and set to
+ *       <code>true</code>, extract the KeyValue's key instead.
+ *   <li><code>flatten</code>: flattens a nested structure selected in the <code>part</code> by
+ *       concatenating nested field names with a <code>delimiter</code> and populating them as top
+ *       level fields. <code>
+ *       delimiter</code> defaults to '_'. <code>part</code> could be any of <code>key</code> or
+ *       <code>value</code>. If not specified, flatten will apply to key and value.
+ *   <li><code>drop</code>: drops the message from further processing. Use in conjunction with
+ *       <code>when</code> to selectively drop messages.
+ *   <li><code>compute</code>: dynamically calculates <code>fields</code> values in the key, value
+ *       or header. Each field has a <code>name</code> to represents a new or existing field (in
+ *       this case, it will be overwritten). The value of the fields is evaluated by the <code>
+ *       expression</code> and respect the <code>type</code>. Supported types are [INT32, INT64,
+ *       FLOAT, DOUBLE, BOOLEAN, DATE, TIME, DATETIME]. Each field is marked as nullable by default.
+ *       To mark the field as non-nullable in the output schema, set <code>optional</code> to false.
+ * </ul>
+ *
+ * <p>The <code>TransformFunction</code> reads its configuration as Json from the {@link Context}
+ * <code>userConfig</code> in the format:
+ *
+ * <pre><code class="lang-json">
+ * {
+ *   "steps": [
+ *     {
+ *       "type": "cast", "schema-type": "STRING"
+ *     },
+ *     {
+ *       "type": "drop-fields", "fields": ["keyField1", "keyField2"], "part": "key"
+ *     },
+ *     {
+ *       "type": "merge-key-value"
+ *     },
+ *     {
+ *       "type": "unwrap-key-value"
+ *     },
+ *     {
+ *       "type": "flatten", "delimiter" : "_" "part" : "value", "when": "value.field == 'value'"
+ *     },
+ *     {
+ *       "type": "drop", "when": "value.field == 'value'"
+ *     },
+ *     {
+ *       "type": "compute", "fields": [{"name": "value.new-field", "expression": "key.existing-field == 'value'", "type": "BOOLEAN"}]
+ *     }
+ *   ]
+ * }
+ * </code></pre>
+ *
+ * @see <a href="https://github.com/apache/pulsar/issues/15902">PIP-173 : Create a built-in Function
+ *     implementing the most common basic transformations</a>
+ */
+@Slf4j
+public class TransformFunction
+        implements Function<GenericObject, Record<GenericObject>>, TransformStep {
+    private List<StepPredicatePair> steps;
+    private TransformStepConfig transformConfig;
+    private QueryStepDataSource dataSource;
+    private ServiceProvider serviceProvider;
+
+    @Override
+    @SneakyThrows
+    public void initialize(Context context) {
+        Map<String, Object> userConfigMap = context.getUserConfigMap();
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        JsonNode jsonNode = mapper.convertValue(userConfigMap, JsonNode.class);
+
+        URNFactory urnFactory =
+                urn -> {
+                    try {
+                        URL absoluteURL =
+                                Thread.currentThread().getContextClassLoader().getResource(urn);
+                        return absoluteURL.toURI();
+                    } catch (Exception ex) {
+                        return null;
+                    }
+                };
+        JsonSchemaFactory factory =
+                JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
+                        .objectMapper(mapper)
+                        .addUrnFactory(urnFactory)
+                        .build();
+        SchemaValidatorsConfig jsonSchemaConfig = new SchemaValidatorsConfig();
+        jsonSchemaConfig.setLosslessNarrowing(true);
+        InputStream is =
+                Thread.currentThread()
+                        .getContextClassLoader()
+                        .getResourceAsStream("config-schema.yaml");
+
+        JsonSchema schema = factory.getSchema(is, jsonSchemaConfig);
+        Set<ValidationMessage> errors = schema.validate(jsonNode);
+
+        if (errors.size() != 0) {
+            if (!jsonNode.hasNonNull("steps")) {
+                throw new IllegalArgumentException("Missing config 'steps' field");
+            }
+            JsonNode steps = jsonNode.get("steps");
+            if (!steps.isArray()) {
+                throw new IllegalArgumentException("Config 'steps' field must be an array");
+            }
+            String errorMessage = null;
+            try {
+                for (JsonNode step : steps) {
+                    String type = step.get("type").asText();
+                    JsonSchema stepSchema =
+                            factory.getSchema(
+                                    String.format(
+                                            "{\"$ref\": \"config-schema.yaml#/components/schemas/%s\"}",
+                                            kebabToPascal(type)));
+
+                    errorMessage =
+                            stepSchema.validate(step).stream()
+                                    .findFirst()
+                                    .map(
+                                            v ->
+                                                    String.format(
+                                                            "Invalid '%s' step config: %s",
+                                                            type, v))
+                                    .orElse(null);
+                    if (errorMessage != null) {
+                        break;
+                    }
+                }
+            } catch (Exception e) {
+                log.debug("Exception during steps validation, ignoring", e);
+            }
+
+            if (errorMessage != null) {
+                throw new IllegalArgumentException(errorMessage);
+            }
+
+            errors.stream()
+                    .findFirst()
+                    .ifPresent(
+                            validationMessage -> {
+                                throw new IllegalArgumentException(
+                                        "Configuration validation failed: " + validationMessage);
+                            });
+        }
+
+        transformConfig = mapper.convertValue(userConfigMap, TransformStepConfig.class);
+
+        serviceProvider = buildServiceProvider(transformConfig);
+        dataSource = buildDataSource(transformConfig.getDatasource());
+
+        steps = getTransformSteps(transformConfig, serviceProvider, dataSource);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+        if (serviceProvider != null) {
+            serviceProvider.close();
+        }
+        for (StepPredicatePair pair : steps) {
+            pair.getTransformStep().close();
+        }
+    }
+
+    @Override
+    public Record<GenericObject> process(GenericObject input, Context context) throws Exception {
+        Object nativeObject = input.getNativeObject();
+        if (log.isDebugEnabled()) {
+            Record<?> currentRecord = context.getCurrentRecord();
+            log.debug("apply to {} {}", input, nativeObject);
+            log.debug(
+                    "record with schema {} version {} {}",
+                    currentRecord.getSchema(),
+                    currentRecord.getMessage().orElseThrow().getSchemaVersion(),
+                    currentRecord);
+        }
+
+        TransformContext transformContext =
+                newTransformContext(
+                        context, nativeObject, transformConfig.isAttemptJsonConversion());
+        process(transformContext);
+        return send(context, transformContext);
+    }
+
+    public static TransformContext newTransformContext(
+            Context context, Object value, boolean attemptJsonConversion) {
+        Record<?> currentRecord = context.getCurrentRecord();
+        TransformContext transformContext = new TransformContext();
+        transformContext.setInputTopic(currentRecord.getTopicName().orElse(null));
+        transformContext.setOutputTopic(currentRecord.getDestinationTopic().orElse(null));
+        transformContext.setKey(currentRecord.getKey().orElse(null));
+        transformContext.setEventTime(currentRecord.getEventTime().orElse(null));
+
+        if (currentRecord.getProperties() != null) {
+            transformContext.setProperties(new HashMap<>(currentRecord.getProperties()));
+        }
+
+        Schema<?> schema = currentRecord.getSchema();
+        if (schema instanceof KeyValueSchema && value instanceof KeyValue) {
+            KeyValueSchema<?, ?> kvSchema = (KeyValueSchema<?, ?>) schema;
+            KeyValue<?, ?> kv = (KeyValue<?, ?>) value;
+            Schema<?> keySchema = kvSchema.getKeySchema();
+            Schema<?> valueSchema = kvSchema.getValueSchema();
+            transformContext.setKeySchemaType(pulsarSchemaToTransformSchemaType(keySchema));
+            transformContext.setKeyNativeSchema(getNativeSchema(keySchema));
+            transformContext.setKeyObject(
+                    keySchema.getSchemaInfo().getType().isStruct()
+                            ? ((GenericObject) kv.getKey()).getNativeObject()
+                            : kv.getKey());
+            transformContext.setValueSchemaType(pulsarSchemaToTransformSchemaType(valueSchema));
+            transformContext.setValueNativeSchema(getNativeSchema(valueSchema));
+            transformContext.setValueObject(
+                    valueSchema.getSchemaInfo().getType().isStruct()
+                            ? ((GenericObject) kv.getValue()).getNativeObject()
+                            : kv.getValue());
+            transformContext
+                    .getCustomContext()
+                    .put("keyValueEncodingType", kvSchema.getKeyValueEncodingType());
+        } else {
+            transformContext.setValueSchemaType(pulsarSchemaToTransformSchemaType(schema));
+            transformContext.setValueNativeSchema(getNativeSchema(schema));
+            transformContext.setValueObject(value);
+        }
+        if (attemptJsonConversion) {
+            transformContext.setKeyObject(
+                    TransformFunctionUtil.attemptJsonConversion(transformContext.getKeyObject()));
+            transformContext.setValueObject(
+                    TransformFunctionUtil.attemptJsonConversion(transformContext.getValueObject()));
+        }
+        return transformContext;
+    }
+
+    private static Object getNativeSchema(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        return schema.getNativeSchema().orElse(null);
+    }
+
+    private static TransformSchemaType pulsarSchemaToTransformSchemaType(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        switch (schema.getSchemaInfo().getType()) {
+            case INT8:
+                return TransformSchemaType.INT8;
+            case INT16:
+                return TransformSchemaType.INT16;
+            case INT32:
+                return TransformSchemaType.INT32;
+            case INT64:
+                return TransformSchemaType.INT64;
+            case FLOAT:
+                return TransformSchemaType.FLOAT;
+            case DOUBLE:
+                return TransformSchemaType.DOUBLE;
+            case BOOLEAN:
+                return TransformSchemaType.BOOLEAN;
+            case STRING:
+                return TransformSchemaType.STRING;
+            case BYTES:
+                return TransformSchemaType.BYTES;
+            case DATE:
+                return TransformSchemaType.DATE;
+            case TIME:
+                return TransformSchemaType.TIME;
+            case TIMESTAMP:
+                return TransformSchemaType.TIMESTAMP;
+            case INSTANT:
+                return TransformSchemaType.INSTANT;
+            case LOCAL_DATE:
+                return TransformSchemaType.LOCAL_DATE;
+            case LOCAL_TIME:
+                return TransformSchemaType.LOCAL_TIME;
+            case LOCAL_DATE_TIME:
+                return TransformSchemaType.LOCAL_DATE_TIME;
+            case JSON:
+                return TransformSchemaType.JSON;
+            case AVRO:
+                return TransformSchemaType.AVRO;
+            case PROTOBUF:
+                return TransformSchemaType.PROTOBUF;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported schema type " + schema.getSchemaInfo().getType());
+        }
+    }
+
+    @Override
+    public void process(TransformContext transformContext) throws Exception {
+        TransformFunctionUtil.processTransformSteps(transformContext, steps);
+    }
+
+    public static Record<GenericObject> send(Context context, TransformContext transformContext)
+            throws IOException {
+        if (transformContext.isDropCurrentRecord()) {
+            return null;
+        }
+        transformContext.convertAvroToBytes();
+        transformContext.convertMapToStringOrBytes();
+
+        Schema outputSchema;
+        Object outputObject;
+        if (transformContext.getKeySchemaType() != null) {
+            KeyValueEncodingType keyValueEncodingType =
+                    (KeyValueEncodingType)
+                            transformContext.getCustomContext().get("keyValueEncodingType");
+            outputSchema =
+                    Schema.KeyValue(
+                            buildSchema(
+                                    transformContext.getKeySchemaType(),
+                                    transformContext.getKeyNativeSchema()),
+                            buildSchema(
+                                    transformContext.getValueSchemaType(),
+                                    transformContext.getValueNativeSchema()),
+                            keyValueEncodingType != null
+                                    ? keyValueEncodingType
+                                    : KeyValueEncodingType.INLINE);
+            Object outputKeyObject = transformContext.getKeyObject();
+            Object outputValueObject = transformContext.getValueObject();
+            outputObject = new KeyValue<>(outputKeyObject, outputValueObject);
+        } else {
+            outputSchema =
+                    buildSchema(
+                            transformContext.getValueSchemaType(),
+                            transformContext.getValueNativeSchema());
+            outputObject = transformContext.getValueObject();
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("output {} schema {}", outputObject, outputSchema);
+        }
+
+        FunctionRecord.FunctionRecordBuilder<GenericObject> recordBuilder =
+                context.newOutputRecordBuilder(outputSchema)
+                        .destinationTopic(transformContext.getOutputTopic())
+                        .value(outputObject)
+                        .properties(transformContext.getProperties());
+
+        if (transformContext.getKeySchemaType() == null && transformContext.getKey() != null) {
+            recordBuilder.key(transformContext.getKey());
+        }
+
+        return recordBuilder.build();
+    }
+
+    private static Schema<?> buildSchema(TransformSchemaType schemaType, Object nativeSchema) {
+        if (schemaType == null) {
+            throw new IllegalArgumentException("Schema type should not be null.");
+        }
+        switch (schemaType) {
+            case INT8:
+                return Schema.INT8;
+            case INT16:
+                return Schema.INT16;
+            case INT32:
+                return Schema.INT32;
+            case INT64:
+                return Schema.INT64;
+            case FLOAT:
+                return Schema.FLOAT;
+            case DOUBLE:
+                return Schema.DOUBLE;
+            case BOOLEAN:
+                return Schema.BOOL;
+            case STRING:
+                return Schema.STRING;
+            case BYTES:
+                return Schema.BYTES;
+            case DATE:
+                return Schema.DATE;
+            case TIME:
+                return Schema.TIME;
+            case TIMESTAMP:
+                return Schema.TIMESTAMP;
+            case INSTANT:
+                return Schema.INSTANT;
+            case LOCAL_DATE:
+                return Schema.LOCAL_DATE;
+            case LOCAL_TIME:
+                return Schema.LOCAL_TIME;
+            case LOCAL_DATE_TIME:
+                return Schema.LOCAL_DATE_TIME;
+            case AVRO:
+                return Schema.NATIVE_AVRO(nativeSchema);
+            case JSON:
+                return new JsonNodeSchema((org.apache.avro.Schema) nativeSchema);
+            default:
+                throw new IllegalArgumentException("Unsupported schema type " + schemaType);
+        }
+    }
+
+    private static String kebabToPascal(String kebab) {
+        return Pattern.compile("(?:^|-)(.)")
+                .matcher(kebab)
+                .replaceAll(mr -> mr.group(1).toUpperCase());
+    }
+
+    protected ServiceProvider buildServiceProvider(TransformStepConfig config) {
+        if (config != null) {
+            if (config.getOpenai() != null) {
+                return new OpenAIServiceProvider(config);
+            }
+            if (config.getHuggingface() != null) {
+                return new HuggingFaceServiceProvider(config);
+            }
+        }
+        return new ServiceProvider.NoopServiceProvider();
+    }
+
+    protected QueryStepDataSource buildDataSource(DataSourceConfig dataSourceConfig) {
+        return TransformFunctionUtil.buildDataSource(dataSourceConfig);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
@@ -18,8 +18,8 @@ package com.datastax.oss.pulsar.functions.transforms;
 import static com.datastax.oss.pulsar.functions.transforms.Utils.assertNonOptionalField;
 import static com.datastax.oss.pulsar.functions.transforms.Utils.assertOptionalField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.datastax.oss.streaming.ai.TransformContext;
 import com.google.gson.Gson;
@@ -138,8 +138,6 @@ public class TransformFunctionTest {
         transformFunction.initialize(context);
     }
 
-    @ParameterizedTest
-    @MethodSource("invalidConfigs")
     public static Object[][] invalidConfigs() {
         return new Object[][] {
             {"{}"},
@@ -463,8 +461,6 @@ public class TransformFunctionTest {
         }
     }
 
-    @ParameterizedTest
-    @MethodSource("dropStepConfigs")
     public static Object[][] dropStepConfigs() {
         return new Object[][] {
             {

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
@@ -1,0 +1,557 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static com.datastax.oss.pulsar.functions.transforms.Utils.assertNonOptionalField;
+import static com.datastax.oss.pulsar.functions.transforms.Utils.assertOptionalField;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.AssertJUnit.assertNull;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class TransformFunctionTest {
+
+    @DataProvider(name = "validConfigs")
+    public static Object[][] validConfigs() {
+        return new Object[][] {
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field']}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'part': 'key'}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'part': 'value'}]}"},
+            {
+                "{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'when': 'key.k1==key1'}]}"
+            },
+            {
+                "{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'part': null, 'when': null}]}"
+            },
+            {"{'steps': [{'type': 'merge-key-value'}]}"},
+            {"{'steps': [{'type': 'unwrap-key-value'}]}"},
+            {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': false}]}"},
+            {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': true}]}"},
+            {
+                "{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': true, 'when': 'value.v1==val1'}]}"
+            },
+            {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': null, 'when': null}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING'}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'key'}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'value'}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'when': 'value.v1==val1'}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': null, 'when': null}]}"},
+            {"{'steps': [{'type': 'flatten'}]}"},
+            {"{'steps': [{'type': 'flatten', 'part': 'key'}]}"},
+            {"{'steps': [{'type': 'flatten', 'part': 'value'}]}"},
+            {"{'steps': [{'type': 'flatten', 'delimiter': '_'}]}"},
+            {"{'steps': [{'type': 'flatten', 'when': 'prop1==val1'}]}"},
+            {"{'steps': [{'type': 'flatten', 'delimiter': null, 'part': null, 'when': null}]}"},
+            {"{'steps': [{'type': 'drop', 'when': null}]}"},
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.some-field', expression: 'true', type: 'BOOLEAN'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'key.some-field', expression: 'string', type: 'STRING'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.some-field', expression: 'int32', type: 'INT32'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'key.some-field', expression: 'int64', type: 'INT64'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.some-field', expression: 'f', type: 'FLOAT'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'key.some-field', expression: 'd', optional: true, type: 'DOUBLE'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'destinationTopic', expression: 'string', optional: true, type: 'STRING'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'destinationTopic', expression: 'date', optional: true, type: 'DATE'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'destinationTopic', expression: 'time', optional: true, type: 'TIME'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'destinationTopic', expression: 'datetime', optional: true, type: 'DATETIME'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value', expression: 'bytes', optional: true, type: 'BYTES'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value', expression: 'value', type: 'STRING'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'key', expression: 'key', type: 'STRING'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.field1', expression: '1234', type: 'DATE'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.field1', expression: 'value.field1', type: 'DECIMAL'}]}]}"
+            }
+        };
+    }
+
+    @Test(dataProvider = "validConfigs")
+    void testValidConfig(String validConfig) {
+        String userConfig = validConfig.replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        Context context = new Utils.TestContext(null, config);
+        TransformFunction transformFunction = new TransformFunction();
+        transformFunction.initialize(context);
+    }
+
+    @DataProvider(name = "invalidConfigs")
+    public static Object[][] invalidConfigs() {
+        return new Object[][] {
+            {"{}"},
+            {"{'steps': 'invalid'}"},
+            {"{'steps': [{}]}"},
+            {"{'steps': [{'type': 'invalid'}]}"},
+            {"{'steps': [{'type': 'drop-fields'}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['']}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'part': 'invalid'}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field', 42]}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'part': 42}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'part': 42}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field'], 'when': ''}]}"},
+            {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field']}, {'type': 'cast'}]}"},
+            {"{'steps': [{'type': 'unwrap-key-value', 'unwrap-key': 'invalid'}]}"},
+            {"{'steps': [{'type': 'unwrap-key-value', 'when': ''}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 42}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'INVALID'}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 'invalid'}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 42}]}"},
+            {"{'steps': [{'type': 'cast', 'schema-type': 'STRING', 'part': 42}], 'when': ''}"},
+            {"{'steps': [{'type': 'flatten', 'part': 'invalid'}]}"},
+            {"{'steps': [{'type': 'flatten', 'when': ''}]}"},
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', expression: 'true', type: 'BOOLEAN'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', expression: 'true', type: 'BOOLEAN'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', expression: 'true', type: 'BOOLEAN'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', expression: 'record', type: 'AVRO'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', expression: 'json', type: 'JSON', part: 'key'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', expression: 'int32', type: 'INT32', part: 'non-key-or-value'}]}]}"
+            },
+            {"{'steps': [{'type': 'compute', 'fields': [{expression: 'int64', type: 'INT64'}]}]}"},
+            {"{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', type: 'FLOAT'}]}]}"},
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'some-field', expression: 'double'}]}]}"
+            },
+            {"{'steps': [{'type': 'compute', 'fields': null}]}"},
+            {"{'steps': [{'type': 'compute', 'fields': []}]}"},
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': '', expression: 'double', type: 'DOUBLE'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.some-field', expression: '', type: 'DOUBLE'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.some-field', expression: 'double', optional: 'true', type: 'DOUBLE'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value.some-field', expression: 'true', type: 'BOOLEAN'}, {'name': 'value.some-field', expression: 'true', type: 'STRING'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'key.some-field', expression: 'true', type: 'BOOLEAN'}, {'name': 'key.some-field', expression: 'true', type: 'STRING'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value', expression: 'true', type: 'BOOLEAN'}, {'name': 'value', expression: 'true', type: 'STRING'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'value', expression: '1234', type: 'DATE'}]}]}"
+            },
+            {
+                "{'steps': [{'type': 'compute', 'fields': [{'name': 'key', expression: '1234', type: 'DATE'}]}]}"
+            }
+        };
+    }
+
+    @Test(dataProvider = "invalidConfigs")
+    void testInvalidConfig(String invalidConfig) {
+        String userConfig = invalidConfig.replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        Context context = new Utils.TestContext(null, config);
+        TransformFunction transformFunction = new TransformFunction();
+        assertThrows(IllegalArgumentException.class, () -> transformFunction.initialize(context));
+    }
+
+    @Test
+    void testDropFields() throws Exception {
+        String userConfig =
+                (""
+                                + "{'steps': ["
+                                + "    {'type': 'drop-fields', 'fields': ['keyField1']},"
+                                + "    {'type': 'drop-fields', 'fields': ['keyField2'], 'part': 'key'},"
+                                + "    {'type': 'drop-fields', 'fields': ['keyField3'], 'part': 'value'},"
+                                + "    {'type': 'drop-fields', 'fields': ['valueField1']},"
+                                + "    {'type': 'drop-fields', 'fields': ['valueField2'], 'part': 'key'},"
+                                + "    {'type': 'drop-fields', 'fields': ['valueField3'], 'part': 'value'}"
+                                + "]}")
+                        .replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyAvroRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(keyAvroRecord.get("keyField3"), new Utf8("key3"));
+        assertNull(keyAvroRecord.getSchema().getField("keyField1"));
+        assertNull(keyAvroRecord.getSchema().getField("keyField2"));
+
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals(valueAvroRecord.get("valueField2"), new Utf8("value2"));
+        assertNull(valueAvroRecord.getSchema().getField("valueField1"));
+        assertNull(valueAvroRecord.getSchema().getField("valueField3"));
+    }
+
+    @Test
+    void testComputeFields() throws Exception {
+        String userConfig =
+                (""
+                                + "{'steps': ["
+                                + "    {'type': 'compute', 'fields':["
+                                + "        {'name': 'key.newField1', 'expression' : '5*3', 'type': 'INT32'},"
+                                + "        {'name': 'key.newField2', 'expression' : 'value.valueField1', 'type': 'STRING', 'optional' : false},"
+                                + "        {'name': 'value.newField1', 'expression' : '5+3', 'type': 'INT32'},"
+                                + "        {'name': 'value.newField2', 'expression' : 'value.valueField1', 'type': 'STRING', 'optional' : false}"
+                                + "    ]}"
+                                + "]}")
+                        .replace("'", "\"");
+
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyAvroRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(keyAvroRecord.get("keyField1"), new Utf8("key1"));
+        assertEquals(keyAvroRecord.get("keyField2"), new Utf8("key2"));
+        assertEquals(keyAvroRecord.get("keyField3"), new Utf8("key3"));
+        assertOptionalField(keyAvroRecord, "newField1", org.apache.avro.Schema.Type.INT, 15);
+        assertNonOptionalField(
+                keyAvroRecord, "newField2", org.apache.avro.Schema.Type.STRING, new Utf8("value1"));
+
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals(valueAvroRecord.get("valueField1"), new Utf8("value1"));
+        assertEquals(valueAvroRecord.get("valueField2"), new Utf8("value2"));
+        assertEquals(valueAvroRecord.get("valueField3"), new Utf8("value3"));
+        assertOptionalField(valueAvroRecord, "newField1", org.apache.avro.Schema.Type.INT, 8);
+        assertNonOptionalField(
+                valueAvroRecord,
+                "newField2",
+                org.apache.avro.Schema.Type.STRING,
+                new Utf8("value1"));
+    }
+
+    @Test
+    void testComputeWithoutType() throws Exception {
+        String userConfig =
+                (""
+                                + "{`steps`: ["
+                                + "    {`type`: `compute`, `fields`:["
+                                + "        {`name`: `destinationTopic`, `expression` : `'routed'`},"
+                                + "        {`name`: `messageKey`, `expression` : `'newKey'`},"
+                                + "        {`name`: `properties.foo`, `expression` : `'bar'`}"
+                                + "    ]}"
+                                + "]}")
+                        .replace("`", "\"");
+
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        Record<GenericObject> record = Utils.createNestedAvroRecord(1, "");
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        assertEquals(outputRecord.getDestinationTopic().orElseThrow(), "routed");
+        assertEquals(outputRecord.getKey().orElseThrow(), "newKey");
+        assertEquals(outputRecord.getProperties().get("foo"), "bar");
+    }
+
+    @Test
+    void testMatchingPredicate() throws Exception {
+        String userConfig =
+                (""
+                        + "{\"steps\": ["
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"keyField1\"], \"when\": \"key.keyField1 == 'key1'\"},"
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"keyField2\"], \"when\": \"key.keyField2 == 'key2'\"}"
+                        + "]}");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyAvroRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(keyAvroRecord.get("keyField3"), new Utf8("key3"));
+        assertNull(keyAvroRecord.getSchema().getField("keyField1"));
+        assertNull(keyAvroRecord.getSchema().getField("keyField2"));
+    }
+
+    @Test
+    void testNonMatchingPredicate() throws Exception {
+        String userConfig =
+                (""
+                        + "{\"steps\": ["
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"keyField1\"], \"when\": \"key.keyField1 == 'key100'\"},"
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"keyField2\"], \"when\": \"key.keyField2 == 'key100'\"},"
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"keyField3\"]}"
+                        + "]}");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        transformFunction.process(record.getValue(), context);
+
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyAvroRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(keyAvroRecord.get("keyField1"), new Utf8("key1"));
+        assertEquals(keyAvroRecord.get("keyField2"), new Utf8("key2"));
+        assertNull(keyAvroRecord.getSchema().getField("keyField3"));
+    }
+
+    @Test
+    void testMixedPredicate() throws Exception {
+        String userConfig =
+                (""
+                        + "{\"steps\": ["
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"keyField1\"], \"when\": \"key.keyField1 == 'key1'\"},"
+                        + "    {\"type\": \"merge-key-value\", \"when\": \"key.keyField2 == 'key100'\"},"
+                        + "    {\"type\": \"unwrap-key-value\", \"when\": \"key.keyField3 == 'key100'\"},"
+                        + "    {\"type\": \"cast\", \"schema-type\": \"STRING\", \"when\": \"value.valueField1 == 'value1'\"}"
+                        + "]}");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+
+        Record<GenericObject> outputRecord = transformFunction.process(record.getValue(), context);
+
+        KeyValue<?, ?> kv = (KeyValue<?, ?>) outputRecord.getValue();
+        assertEquals(kv.getKey(), "{\"keyField2\":\"key2\",\"keyField3\":\"key3\"}");
+        assertEquals(
+                kv.getValue(),
+                "{\"valueField1\":\"value1\",\"valueField2\":\"value2\",\"valueField3\":\"value3\"}");
+    }
+
+    @Test(dataProvider = "dropStepConfigs")
+    void testDropOnPredicateMatch(String stepConfig, boolean drop) throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+        Map<String, Object> config =
+                new Gson().fromJson(stepConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        if (drop) {
+            assertNull(outputRecord);
+        } else {
+            GenericData.Record read =
+                    Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+            assertEquals(read.get("age"), 42);
+            Assert.assertNull(read.getSchema().getField("firstName"));
+            Assert.assertNull(read.getSchema().getField("lastName"));
+        }
+    }
+
+    @DataProvider(name = "dropStepConfigs")
+    public static Object[][] dropStepConfigs() {
+        return new Object[][] {
+            {
+                (""
+                        + "{\"steps\": ["
+                        + "    {\"type\": \"drop\", \"when\": \"value.firstName=='Jane' || value.lastName=='Doe'\"},"
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"firstName\"]},"
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"lastName\"]}"
+                        + "]}"),
+                true
+            },
+            {
+                (""
+                        + "{\"steps\": ["
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"firstName\"]},"
+                        + "    {\"type\": \"drop\", \"when\": \"value.firstName=='Jane' || value.lastName=='Doe'\"},"
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"lastName\"]}"
+                        + "]}"),
+                true
+            },
+            {
+                (""
+                        + "{\"steps\": ["
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"firstName\"]},"
+                        + "    {\"type\": \"drop-fields\", \"fields\": [\"lastName\"]},"
+                        + "    {\"type\": \"drop\", \"when\": \"value.firstName=='Jane' || value.lastName=='Doe'\"}"
+                        + "]}"),
+                false
+            }
+        };
+    }
+
+    // TODO: just for demo. To be removed
+    @Test
+    void testRemoveMergeAndToString() throws Exception {
+        String userConfig =
+                (""
+                                + "{'steps': ["
+                                + "    {'type': 'drop-fields', 'fields': ['keyField1']},"
+                                + "    {'type': 'merge-key-value'},"
+                                + "    {'type': 'unwrap-key-value'},"
+                                + "    {'type': 'cast', 'schema-type': 'STRING'}"
+                                + "]}")
+                        .replace("'", "\"");
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Utils.TestContext context = new Utils.TestContext(record, config);
+        transformFunction.initialize(context);
+        Record<?> outputRecord = transformFunction.process(record.getValue(), context);
+
+        assertEquals(
+                outputRecord.getValue(),
+                "{\"keyField2\":\"key2\",\"keyField3\":\"key3\",\"valueField1\":"
+                        + "\"value1\",\"valueField2\":\"value2\",\"valueField3\":\"value3\"}");
+    }
+
+    @Test
+    void testComputeFilterList() throws Exception {
+        String userConfig =
+                (""
+                                + "{'steps': ["
+                                + "    {'type': 'compute', 'fields':["
+                                + "        {'name': 'value.newQueryResults', 'expression' : 'fn:filter(value.queryResults, \\'true\\')'}"
+                                + "    ]}"
+                                + "]}")
+                        .replace("'", "\"");
+
+        Map<String, Object> config =
+                new Gson().fromJson(userConfig, new TypeToken<Map<String, Object>>() {}.getType());
+        TransformFunction transformFunction = new TransformFunction();
+
+        String value = "{\"queryResults\":[{\"v1\":\"v2\"}]}";
+        Utils.TestRecord<String> testRecord = new Utils.TestRecord<>(Schema.STRING, value, null);
+        Utils.TestContext context = new Utils.TestContext(testRecord, config);
+        transformFunction.initialize(context);
+        TransformContext transformContext =
+                TransformFunction.newTransformContext(context, value, true);
+        transformFunction.process(transformContext);
+        log.info(
+                "result: {} {}",
+                transformContext.getValueObject(),
+                transformContext.getValueObject().getClass());
+        assertEquals(
+                Map.of(
+                        "queryResults",
+                        List.of(Map.of("v1", "v2")),
+                        "newQueryResults",
+                        List.of(Map.of("v1", "v2"))),
+                transformContext.getValueObject());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunctionTest.java
@@ -17,9 +17,9 @@ package com.datastax.oss.pulsar.functions.transforms;
 
 import static com.datastax.oss.pulsar.functions.transforms.Utils.assertNonOptionalField;
 import static com.datastax.oss.pulsar.functions.transforms.Utils.assertOptionalField;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
-import static org.testng.AssertJUnit.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.datastax.oss.streaming.ai.TransformContext;
 import com.google.gson.Gson;
@@ -41,14 +41,13 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Slf4j
 public class TransformFunctionTest {
 
-    @DataProvider(name = "validConfigs")
     public static Object[][] validConfigs() {
         return new Object[][] {
             {"{'steps': [{'type': 'drop-fields', 'fields': ['some-field']}]}"},
@@ -128,7 +127,8 @@ public class TransformFunctionTest {
         };
     }
 
-    @Test(dataProvider = "validConfigs")
+    @ParameterizedTest
+    @MethodSource("validConfigs")
     void testValidConfig(String validConfig) {
         String userConfig = validConfig.replace("'", "\"");
         Map<String, Object> config =
@@ -138,7 +138,8 @@ public class TransformFunctionTest {
         transformFunction.initialize(context);
     }
 
-    @DataProvider(name = "invalidConfigs")
+    @ParameterizedTest
+    @MethodSource("invalidConfigs")
     public static Object[][] invalidConfigs() {
         return new Object[][] {
             {"{}"},
@@ -214,7 +215,8 @@ public class TransformFunctionTest {
         };
     }
 
-    @Test(dataProvider = "invalidConfigs")
+    @ParameterizedTest
+    @MethodSource("invalidConfigs")
     void testInvalidConfig(String invalidConfig) {
         String userConfig = invalidConfig.replace("'", "\"");
         Map<String, Object> config =
@@ -421,7 +423,8 @@ public class TransformFunctionTest {
                 "{\"valueField1\":\"value1\",\"valueField2\":\"value2\",\"valueField3\":\"value3\"}");
     }
 
-    @Test(dataProvider = "dropStepConfigs")
+    @ParameterizedTest
+    @MethodSource("dropStepConfigs")
     void testDropOnPredicateMatch(String stepConfig, boolean drop) throws Exception {
         RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
         recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
@@ -455,12 +458,13 @@ public class TransformFunctionTest {
             GenericData.Record read =
                     Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
             assertEquals(read.get("age"), 42);
-            Assert.assertNull(read.getSchema().getField("firstName"));
-            Assert.assertNull(read.getSchema().getField("lastName"));
+            assertNull(read.getSchema().getField("firstName"));
+            assertNull(read.getSchema().getField("lastName"));
         }
     }
 
-    @DataProvider(name = "dropStepConfigs")
+    @ParameterizedTest
+    @MethodSource("dropStepConfigs")
     public static Object[][] dropStepConfigs() {
         return new Object[][] {
             {

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
@@ -1,0 +1,752 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.pulsar.functions.transforms;
+
+import static com.datastax.oss.streaming.ai.FlattenStep.AVRO_READ_OFFSET_PROP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.utils.FunctionRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Utils {
+
+    public static GenericData.Record getRecord(Schema<?> schema, byte[] value) throws IOException {
+        DatumReader<GenericData.Record> reader =
+                new GenericDatumReader<>(
+                        (org.apache.avro.Schema) schema.getNativeSchema().orElseThrow());
+        Decoder decoder = DecoderFactory.get().binaryDecoder(value, null);
+        return reader.read(null, decoder);
+    }
+
+    public static Record<GenericObject> createTestAvroKeyValueRecord() {
+        RecordSchemaBuilder keySchemaBuilder =
+                org.apache.pulsar.client.api.schema.SchemaBuilder.record("record");
+        keySchemaBuilder.field("keyField1").type(SchemaType.STRING);
+        keySchemaBuilder.field("keyField2").type(SchemaType.STRING);
+        keySchemaBuilder.field("keyField3").type(SchemaType.STRING);
+        GenericSchema<GenericRecord> keySchema =
+                Schema.generic(keySchemaBuilder.build(SchemaType.AVRO));
+
+        RecordSchemaBuilder valueSchemaBuilder =
+                org.apache.pulsar.client.api.schema.SchemaBuilder.record("record");
+        valueSchemaBuilder.field("valueField1").type(SchemaType.STRING);
+        valueSchemaBuilder.field("valueField2").type(SchemaType.STRING);
+        valueSchemaBuilder.field("valueField3").type(SchemaType.STRING);
+        GenericSchema<GenericRecord> valueSchema =
+                Schema.generic(valueSchemaBuilder.build(SchemaType.AVRO));
+
+        GenericRecord keyRecord =
+                keySchema
+                        .newRecordBuilder()
+                        .set("keyField1", "key1")
+                        .set("keyField2", "key2")
+                        .set("keyField3", "key3")
+                        .build();
+
+        GenericRecord valueRecord =
+                valueSchema
+                        .newRecordBuilder()
+                        .set("valueField1", "value1")
+                        .set("valueField2", "value2")
+                        .set("valueField3", "value3")
+                        .build();
+
+        Schema<KeyValue<GenericRecord, GenericRecord>> keyValueSchema =
+                Schema.KeyValue(keySchema, valueSchema, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<GenericRecord, GenericRecord> keyValue = new KeyValue<>(keyRecord, valueRecord);
+
+        GenericObject genericObject =
+                new GenericObject() {
+                    @Override
+                    public SchemaType getSchemaType() {
+                        return SchemaType.KEY_VALUE;
+                    }
+
+                    @Override
+                    public Object getNativeObject() {
+                        return keyValue;
+                    }
+                };
+
+        return new TestRecord<>(keyValueSchema, genericObject, null);
+    }
+
+    public static Record<GenericObject> createNestedAvroRecord(int levels, String key) {
+        GenericAvroRecord valueRecord = createNestedAvroRecord(levels);
+
+        Schema<org.apache.avro.generic.GenericRecord> pulsarValueSchema =
+                new NativeSchemaWrapper(valueRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
+
+        return new TestRecord<>(pulsarValueSchema, valueRecord, key);
+    }
+
+    /**
+     * Returns a nested Avro record with a certain number of levels. Example for levels = 4: {
+     * "level1KeyField1": "level1_Key1", "level1KeyField2": { "level2KeyField1": "level2_Key1",
+     * "level2KeyField2": { "level3KeyField1": "level3_Key1", "level3KeyField2": {
+     * "level4KeyField1": "level4_Key1", "level4KeyField2": "level4_Key2" } } } }
+     */
+    public static GenericAvroRecord createNestedAvroRecord(int levels) {
+        // Create the last, unnested level
+        List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        org.apache.avro.Schema nullAndString =
+                SchemaBuilder.unionOf().stringType().and().nullType().endUnion();
+        org.apache.avro.Schema nullLevel =
+                org.apache.avro.Schema.createRecord(
+                        "nullLevel",
+                        "doc ",
+                        "ns",
+                        false,
+                        List.of(
+                                new org.apache.avro.Schema.Field(
+                                        "ignored",
+                                        org.apache.avro.Schema.create(
+                                                org.apache.avro.Schema.Type.STRING))));
+        org.apache.avro.Schema nullAndRecord =
+                SchemaBuilder.unionOf().nullType().and().type(nullLevel).endUnion();
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "String",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
+                        "stringDoc",
+                        "stringDefault"));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "Integer",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
+                        "integerDoc",
+                        3));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "Double",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.DOUBLE),
+                        "doubleDoc",
+                        5.5D));
+        org.apache.avro.Schema arraySchema =
+                org.apache.avro.Schema.createArray(
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "Array",
+                        arraySchema,
+                        "arrayDoc",
+                        Collections.emptyList()));
+        org.apache.avro.Schema.Field stringWithProps =
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "StringWithPropsAndAlias",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+        stringWithProps.addProp("p1", "v1");
+        stringWithProps.addProp("p2", "v2");
+        stringWithProps.addProp(AVRO_READ_OFFSET_PROP, "5");
+        stringWithProps.addAlias("a1");
+        fields.add(stringWithProps);
+        fields.add(new org.apache.avro.Schema.Field("level" + levels + "Union", nullAndString));
+        fields.add(new org.apache.avro.Schema.Field("level" + levels + "Null", nullAndString));
+        fields.add(
+                new org.apache.avro.Schema.Field("level" + levels + "NullRecord", nullAndRecord));
+        org.apache.avro.Schema lastLevelSchema =
+                org.apache.avro.Schema.createRecord("nested" + levels, "doc ", "ns", false, fields);
+        org.apache.avro.generic.GenericRecord lastLevelRecord =
+                new GenericData.Record(lastLevelSchema);
+        lastLevelRecord.put("level" + levels + "String", "level" + levels + "_" + "1");
+        lastLevelRecord.put("level" + levels + "Integer", 9);
+        lastLevelRecord.put("level" + levels + "Double", 8.8D);
+        lastLevelRecord.put(
+                "level" + levels + "Array",
+                List.of("level" + levels + "_" + "1", "level" + levels + "_" + "2"));
+        lastLevelRecord.put(
+                "level" + levels + "StringWithPropsAndAlias", "level" + levels + "_" + "WithProps");
+        lastLevelRecord.put("level" + levels + "Union", "level" + levels + "_" + "2");
+        lastLevelRecord.put("level" + levels + "Null", null);
+        lastLevelRecord.put("level" + levels + "NullRecord", null);
+
+        org.apache.avro.Schema nextLevelSchema = lastLevelSchema;
+        org.apache.avro.generic.GenericRecord nextLevelRecord = lastLevelRecord;
+        // Create the nested levels one by one, working backwards from the last level up to the top
+        // level
+        for (int level = levels - 1; level > 0; level--) {
+            fields = new ArrayList<>();
+            fields.add(
+                    new org.apache.avro.Schema.Field(
+                            "level" + level + "String",
+                            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING)));
+            fields.add(
+                    new org.apache.avro.Schema.Field("level" + level + "Record", nextLevelSchema));
+            org.apache.avro.Schema currentLevelSchema =
+                    org.apache.avro.Schema.createRecord(
+                            "nested" + level, "doc ", "ns", false, fields);
+
+            org.apache.avro.generic.GenericRecord currentLevelRecord =
+                    new GenericData.Record(currentLevelSchema);
+            currentLevelRecord.put("level" + level + "String", "level" + level + "_" + "1");
+            currentLevelRecord.put("level" + level + "Record", nextLevelRecord);
+
+            nextLevelSchema = currentLevelSchema;
+            nextLevelRecord = currentLevelRecord;
+        }
+
+        nextLevelSchema.addProp(AVRO_READ_OFFSET_PROP, 5);
+        nextLevelSchema.addProp("t1", 9);
+        List<Field> pulsarFields =
+                fields.stream().map(v -> new Field(v.name(), v.pos())).collect(Collectors.toList());
+        return new GenericAvroRecord(new byte[0], nextLevelSchema, pulsarFields, nextLevelRecord);
+    }
+
+    static void assertOptionalField(
+            GenericData.Record record,
+            String fieldName,
+            org.apache.avro.Schema.Type expectedType,
+            Object expectedValue) {
+        assertTrue(record.hasField(fieldName));
+        org.apache.avro.Schema.Field field = record.getSchema().getField(fieldName);
+        assertTrue(field.schema().isNullable());
+        assertEquals(field.defaultVal(), org.apache.avro.Schema.NULL_VALUE);
+        assertTrue(field.schema().isUnion());
+        org.apache.avro.Schema nullSchema = field.schema().getTypes().get(0);
+        assertEquals(nullSchema.getType(), org.apache.avro.Schema.Type.NULL);
+        org.apache.avro.Schema typedSchema = field.schema().getTypes().get(1);
+        assertEquals(typedSchema.getType(), expectedType);
+        assertEquals(record.get(fieldName), expectedValue);
+    }
+
+    static void assertNonOptionalField(
+            GenericData.Record record,
+            String fieldName,
+            org.apache.avro.Schema.Type expectedType,
+            Object expectedValue) {
+        assertTrue(record.hasField(fieldName));
+        org.apache.avro.Schema.Field field = record.getSchema().getField(fieldName);
+        assertFalse(field.schema().isNullable());
+        assertNull(field.defaultVal());
+        assertFalse(field.schema().isUnion());
+        assertEquals(field.schema().getType(), expectedType);
+        assertEquals(record.get(fieldName), expectedValue);
+    }
+
+    @Builder
+    @RequiredArgsConstructor
+    @AllArgsConstructor
+    public static class TestRecord<T> implements Record<T> {
+        private final Schema<?> schema;
+        private final T value;
+        private final String key;
+        private String topicName;
+        private String destinationTopic;
+        private Long eventTime;
+        Map<String, String> properties;
+
+        @Override
+        public Optional<String> getKey() {
+            return Optional.ofNullable(key);
+        }
+
+        @Override
+        public Schema<T> getSchema() {
+            return (Schema<T>) schema;
+        }
+
+        @Override
+        public T getValue() {
+            return value;
+        }
+
+        @Override
+        public Optional<String> getTopicName() {
+            return Optional.ofNullable(topicName);
+        }
+
+        @Override
+        public Optional<String> getDestinationTopic() {
+            return Optional.ofNullable(destinationTopic);
+        }
+
+        @Override
+        public Optional<Long> getEventTime() {
+            return Optional.ofNullable(eventTime);
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+    }
+
+    public static class TestContext implements Context {
+        private final Record<?> currentRecord;
+        private final Map<String, Object> userConfig;
+
+        public TestContext(Record<?> currentRecord, Map<String, Object> userConfig) {
+            this.currentRecord = currentRecord;
+            this.userConfig = userConfig;
+        }
+
+        @Override
+        public Collection<String> getInputTopics() {
+            return null;
+        }
+
+        @Override
+        public String getOutputTopic() {
+            return "test-context-topic";
+        }
+
+        @Override
+        public Record<?> getCurrentRecord() {
+            return currentRecord;
+        }
+
+        @Override
+        public String getOutputSchemaType() {
+            return null;
+        }
+
+        @Override
+        public String getFunctionName() {
+            return null;
+        }
+
+        @Override
+        public String getFunctionId() {
+            return null;
+        }
+
+        @Override
+        public String getFunctionVersion() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getUserConfigMap() {
+            return userConfig;
+        }
+
+        @Override
+        public Optional<Object> getUserConfigValue(String key) {
+            return Optional.ofNullable(userConfig.get(key));
+        }
+
+        @Override
+        public Object getUserConfigValueOrDefault(String key, Object defaultValue) {
+            return null;
+        }
+
+        @Override
+        public PulsarAdmin getPulsarAdmin() {
+            return null;
+        }
+
+        @Override
+        public <X> CompletableFuture<Void> publish(
+                String topicName, X object, String schemaOrSerdeClassName) {
+            return null;
+        }
+
+        @Override
+        public <X> CompletableFuture<Void> publish(String topicName, X object) {
+            return null;
+        }
+
+        @Override
+        public <X> TypedMessageBuilder<X> newOutputMessage(String topicName, Schema<X> schema) {
+            return null;
+        }
+
+        @Override
+        public <X> ConsumerBuilder<X> newConsumerBuilder(Schema<X> schema) {
+            return null;
+        }
+
+        @Override
+        public <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder(
+                Schema<X> schema) {
+            return FunctionRecord.from(
+                    new Context() {
+                        @Override
+                        public Collection<String> getInputTopics() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getOutputTopic() {
+                            return "test-context-topic";
+                        }
+
+                        @Override
+                        public Record<?> getCurrentRecord() {
+                            return currentRecord;
+                        }
+
+                        @Override
+                        public String getOutputSchemaType() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getFunctionName() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getFunctionId() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getFunctionVersion() {
+                            return null;
+                        }
+
+                        @Override
+                        public Map<String, Object> getUserConfigMap() {
+                            return null;
+                        }
+
+                        @Override
+                        public Optional<Object> getUserConfigValue(String key) {
+                            return Optional.empty();
+                        }
+
+                        @Override
+                        public Object getUserConfigValueOrDefault(String key, Object defaultValue) {
+                            return null;
+                        }
+
+                        @Override
+                        public PulsarAdmin getPulsarAdmin() {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> CompletableFuture<Void> publish(
+                                String topicName, O object, String schemaOrSerdeClassName) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> CompletableFuture<Void> publish(String topicName, O object) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> TypedMessageBuilder<O> newOutputMessage(
+                                String topicName, Schema<O> schema) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> FunctionRecord.FunctionRecordBuilder<O> newOutputRecordBuilder(
+                                Schema<O> schema) {
+                            return null;
+                        }
+
+                        @Override
+                        public String getTenant() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getNamespace() {
+                            return null;
+                        }
+
+                        @Override
+                        public int getInstanceId() {
+                            return 0;
+                        }
+
+                        @Override
+                        public int getNumInstances() {
+                            return 0;
+                        }
+
+                        @Override
+                        public Logger getLogger() {
+                            return LoggerFactory.getILoggerFactory().getLogger("Context");
+                        }
+
+                        @Override
+                        public String getSecret(String secretName) {
+                            return null;
+                        }
+
+                        @Override
+                        public void putState(String key, ByteBuffer value) {}
+
+                        @Override
+                        public CompletableFuture<Void> putStateAsync(String key, ByteBuffer value) {
+                            return null;
+                        }
+
+                        @Override
+                        public ByteBuffer getState(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public CompletableFuture<ByteBuffer> getStateAsync(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public void deleteState(String key) {}
+
+                        @Override
+                        public CompletableFuture<Void> deleteStateAsync(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public void incrCounter(String key, long amount) {}
+
+                        @Override
+                        public CompletableFuture<Void> incrCounterAsync(String key, long amount) {
+                            return null;
+                        }
+
+                        @Override
+                        public long getCounter(String key) {
+                            return 0;
+                        }
+
+                        @Override
+                        public CompletableFuture<Long> getCounterAsync(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public void recordMetric(String metricName, double value) {}
+                    },
+                    schema);
+        }
+
+        @Override
+        public String getTenant() {
+            return null;
+        }
+
+        @Override
+        public String getNamespace() {
+            return null;
+        }
+
+        @Override
+        public int getInstanceId() {
+            return 0;
+        }
+
+        @Override
+        public int getNumInstances() {
+            return 0;
+        }
+
+        @Override
+        public Logger getLogger() {
+            return LoggerFactory.getILoggerFactory().getLogger("Context");
+        }
+
+        @Override
+        public String getSecret(String secretName) {
+            return null;
+        }
+
+        @Override
+        public void putState(String key, ByteBuffer value) {}
+
+        @Override
+        public CompletableFuture<Void> putStateAsync(String key, ByteBuffer value) {
+            return null;
+        }
+
+        @Override
+        public ByteBuffer getState(String key) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<ByteBuffer> getStateAsync(String key) {
+            return null;
+        }
+
+        @Override
+        public void deleteState(String key) {}
+
+        @Override
+        public CompletableFuture<Void> deleteStateAsync(String key) {
+            return null;
+        }
+
+        @Override
+        public void incrCounter(String key, long amount) {}
+
+        @Override
+        public CompletableFuture<Void> incrCounterAsync(String key, long amount) {
+            return null;
+        }
+
+        @Override
+        public long getCounter(String key) {
+            return 0;
+        }
+
+        @Override
+        public CompletableFuture<Long> getCounterAsync(String key) {
+            return null;
+        }
+
+        @Override
+        public void recordMetric(String metricName, double value) {}
+    }
+
+    public static class NativeSchemaWrapper
+            implements Schema<org.apache.avro.generic.GenericRecord> {
+
+        private final SchemaInfo pulsarSchemaInfo;
+        private final org.apache.avro.Schema nativeSchema;
+
+        private final SchemaType pulsarSchemaType;
+
+        private final SpecificDatumWriter<org.apache.avro.generic.GenericRecord> datumWriter;
+
+        public NativeSchemaWrapper(
+                org.apache.avro.Schema nativeSchema, SchemaType pulsarSchemaType) {
+            this.nativeSchema = nativeSchema;
+            this.pulsarSchemaType = pulsarSchemaType;
+            this.pulsarSchemaInfo =
+                    SchemaInfoImpl.builder()
+                            .schema(nativeSchema.toString(false).getBytes(StandardCharsets.UTF_8))
+                            .properties(new HashMap<>())
+                            .type(pulsarSchemaType)
+                            .name(nativeSchema.getName())
+                            .build();
+            this.datumWriter = new SpecificDatumWriter<>(this.nativeSchema);
+        }
+
+        @Override
+        public byte[] encode(org.apache.avro.generic.GenericRecord genericRecord) {
+            try {
+
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                BinaryEncoder binaryEncoder =
+                        new EncoderFactory().binaryEncoder(byteArrayOutputStream, null);
+                datumWriter.write(genericRecord, binaryEncoder);
+                binaryEncoder.flush();
+                return byteArrayOutputStream.toByteArray();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public SchemaInfo getSchemaInfo() {
+            return pulsarSchemaInfo;
+        }
+
+        @Override
+        public NativeSchemaWrapper clone() {
+            return new NativeSchemaWrapper(nativeSchema, pulsarSchemaType);
+        }
+
+        @Override
+        public void validate(byte[] message) {
+            // nothing to do
+        }
+
+        @Override
+        public boolean supportSchemaVersioning() {
+            return true;
+        }
+
+        @Override
+        public void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {}
+
+        @Override
+        public org.apache.avro.generic.GenericRecord decode(byte[] bytes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.apache.avro.generic.GenericRecord decode(byte[] bytes, byte[] schemaVersion) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean requireFetchingSchemaInfo() {
+            return true;
+        }
+
+        @Override
+        public void configureSchemaInfo(
+                String topic, String componentName, SchemaInfo schemaInfo) {}
+
+        @Override
+        public Optional<Object> getNativeSchema() {
+            return Optional.of(nativeSchema);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/Utils.java
@@ -16,10 +16,10 @@
 package com.datastax.oss.pulsar.functions.transforms;
 
 import static com.datastax.oss.streaming.ai.FlattenStep.AVRO_READ_OFFSET_PROP;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/CastStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/CastStepTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import java.nio.charset.StandardCharsets;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.TimeZone;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class CastStepTest {
+
+    @Test
+    void testKeyValueAvroToString() throws Exception {
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        CastStep step =
+                CastStep.builder()
+                        .keySchemaType(TransformSchemaType.STRING)
+                        .valueSchemaType(TransformSchemaType.STRING)
+                        .build();
+        Record<?> outputRecord = Utils.process(record, step);
+
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertSame(messageSchema.getKeySchema(), Schema.STRING);
+        assertEquals(
+                messageValue.getKey(),
+                "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}");
+        assertSame(messageSchema.getValueSchema(), Schema.STRING);
+        assertEquals(
+                messageValue.getValue(),
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", "
+                        + "\"valueField3\": \"value3\"}");
+    }
+
+    @DataProvider
+    public static Object[][] testPrimitiveSchemaTypes() {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        return new Object[][] {
+            {
+                "test",
+                TransformSchemaType.BYTES,
+                Schema.BYTES,
+                "test".getBytes(StandardCharsets.UTF_8)
+            },
+            {"true", TransformSchemaType.BOOLEAN, Schema.BOOL, true},
+            {"42", TransformSchemaType.INT8, Schema.INT8, (byte) 42},
+            {"42", TransformSchemaType.INT32, Schema.INT32, 42},
+            {"42", TransformSchemaType.INT64, Schema.INT64, 42L},
+            {"42.8", TransformSchemaType.FLOAT, Schema.FLOAT, 42.8F},
+            {"42.8", TransformSchemaType.DOUBLE, Schema.DOUBLE, 42.8D},
+            {
+                "2023-01-02T22:04:05.000000006-01:00",
+                TransformSchemaType.DATE,
+                Schema.DATE,
+                new Date(1672700645000L)
+            },
+            {
+                "2023-01-02T22:04:05.000000006-01:00",
+                TransformSchemaType.TIMESTAMP,
+                Schema.TIMESTAMP,
+                Timestamp.from(Instant.ofEpochSecond(1672700645L, 6))
+            },
+            {"23:04:05.000000006", TransformSchemaType.TIME, Schema.TIME, new Time(83045000L)},
+            {
+                "2023-01-02T23:04:05.000000006",
+                TransformSchemaType.LOCAL_DATE_TIME,
+                Schema.LOCAL_DATE_TIME,
+                LocalDateTime.of(2023, 1, 2, 23, 4, 5, 6)
+            },
+            {
+                "2023-01-02T22:04:05.000000006-01:00",
+                TransformSchemaType.INSTANT,
+                Schema.INSTANT,
+                Instant.ofEpochSecond(1672700645, 6)
+            },
+            {
+                "2023-01-02",
+                TransformSchemaType.LOCAL_DATE,
+                Schema.LOCAL_DATE,
+                LocalDate.of(2023, 1, 2)
+            },
+            {
+                "23:04:05.000000006",
+                TransformSchemaType.LOCAL_TIME,
+                Schema.LOCAL_TIME,
+                LocalTime.of(23, 4, 5, 6)
+            },
+        };
+    }
+
+    @Test(dataProvider = "testPrimitiveSchemaTypes")
+    void testPrimitiveSchemaTypes(
+            String input,
+            TransformSchemaType outputSchemaType,
+            Schema<?> expectedSchema,
+            Object expectedOutput)
+            throws Exception {
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .schema(Schema.STRING)
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        input, SchemaType.STRING, new byte[] {}))
+                        .build();
+        CastStep step = CastStep.builder().valueSchemaType(outputSchemaType).build();
+        Record<?> outputRecord = Utils.process(record, step);
+
+        assertEquals(outputRecord.getSchema(), expectedSchema);
+        assertEquals(outputRecord.getValue(), expectedOutput);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/CastStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/CastStepTest.java
@@ -15,8 +15,9 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.datastax.oss.streaming.ai.model.TransformSchemaType;
 import java.nio.charset.StandardCharsets;
@@ -36,8 +37,9 @@ import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class CastStepTest {
 
@@ -65,7 +67,6 @@ public class CastStepTest {
                         + "\"valueField3\": \"value3\"}");
     }
 
-    @DataProvider
     public static Object[][] testPrimitiveSchemaTypes() {
         TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
         return new Object[][] {
@@ -121,7 +122,8 @@ public class CastStepTest {
         };
     }
 
-    @Test(dataProvider = "testPrimitiveSchemaTypes")
+    @ParameterizedTest
+    @MethodSource("testPrimitiveSchemaTypes")
     void testPrimitiveSchemaTypes(
             String input,
             TransformSchemaType outputSchemaType,
@@ -139,6 +141,12 @@ public class CastStepTest {
         Record<?> outputRecord = Utils.process(record, step);
 
         assertEquals(outputRecord.getSchema(), expectedSchema);
-        assertEquals(outputRecord.getValue(), expectedOutput);
+
+        if (expectedOutput instanceof byte[]) {
+            assertArrayEquals((byte[]) outputRecord.getValue(), (byte[]) expectedOutput);
+        } else {
+            assertEquals(outputRecord.getValue(), expectedOutput);
+        }
+
     }
 }

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/CastStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/CastStepTest.java
@@ -147,6 +147,5 @@ public class CastStepTest {
         } else {
             assertEquals(outputRecord.getValue(), expectedOutput);
         }
-
     }
 }

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.models.ChatCompletions;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.datastax.oss.streaming.ai.completions.ChatMessage;
+import com.datastax.oss.streaming.ai.completions.OpenAICompletionService;
+import com.datastax.oss.streaming.ai.model.config.ChatCompletionsConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ChatCompletionsStepTest {
+
+    private static final String COMPLETION =
+            (""
+                            + "{"
+                            + "  'choices': ["
+                            + "    {"
+                            + "      'message': {"
+                            + "        'content': 'result'"
+                            + "      }"
+                            + "    }"
+                            + "  ]"
+                            + "}")
+                    .replace("'", "\"");
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private OpenAICompletionService completionService;
+    private OpenAIClient openAIClient;
+
+    @BeforeMethod
+    void setup() throws Exception {
+        openAIClient = mock(OpenAIClient.class);
+        when(openAIClient.getChatCompletions(eq("test-model"), any()))
+                .thenReturn(mapper.readValue(COMPLETION, ChatCompletions.class));
+        this.completionService = new OpenAICompletionService(openAIClient);
+    }
+
+    @Test
+    void testPrimitive() throws Exception {
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .key("test-key")
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        "test-message", SchemaType.STRING, new byte[] {}))
+                        .schema(Schema.STRING)
+                        .eventTime(42L)
+                        .topicName("test-input-topic")
+                        .destinationTopic("test-output-topic")
+                        .properties(Map.of("test-key", "test-value"))
+                        .build();
+
+        ArgumentCaptor<ChatCompletionsOptions> captor =
+                ArgumentCaptor.forClass(ChatCompletionsOptions.class);
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(
+                List.of(
+                        new ChatMessage("user")
+                                .setContent(
+                                        "{{ value }} {{ key}} {{ eventTime }} {{ topicName }} {{ destinationTopic }} {{ properties.test-key }}")));
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
+        verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
+
+        assertEquals(
+                captor.getValue().getMessages().get(0).getContent(),
+                "test-message test-key 42 test-input-topic test-output-topic test-value");
+    }
+
+    @DataProvider(name = "structuredSchemaTypes")
+    public static Object[][] structuredSchemaTypes() {
+        return new Object[][] {{SchemaType.AVRO}, {SchemaType.JSON}};
+    }
+
+    @Test(dataProvider = "structuredSchemaTypes")
+    void testStructured(SchemaType schemaType) throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+        recordSchemaBuilder.field("date").type(SchemaType.DATE);
+        recordSchemaBuilder.field("timestamp").type(SchemaType.TIMESTAMP);
+        recordSchemaBuilder.field("time").type(SchemaType.TIME);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(schemaType);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .set("date", (int) LocalDate.of(2023, 1, 2).toEpochDay())
+                        .set("timestamp", Instant.parse("2023-01-02T23:04:05.006Z").toEpochMilli())
+                        .set(
+                                "time",
+                                (int) (LocalTime.parse("23:04:05.006").toNanoOfDay() / 1_000_000))
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(
+                List.of(
+                        new ChatMessage("user")
+                                .setContent(
+                                        "{{ value.firstName }} {{ value.lastName }} {{ value.age }} {{ value.date }} {{ value.timestamp }} {{ value.time }} {{ key }}")));
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
+        ArgumentCaptor<ChatCompletionsOptions> captor =
+                ArgumentCaptor.forClass(ChatCompletionsOptions.class);
+        verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
+
+        assertEquals(
+                captor.getValue().getMessages().get(0).getContent(),
+                "Jane Doe 42 19359 1672700645006 83045006 test-key");
+    }
+
+    @DataProvider(name = "jsonStringSchemas")
+    public static Object[][] jsonStringSchemas() {
+        return new Object[][] {{Schema.STRING}, {Schema.BYTES}};
+    }
+
+    @Test(dataProvider = "jsonStringSchemas")
+    void testJsonString(Schema<?> schema) throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        Object json =
+                "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"age\":42,\"date\":19359,\"timestamp\":1672700645006,\"time\":83045006}";
+        if (schema.getSchemaInfo().getType() == SchemaType.BYTES) {
+            json = ((String) json).getBytes(StandardCharsets.UTF_8);
+        }
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        schema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                json, schema.getSchemaInfo().getType(), new byte[] {}),
+                        "test-key");
+
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(
+                List.of(
+                        new ChatMessage("user")
+                                .setContent(
+                                        "{{ value.firstName }} {{ value.lastName }} {{ value.age }} {{ value.date }} {{ value.timestamp }} {{ value.time }} {{ key }}")));
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
+
+        ArgumentCaptor<ChatCompletionsOptions> captor =
+                ArgumentCaptor.forClass(ChatCompletionsOptions.class);
+        verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
+
+        assertEquals(
+                captor.getValue().getMessages().get(0).getContent(),
+                "Jane Doe 42 19359 1672700645006 83045006 test-key");
+    }
+
+    @Test(dataProvider = "structuredSchemaTypes")
+    void testKVStructured(SchemaType schemaType) throws Exception {
+        ArgumentCaptor<ChatCompletionsOptions> captor =
+                ArgumentCaptor.forClass(ChatCompletionsOptions.class);
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(
+                List.of(
+                        new ChatMessage("user")
+                                .setContent("{{ value.valueField1 }} {{ key.keyField2 }}")));
+        Utils.process(
+                Utils.createTestStructKeyValueRecord(schemaType),
+                new ChatCompletionsStep(completionService, config));
+        verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
+
+        assertEquals(captor.getValue().getMessages().get(0).getContent(), "value1 key2");
+    }
+
+    @Test(dataProvider = "jsonStringSchemas")
+    void testKVJsonString(Schema<?> schema) throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        Object json =
+                "{\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"age\":42,\"date\":19359,\"timestamp\":1672700645006,\"time\":83045006}";
+        if (schema.getSchemaInfo().getType() == SchemaType.BYTES) {
+            json = ((String) json).getBytes(StandardCharsets.UTF_8);
+        }
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        schema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                json, schema.getSchemaInfo().getType(), new byte[] {}),
+                        "test-key");
+
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(
+                List.of(
+                        new ChatMessage("user")
+                                .setContent(
+                                        "{{ value.firstName }} {{ value.lastName }} {{ value.age }} {{ value.date }} {{ value.timestamp }} {{ value.time }} {{ key }}")));
+        Utils.process(record, new ChatCompletionsStep(completionService, config));
+
+        ArgumentCaptor<ChatCompletionsOptions> captor =
+                ArgumentCaptor.forClass(ChatCompletionsOptions.class);
+        verify(openAIClient).getChatCompletions(eq("test-model"), captor.capture());
+
+        assertEquals(
+                captor.getValue().getMessages().get(0).getContent(),
+                "Jane Doe 42 19359 1672700645006 83045006 test-key");
+    }
+
+    @Test
+    void testValueOutput() throws Exception {
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .key("test-key")
+                        .schema(Schema.STRING)
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        "test-message", SchemaType.STRING, new byte[] {}))
+                        .build();
+
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        Record<?> outputRecord =
+                Utils.process(record, new ChatCompletionsStep(completionService, config));
+        assertEquals(outputRecord.getValue(), "result");
+    }
+
+    @Test
+    void testKeyOutput() throws Exception {
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("key");
+        Record<?> outputRecord =
+                Utils.process(
+                        Utils.createTestAvroKeyValueRecord(),
+                        new ChatCompletionsStep(completionService, config));
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(messageSchema.getKeySchema().getSchemaInfo().getType(), SchemaType.STRING);
+        assertEquals(messageValue.getKey(), "result");
+    }
+
+    @Test
+    void testDestinationTopicOutput() throws Exception {
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .key("test-key")
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        "test-message", SchemaType.STRING, new byte[] {}))
+                        .schema(Schema.STRING)
+                        .build();
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("destinationTopic");
+        Record<?> outputRecord =
+                Utils.process(record, new ChatCompletionsStep(completionService, config));
+        assertEquals(outputRecord.getDestinationTopic().orElseThrow(), "result");
+    }
+
+    @Test
+    void testMessageKeyOutput() throws Exception {
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .key("test-key")
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        "test-message", SchemaType.STRING, new byte[] {}))
+                        .schema(Schema.STRING)
+                        .build();
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("messageKey");
+        Record<?> outputRecord =
+                Utils.process(record, new ChatCompletionsStep(completionService, config));
+        assertEquals(outputRecord.getKey().orElseThrow(), "result");
+    }
+
+    @Test
+    void testPropertyOutput() throws Exception {
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .key("test-key")
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        "test-message", SchemaType.STRING, new byte[] {}))
+                        .schema(Schema.STRING)
+                        .build();
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("properties.chat");
+        Record<?> outputRecord =
+                Utils.process(record, new ChatCompletionsStep(completionService, config));
+        assertEquals(outputRecord.getProperties().get("chat"), "result");
+    }
+
+    @Test
+    void testAvroValueFieldOutput() throws Exception {
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("value.chat");
+        Record<?> outputRecord =
+                Utils.process(
+                        Utils.createTestAvroKeyValueRecord(),
+                        new ChatCompletionsStep(completionService, config));
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals(valueAvroRecord.get("chat"), new Utf8("result"));
+    }
+
+    @Test
+    void testJsonValueFieldOutput() throws Exception {
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("value.chat");
+        Record<?> outputRecord =
+                Utils.process(
+                        Utils.createTestJsonKeyValueRecord(),
+                        new ChatCompletionsStep(completionService, config));
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        org.apache.avro.Schema schema =
+                (org.apache.avro.Schema)
+                        messageSchema.getValueSchema().getNativeSchema().orElseThrow();
+        assertEquals(
+                schema.getField("chat").schema().getType(), org.apache.avro.Schema.Type.STRING);
+        assertEquals(((JsonNode) messageValue.getValue()).get("chat").asText(), "result");
+    }
+
+    @DataProvider(name = "jsonStringFieldOutput")
+    public static Object[][] jsonStringFieldOutput() {
+        return new Object[][] {
+            {Schema.STRING, "{\"name\":\"Jane\"}", "{\"name\":\"Jane\",\"chat\":\"result\"}"},
+            {
+                Schema.BYTES,
+                "{\"name\":\"Jane\"}".getBytes(StandardCharsets.UTF_8),
+                "{\"name\":\"Jane\",\"chat\":\"result\"}".getBytes(StandardCharsets.UTF_8)
+            }
+        };
+    }
+
+    @Test(dataProvider = "jsonStringFieldOutput")
+    void testJsonStringValueFieldOutput(Schema<?> schema, Object input, Object expected)
+            throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        schema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                input, schema.getSchemaInfo().getType(), new byte[] {}),
+                        "test-key");
+
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("value.chat");
+        Record<?> outputRecord =
+                Utils.process(record, new ChatCompletionsStep(completionService, config));
+
+        assertEquals(outputRecord.getSchema(), schema);
+        assertEquals(outputRecord.getValue(), expected);
+    }
+
+    @Test
+    void testAvroKeyFieldOutput() throws Exception {
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("key.chat");
+        Record<?> outputRecord =
+                Utils.process(
+                        Utils.createTestAvroKeyValueRecord(),
+                        new ChatCompletionsStep(completionService, config));
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyAvroRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(keyAvroRecord.get("chat"), new Utf8("result"));
+    }
+
+    @Test
+    void testJsonKeyFieldOutput() throws Exception {
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("key.chat");
+        Record<?> outputRecord =
+                Utils.process(
+                        Utils.createTestJsonKeyValueRecord(),
+                        new ChatCompletionsStep(completionService, config));
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        org.apache.avro.Schema schema =
+                (org.apache.avro.Schema)
+                        messageSchema.getKeySchema().getNativeSchema().orElseThrow();
+        assertEquals(
+                schema.getField("chat").schema().getType(), org.apache.avro.Schema.Type.STRING);
+        assertEquals(((JsonNode) messageValue.getKey()).get("chat").asText(), "result");
+    }
+
+    @Test(dataProvider = "jsonStringFieldOutput")
+    void testJsonStringKeyFieldOutput(Schema<?> schema, Object input, Object expected)
+            throws Exception {
+        Schema<? extends KeyValue<?, Integer>> keyValueSchema =
+                Schema.KeyValue(schema, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<Object, Integer> keyValue = new KeyValue<>(input, 42);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        "test-key");
+
+        ChatCompletionsConfig config = new ChatCompletionsConfig();
+        config.setModel("test-model");
+        config.setMessages(List.of(new ChatMessage("user").setContent("content")));
+        config.setFieldName("key.chat");
+        Record<?> outputRecord =
+                Utils.process(record, new ChatCompletionsStep(completionService, config));
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(messageSchema.getKeySchema(), schema);
+        assertEquals(messageValue.getKey(), expected);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ChatCompletionsStepTest.java
@@ -16,12 +16,12 @@
 package com.datastax.oss.streaming.ai;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletions;
@@ -55,10 +55,10 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.junit.jupiter.api.Test;
 
 public class ChatCompletionsStepTest {
 
@@ -424,8 +424,8 @@ public class ChatCompletionsStepTest {
                 Utils.process(record, new ChatCompletionsStep(completionService, config));
 
         assertEquals(outputRecord.getSchema(), schema);
-        if (expected instanceof  byte[]) {
-            assertArrayEquals((byte[]) outputRecord.getValue(),(byte[])  expected);
+        if (expected instanceof byte[]) {
+            assertArrayEquals((byte[]) outputRecord.getValue(), (byte[]) expected);
         } else {
             assertEquals(outputRecord.getValue(), expected);
         }

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsTest.java
@@ -15,8 +15,8 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.datastax.oss.streaming.ai.embeddings.MockEmbeddingsService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,8 +35,8 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Ignore;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ComputeAIEmbeddingsTest {
 
@@ -95,7 +95,7 @@ public class ComputeAIEmbeddingsTest {
     }
 
     @Test
-    @Ignore("JSON not supported at the moment")
+    @Disabled("JSON not supported at the moment")
     void testJson() throws Exception {
         RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
         recordSchemaBuilder.field("firstName").type(SchemaType.STRING);

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.datastax.oss.streaming.ai.embeddings.MockEmbeddingsService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericData;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+public class ComputeAIEmbeddingsTest {
+
+    @Test
+    void testAvro() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "The Princess ")
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+        MockEmbeddingsService mockService = new MockEmbeddingsService();
+        final List<Double> expectedEmbeddings = Arrays.asList(1.0d, 2.0d, 3.0d);
+        mockService.setEmbeddingsForText("Jane The Princess ", expectedEmbeddings);
+        ComputeAIEmbeddingsStep step =
+                new ComputeAIEmbeddingsStep(
+                        "{{ value.firstName }} {{ value.lastName }}",
+                        "value.newField",
+                        mockService);
+
+        Record<?> outputRecord = Utils.process(record, step);
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertNotNull(read.get("newField"));
+        List<Double> embeddings = (List<Double>) read.get("newField");
+        assertEquals(embeddings, expectedEmbeddings);
+        assertEquals(outputRecord.getSchema().getSchemaInfo().getType(), SchemaType.AVRO);
+    }
+
+    @Test
+    void testKeyValueAvro() throws Exception {
+        MockEmbeddingsService mockService = new MockEmbeddingsService();
+        final List<Double> expectedEmbeddings = Arrays.asList(1.0d, 2.0d, 3.0d);
+        mockService.setEmbeddingsForText("key1", expectedEmbeddings);
+        ComputeAIEmbeddingsStep step =
+                new ComputeAIEmbeddingsStep("{{ key.keyField1 }}", "value.newField", mockService);
+
+        Record<?> outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals(valueAvroRecord.get("newField"), expectedEmbeddings);
+        assertEquals(outputRecord.getSchema().getSchemaInfo().getType(), SchemaType.KEY_VALUE);
+    }
+
+    @Test
+    @Ignore("JSON not supported at the moment")
+    void testJson() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.JSON);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "The Princess ")
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+        MockEmbeddingsService mockService = new MockEmbeddingsService();
+        final List<Double> expectedEmbeddings = Arrays.asList(1.0d, 2.0d, 3.0d);
+        mockService.setEmbeddingsForText("Jane The Princess ", expectedEmbeddings);
+        ComputeAIEmbeddingsStep step =
+                new ComputeAIEmbeddingsStep(
+                        "{{ value.firstName }} {{ value.lastName }}",
+                        "value.newField",
+                        mockService);
+
+        Record<?> outputRecord = Utils.process(record, step);
+
+        final ObjectNode jsonNode = (ObjectNode) outputRecord.getValue();
+        assertNotNull(jsonNode.get("newField"));
+        final List asList = new ObjectMapper().convertValue(jsonNode.get("newField"), List.class);
+        assertEquals(asList, expectedEmbeddings);
+        assertEquals(outputRecord.getSchema().getSchemaInfo().getType(), SchemaType.JSON);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeStepTest.java
@@ -1,0 +1,1474 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static com.datastax.oss.streaming.ai.Utils.assertOptionalField;
+import static org.apache.avro.Schema.Type.BOOLEAN;
+import static org.apache.avro.Schema.Type.BYTES;
+import static org.apache.avro.Schema.Type.DOUBLE;
+import static org.apache.avro.Schema.Type.FLOAT;
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.LONG;
+import static org.apache.avro.Schema.Type.STRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import com.datastax.oss.streaming.ai.model.ComputeField;
+import com.datastax.oss.streaming.ai.model.ComputeFieldType;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ComputeStepTest {
+
+    private static final org.apache.avro.Schema STRING_SCHEMA =
+            org.apache.avro.Schema.create(STRING);
+    private static final org.apache.avro.Schema INT_SCHEMA = org.apache.avro.Schema.create(INT);
+    private static final org.apache.avro.Schema LONG_SCHEMA = org.apache.avro.Schema.create(LONG);
+    private static final org.apache.avro.Schema FLOAT_SCHEMA = org.apache.avro.Schema.create(FLOAT);
+    private static final org.apache.avro.Schema DOUBLE_SCHEMA =
+            org.apache.avro.Schema.create(DOUBLE);
+    private static final org.apache.avro.Schema BOOLEAN_SCHEMA =
+            org.apache.avro.Schema.create(BOOLEAN);
+    private static final org.apache.avro.Schema BYTES_SCHEMA = org.apache.avro.Schema.create(BYTES);
+
+    private static final org.apache.avro.Schema DATE_SCHEMA =
+            LogicalTypes.date().addToSchema(org.apache.avro.Schema.create(INT));
+
+    private static final org.apache.avro.Schema TIME_SCHEMA =
+            LogicalTypes.timeMillis().addToSchema(org.apache.avro.Schema.create(INT));
+    private static final org.apache.avro.Schema TIMESTAMP_SCHEMA =
+            LogicalTypes.timestampMillis().addToSchema(org.apache.avro.Schema.create(LONG));
+
+    private static final CqlDecimalLogicalType CQL_DECIMAL_LOGICAL_TYPE =
+            new CqlDecimalLogicalType();
+    private static final String CQL_DECIMAL = "cql_decimal";
+    private static final String CQL_DECIMAL_BIGINT = "bigint";
+    private static final String CQL_DECIMAL_SCALE = "scale";
+    private static final org.apache.avro.Schema decimalType =
+            CQL_DECIMAL_LOGICAL_TYPE.addToSchema(
+                    org.apache.avro.SchemaBuilder.record(CQL_DECIMAL)
+                            .fields()
+                            .name(CQL_DECIMAL_BIGINT)
+                            .type()
+                            .bytesType()
+                            .noDefault()
+                            .name(CQL_DECIMAL_SCALE)
+                            .type()
+                            .intType()
+                            .noDefault()
+                            .endRecord());
+
+    @Test
+    void testAvro() throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+        recordSchemaBuilder.field("date").type(SchemaType.DATE);
+        recordSchemaBuilder.field("timestamp").type(SchemaType.TIMESTAMP);
+        recordSchemaBuilder.field("time").type(SchemaType.TIME);
+        recordSchemaBuilder.field("integerStr").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .set("date", (int) LocalDate.of(2023, 1, 2).toEpochDay())
+                        .set("timestamp", Instant.parse("2023-01-02T23:04:05.006Z").toEpochMilli())
+                        .set(
+                                "time",
+                                (int) (LocalTime.parse("23:04:05.006").toNanoOfDay() / 1_000_000))
+                        .set("integerStr", "13360")
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        List<ComputeField> fields = buildComputeFields("value", false, false, false);
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.age")
+                        .expression("value.age + 1")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.dateStr")
+                        .expression("value.date")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.timestampStr")
+                        .expression("value.timestamp")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.timeStr")
+                        .expression("value.time")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.integer")
+                        .expression("value.integerStr")
+                        .type(ComputeFieldType.INT32)
+                        .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(outputRecord.getKey().orElse(null), "test-key");
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertEquals(read.get("firstName"), new Utf8("Jane"));
+        assertEquals(read.get("dateStr"), new Utf8("2023-01-02"));
+        assertEquals(read.get("timestampStr"), new Utf8("2023-01-02T23:04:05.006Z"));
+        assertEquals(read.get("timeStr"), new Utf8("23:04:05.006"));
+        assertEquals(read.get("integer"), 13360);
+
+        assertTrue(read.hasField("newStringField"));
+        assertEquals(read.getSchema().getField("newStringField").schema(), STRING_SCHEMA);
+        assertEquals(read.get("newStringField"), new Utf8("Hotaru"));
+
+        assertTrue(read.hasField("newInt8Field"));
+        assertEquals(read.getSchema().getField("newInt8Field").schema(), INT_SCHEMA);
+        assertEquals(read.get("newInt8Field"), 127);
+
+        assertTrue(read.hasField("newInt16Field"));
+        assertEquals(read.getSchema().getField("newInt16Field").schema(), INT_SCHEMA);
+        assertEquals(read.get("newInt16Field"), 32767);
+
+        assertTrue(read.hasField("newInt32Field"));
+        assertEquals(read.getSchema().getField("newInt32Field").schema(), INT_SCHEMA);
+        assertEquals(read.get("newInt32Field"), 2147483647);
+
+        assertTrue(read.hasField("newInt64Field"));
+        assertEquals(read.getSchema().getField("newInt64Field").schema(), LONG_SCHEMA);
+        assertEquals(read.get("newInt64Field"), 9223372036854775807L);
+
+        assertTrue(read.hasField("newFloatField"));
+        assertEquals(read.getSchema().getField("newFloatField").schema(), FLOAT_SCHEMA);
+        assertEquals(read.get("newFloatField"), 340282346638528859999999999999999999999.999999F);
+
+        assertTrue(read.hasField("newDoubleField"));
+        assertEquals(read.getSchema().getField("newDoubleField").schema(), DOUBLE_SCHEMA);
+        assertEquals(read.get("newDoubleField"), 1.79769313486231570e+308D);
+
+        assertTrue(read.hasField("newBooleanField"));
+        assertEquals(read.getSchema().getField("newBooleanField").schema(), BOOLEAN_SCHEMA);
+        assertTrue((Boolean) read.get("newBooleanField"));
+
+        assertTrue(read.hasField("newBytesField"));
+        assertEquals(read.getSchema().getField("newBytesField").schema(), BYTES_SCHEMA);
+        assertEquals(
+                read.get("newBytesField"),
+                ByteBuffer.wrap("Hotaru".getBytes(StandardCharsets.UTF_8)));
+
+        assertTrue(read.hasField("newDateField"));
+        assertEquals(read.getSchema().getField("newDateField").schema(), DATE_SCHEMA);
+        assertEquals(read.get("newDateField"), 13850); // 13850 days since 1970-01-01
+
+        assertTrue(read.hasField("newDateField2"));
+        assertEquals(read.getSchema().getField("newDateField2").schema(), DATE_SCHEMA);
+        assertEquals(read.get("newDateField2"), 13850); // 13850 days since 1970-01-01
+
+        assertTrue(read.hasField("newLocalDateField"));
+        assertEquals(read.getSchema().getField("newLocalDateField").schema(), DATE_SCHEMA);
+        assertEquals(read.get("newLocalDateField"), 13850); // 13850 days since 1970-01-01
+
+        assertTrue(read.hasField("newLocalDateField2"));
+        assertEquals(read.getSchema().getField("newLocalDateField2").schema(), DATE_SCHEMA);
+        assertEquals(read.get("newLocalDateField2"), 13850); // 13850 days since 1970-01-01
+
+        assertTrue(read.hasField("newTimeField"));
+        assertEquals(read.getSchema().getField("newTimeField").schema(), TIME_SCHEMA);
+        assertEquals(read.get("newTimeField"), 36930000); // 36930000 ms since 00:00:00
+
+        assertTrue(read.hasField("newTimeField2"));
+        assertEquals(read.getSchema().getField("newTimeField2").schema(), TIME_SCHEMA);
+        assertEquals(read.get("newTimeField2"), 36930000); // 36930000 ms since 00:00:00
+
+        assertTrue(read.hasField("newLocalTimeField"));
+        assertEquals(read.getSchema().getField("newLocalTimeField").schema(), TIME_SCHEMA);
+        assertEquals(read.get("newLocalTimeField"), 36930000); // 36930000 ms since 00:00:00
+
+        assertTrue(read.hasField("newLocalTimeField2"));
+        assertEquals(read.getSchema().getField("newLocalTimeField2").schema(), TIME_SCHEMA);
+        assertEquals(read.get("newLocalTimeField2"), 36930000); // 36930000 ms since 00:00:00
+
+        assertTrue(read.hasField("newDateTimeField"));
+        assertEquals(read.getSchema().getField("newDateTimeField").schema(), TIMESTAMP_SCHEMA);
+        assertEquals(read.get("newDateTimeField"), 1196676930000L);
+
+        assertTrue(read.hasField("newInstantField"));
+        assertEquals(read.getSchema().getField("newInstantField").schema(), TIMESTAMP_SCHEMA);
+        assertEquals(read.get("newInstantField"), 1196676930000L);
+
+        assertTrue(read.hasField("newInstantField2"));
+        assertEquals(read.getSchema().getField("newInstantField2").schema(), TIMESTAMP_SCHEMA);
+        assertEquals(read.get("newInstantField2"), 1196676930000L);
+
+        assertTrue(read.hasField("newTimestampField"));
+        assertEquals(read.getSchema().getField("newTimestampField").schema(), TIMESTAMP_SCHEMA);
+        assertEquals(read.get("newTimestampField"), 1196676930000L);
+
+        assertTrue(read.hasField("newTimestampField2"));
+        assertEquals(read.getSchema().getField("newTimestampField2").schema(), TIMESTAMP_SCHEMA);
+        assertEquals(read.get("newTimestampField2"), 1196676930000L);
+
+        assertTrue(read.hasField("newLocalDateTimeField"));
+        assertEquals(read.getSchema().getField("newLocalDateTimeField").schema(), TIMESTAMP_SCHEMA);
+        assertEquals(read.get("newLocalDateTimeField"), 1196676930000L);
+
+        assertTrue(read.hasField("newLocalDateTimeField2"));
+        assertEquals(
+                read.getSchema().getField("newLocalDateTimeField2").schema(), TIMESTAMP_SCHEMA);
+        assertEquals(read.get("newLocalDateTimeField2"), 1196676930000L);
+
+        assertEquals(read.getSchema().getField("age").schema(), STRING_SCHEMA);
+        assertEquals(read.get("age"), new Utf8("43"));
+    }
+
+    @Test
+    void testJson() throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+        recordSchemaBuilder.field("date").type(SchemaType.DATE);
+        recordSchemaBuilder.field("timestamp").type(SchemaType.TIMESTAMP);
+        recordSchemaBuilder.field("time").type(SchemaType.TIME);
+        recordSchemaBuilder.field("integerStr").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.JSON);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .set("date", (int) LocalDate.of(2023, 1, 2).toEpochDay())
+                        .set("timestamp", Instant.parse("2023-01-02T23:04:05.006Z").toEpochMilli())
+                        .set(
+                                "time",
+                                (int) (LocalTime.parse("23:04:05.006").toNanoOfDay() / 1_000_000))
+                        .set("integerStr", "13360")
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        List<ComputeField> fields = buildComputeFields("value", false, false, false);
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.age")
+                        .expression("value.age + 1")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.dateStr")
+                        .expression("value.date")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.timestampStr")
+                        .expression("value.timestamp")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.timeStr")
+                        .expression("value.time")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.integer")
+                        .expression("value.integerStr")
+                        .type(ComputeFieldType.INT32)
+                        .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(outputRecord.getKey().orElse(null), "test-key");
+        JsonNode read = (JsonNode) outputRecord.getValue();
+        assertEquals(read.get("firstName").asText(), "Jane");
+        assertEquals(read.get("dateStr").asText(), "2023-01-02");
+        assertEquals(read.get("timestampStr").asText(), "2023-01-02T23:04:05.006Z");
+        assertEquals(read.get("timeStr").asText(), "23:04:05.006");
+        assertEquals(read.get("integer").asInt(), 13360);
+        assertEquals(read.get("newStringField").asText(), "Hotaru");
+        assertEquals(read.get("newInt8Field").asInt(), 127);
+        assertEquals(read.get("newInt16Field").asInt(), 32767);
+        assertEquals(read.get("newInt32Field").asInt(), 2147483647);
+        assertEquals(read.get("newInt64Field").asLong(), 9223372036854775807L);
+        assertEquals(
+                read.get("newFloatField").asDouble(),
+                340282346638528859999999999999999999999.999999F);
+        assertEquals(read.get("newDoubleField").asDouble(), 1.79769313486231570e+308D);
+        assertTrue(read.get("newBooleanField").asBoolean());
+        assertEquals(
+                read.get("newBytesField").asText(),
+                Base64.getEncoder().encodeToString("Hotaru".getBytes(StandardCharsets.UTF_8)));
+        assertEquals(read.get("newDateField").asInt(), 13850); // 13850 days since 1970-01-01
+        assertEquals(read.get("newDateField2").asInt(), 13850); // 13850 days since 1970-01-01
+        assertEquals(read.get("newLocalDateField").asInt(), 13850); // 13850 days since 1970-01-01
+        assertEquals(read.get("newLocalDateField2").asInt(), 13850); // 13850 days since 1970-01-01
+        assertEquals(read.get("newTimeField").asInt(), 36930000); // 36930000 ms since 00:00:00
+        assertEquals(read.get("newTimeField2").asInt(), 36930000); // 36930000 ms since 00:00:00
+        assertEquals(read.get("newLocalTimeField").asInt(), 36930000); // 36930000 ms since 00:00:00
+        assertEquals(
+                read.get("newLocalTimeField2").asInt(), 36930000); // 36930000 ms since 00:00:00
+        assertEquals(read.get("newDateTimeField").asLong(), 1196676930000L);
+        assertEquals(read.get("newInstantField").asLong(), 1196676930000L);
+        assertEquals(read.get("newInstantField2").asLong(), 1196676930000L);
+        assertEquals(read.get("newTimestampField").asLong(), 1196676930000L);
+        assertEquals(read.get("newTimestampField2").asLong(), 1196676930000L);
+        assertEquals(read.get("newLocalDateTimeField").asLong(), 1196676930000L);
+        assertEquals(read.get("newLocalDateTimeField2").asLong(), 1196676930000L);
+        assertEquals(read.get("age").asText(), "43");
+    }
+
+    @DataProvider(name = "jsonStringSchemas")
+    public static Object[][] jsonStringSchemas() {
+        return new Object[][] {{Schema.STRING}, {Schema.BYTES}};
+    }
+
+    @Test(dataProvider = "jsonStringSchemas")
+    void testStringJson(Schema schema) throws Exception {
+        SchemaType schemaType = schema.getSchemaInfo().getType();
+        Object json =
+                "{\"name\":\"Jane\",\"age\":42,\"date\":18999,\"timestamp\":1672525445006,\"time\":83085006,\"integerStr\":\"13360\"}";
+        if (schemaType == SchemaType.BYTES) {
+            json = ((String) json).getBytes(StandardCharsets.UTF_8);
+        }
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        schema,
+                        AutoConsumeSchema.wrapPrimitiveObject(json, schemaType, new byte[] {}),
+                        "test-key");
+
+        List<ComputeField> fields =
+                Collections.singletonList(
+                        ComputeField.builder()
+                                .scopedName("value.age")
+                                .expression("value.age + 1")
+                                .type(ComputeFieldType.STRING)
+                                .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Record<?> outputRecord = Utils.process(record, step);
+
+        assertEquals(outputRecord.getSchema(), schema);
+
+        Object expected =
+                "{\"name\":\"Jane\",\"age\":\"43\",\"date\":18999,\"timestamp\":1672525445006,\"time\":83085006,"
+                        + "\"integerStr\":\"13360\"}";
+        if (schemaType == SchemaType.BYTES) {
+            expected = ((String) expected).getBytes(StandardCharsets.UTF_8);
+        }
+        assertEquals(outputRecord.getValue(), expected);
+    }
+
+    @Test(dataProvider = "jsonStringSchemas")
+    void testKVStringJson(Schema<?> schema) throws Exception {
+        SchemaType schemaType = schema.getSchemaInfo().getType();
+        Object json =
+                "{\"name\":\"Jane\",\"age\":42,\"date\":18999,\"timestamp\":1672525445006,\"time\":83085006,\"integerStr\":\"13360\"}";
+        if (schemaType == SchemaType.BYTES) {
+            json = ((String) json).getBytes(StandardCharsets.UTF_8);
+        }
+
+        Schema<? extends KeyValue<?, Integer>> keyValueSchema =
+                Schema.KeyValue(schema, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<Object, Integer> keyValue = new KeyValue<>(json, 42);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        "test-key");
+
+        List<ComputeField> fields =
+                List.of(
+                        ComputeField.builder()
+                                .scopedName("value.age")
+                                .expression("value.age + 1")
+                                .type(ComputeFieldType.STRING)
+                                .build(),
+                        ComputeField.builder()
+                                .scopedName("key.age")
+                                .expression("key.age + 2")
+                                .type(ComputeFieldType.STRING)
+                                .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(messageSchema.getKeySchema(), schema);
+        assertEquals(messageSchema.getValueSchema(), Schema.INT32);
+
+        assertEquals(messageValue.getValue(), 42);
+        Object expected =
+                "{\"name\":\"Jane\",\"age\":\"44\",\"date\":18999,\"timestamp\":1672525445006,\"time\":83085006,"
+                        + "\"integerStr\":\"13360\"}";
+        if (schemaType == SchemaType.BYTES) {
+            expected = ((String) expected).getBytes(StandardCharsets.UTF_8);
+        }
+        assertEquals(messageValue.getKey(), expected);
+    }
+
+    @Test
+    void testAvroInferredType() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+        recordSchemaBuilder.field("size").type(SchemaType.FLOAT);
+        recordSchemaBuilder.field("date").type(SchemaType.DATE);
+        recordSchemaBuilder.field("timestamp").type(SchemaType.TIMESTAMP);
+        recordSchemaBuilder.field("time").type(SchemaType.TIME);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        int date = (int) LocalDate.of(2023, 1, 2).toEpochDay();
+        long timestampMillis = Instant.parse("2023-01-02T23:04:05.006Z").toEpochMilli();
+        int timeMillis = (int) (LocalTime.parse("23:04:05.006").toNanoOfDay() / 1_000_000);
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .set("size", 5.6F)
+                        .set("date", date)
+                        .set("timestamp", timestampMillis)
+                        .set("time", timeMillis)
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        List<ComputeField> fields = buildComputeFields("value", false, false, true);
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.newSizeField")
+                        .expression("value.size")
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.newDate")
+                        .expression("value.date")
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.newTimestamp")
+                        .expression("value.timestamp")
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.newTime")
+                        .expression("value.time")
+                        .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(outputRecord.getKey().orElse(null), "test-key");
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        org.apache.avro.Schema avroSchema =
+                (org.apache.avro.Schema) outputRecord.getSchema().getNativeSchema().orElseThrow();
+
+        assertEquals(read.get("firstName"), new Utf8("Jane"));
+        assertEquals(read.get("newSizeField"), 5.6F);
+        assertEquals(avroSchema.getField("newDate").schema().getLogicalType(), LogicalTypes.date());
+        assertEquals(read.get("newDate"), date);
+        assertEquals(
+                avroSchema.getField("newTimestamp").schema().getLogicalType(),
+                LogicalTypes.timestampMillis());
+        assertEquals(read.get("newTimestamp"), timestampMillis);
+        assertEquals(
+                avroSchema.getField("newTime").schema().getLogicalType(),
+                LogicalTypes.timeMillis());
+        assertEquals(read.get("newTime"), timeMillis);
+
+        assertTrue(read.hasField("newStringField"));
+        assertEquals(read.getSchema().getField("newStringField").schema(), STRING_SCHEMA);
+        assertEquals(read.get("newStringField"), new Utf8("Hotaru"));
+
+        assertTrue(read.hasField("newInt8Field"));
+        assertEquals(read.getSchema().getField("newInt8Field").schema(), LONG_SCHEMA);
+        assertEquals(read.get("newInt8Field"), 127L);
+
+        assertTrue(read.hasField("newInt16Field"));
+        assertEquals(read.getSchema().getField("newInt16Field").schema(), LONG_SCHEMA);
+        assertEquals(read.get("newInt16Field"), 32767L);
+
+        assertTrue(read.hasField("newInt32Field"));
+        assertEquals(read.getSchema().getField("newInt32Field").schema(), LONG_SCHEMA);
+        assertEquals(read.get("newInt32Field"), 2147483647L);
+
+        assertTrue(read.hasField("newInt64Field"));
+        assertEquals(read.getSchema().getField("newInt64Field").schema(), LONG_SCHEMA);
+        assertEquals(read.get("newInt64Field"), 9223372036854775807L);
+
+        assertTrue(read.hasField("newFloatField"));
+        assertEquals(read.getSchema().getField("newFloatField").schema(), DOUBLE_SCHEMA);
+        assertEquals(read.get("newFloatField"), 340282346638528859999999999999999999999.999999D);
+
+        assertTrue(read.hasField("newDoubleField"));
+        assertEquals(read.getSchema().getField("newDoubleField").schema(), DOUBLE_SCHEMA);
+        assertEquals(read.get("newDoubleField"), 1.79769313486231570e+308D);
+
+        assertTrue(read.hasField("newBooleanField"));
+        assertEquals(read.getSchema().getField("newBooleanField").schema(), BOOLEAN_SCHEMA);
+        assertTrue((Boolean) read.get("newBooleanField"));
+
+        assertTrue(read.hasField("newBytesField"));
+        assertEquals(read.getSchema().getField("newBytesField").schema(), BYTES_SCHEMA);
+        assertEquals(
+                read.get("newBytesField"),
+                ByteBuffer.wrap("Hotaru".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test(expectedExceptions = AvroRuntimeException.class)
+    void testAvroNullsNotAllowed() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Collections.singletonList(
+                                        ComputeField.builder()
+                                                .scopedName("value.newLongField")
+                                                .expression("null")
+                                                .optional(false)
+                                                .type(ComputeFieldType.INT64)
+                                                .build()))
+                        .build();
+        Utils.process(record, step);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    void testAvroNullInferredType() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord = genericSchema.newRecordBuilder().build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        List<ComputeField> fields = new ArrayList<>();
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("value.newStringField")
+                        .expression("null")
+                        .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Utils.process(record, step);
+    }
+
+    @Test
+    void testAvroWithNonNullOptionalFields() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(buildComputeFields("value", true, false, false))
+                        .build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(outputRecord.getKey().orElse(null), "test-key");
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertEquals(read.get("firstName"), new Utf8("Jane"));
+        assertOptionalField(read, "newStringField", STRING, new Utf8("Hotaru"));
+        assertOptionalField(read, "newInt32Field", INT, 2147483647);
+        assertOptionalField(read, "newInt64Field", LONG, 9223372036854775807L);
+        assertOptionalField(
+                read, "newFloatField", FLOAT, 340282346638528859999999999999999999999.999999F);
+        assertOptionalField(read, "newDoubleField", DOUBLE, 1.79769313486231570e+308D);
+        assertOptionalField(read, "newBooleanField", BOOLEAN, true);
+        assertOptionalField(
+                read,
+                "newBytesField",
+                BYTES,
+                ByteBuffer.wrap("Hotaru".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void testAvroWithNullOptionalFields() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(buildComputeFields("value", true, true, false))
+                        .build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(outputRecord.getKey().orElse(null), "test-key");
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertEquals(read.get("firstName"), new Utf8("Jane"));
+        assertOptionalFieldNull(read, "newStringField", STRING);
+        assertOptionalFieldNull(read, "newInt32Field", INT);
+        assertOptionalFieldNull(read, "newInt64Field", LONG);
+        assertOptionalFieldNull(read, "newFloatField", FLOAT);
+        assertOptionalFieldNull(read, "newDoubleField", DOUBLE);
+        assertOptionalFieldNull(read, "newBooleanField", BOOLEAN);
+        assertOptionalFieldNull(read, "newBytesField", BYTES);
+    }
+
+    @Test
+    void testAvroWithCqlDecimal() throws Exception {
+        List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        fields.add(createDecimalField("cqlDecimalField"));
+
+        org.apache.avro.Schema avroSchema =
+                org.apache.avro.Schema.createRecord("custom", "", "ns1", false, fields);
+        org.apache.avro.generic.GenericRecord avroRecord = new GenericData.Record(avroSchema);
+        BigDecimal decimal =
+                new BigDecimal(new BigInteger("1234567890123456789012345678901234567890"), 38);
+        avroRecord.put("cqlDecimalField", createDecimalRecord(decimal));
+        Schema<org.apache.avro.generic.GenericRecord> genericSchema =
+                new Utils.NativeSchemaWrapper(avroSchema, SchemaType.AVRO);
+        List<Field> pulsarFields =
+                fields.stream().map(v -> new Field(v.name(), v.pos())).collect(Collectors.toList());
+        GenericAvroRecord genericRecord =
+                new GenericAvroRecord(new byte[0], avroSchema, pulsarFields, avroRecord);
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                List.of(
+                                        ComputeField.builder()
+                                                .scopedName("value.decimalField")
+                                                .expression(
+                                                        "fn:decimalFromUnscaled(value.cqlDecimalField.bigint, value.cqlDecimalField.scale)")
+                                                .type(ComputeFieldType.DECIMAL)
+                                                .build(),
+                                        ComputeField.builder()
+                                                .scopedName("value.decimalFieldFromDouble")
+                                                .expression("fn:decimalFromNumber(12.23)")
+                                                .type(ComputeFieldType.DECIMAL)
+                                                .build()))
+                        .build();
+        Record<?> outputRecord = Utils.process(record, step);
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertEquals(read.get("decimalField"), decimal);
+        assertEquals(read.get("decimalFieldFromDouble"), BigDecimal.valueOf(12.23d));
+    }
+
+    @Test
+    void testKeyValueAvro() throws Exception {
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Arrays.asList(
+                                        ComputeField.builder()
+                                                .scopedName("value.newValueStringField")
+                                                .expression("value.valueField1")
+                                                .type(ComputeFieldType.STRING)
+                                                .build(),
+                                        ComputeField.builder()
+                                                .scopedName("key.newKeyStringField")
+                                                .expression("key.keyField1")
+                                                .type(ComputeFieldType.STRING)
+                                                .build()))
+                        .build();
+
+        Record<?> outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyAvroRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(keyAvroRecord.getSchema().getFields().size(), 4);
+        assertEquals(keyAvroRecord.get("keyField1"), new Utf8("key1"));
+        assertEquals(keyAvroRecord.get("keyField2"), new Utf8("key2"));
+        assertEquals(keyAvroRecord.get("keyField3"), new Utf8("key3"));
+
+        assertTrue(keyAvroRecord.hasField("newKeyStringField"));
+        assertEquals(
+                keyAvroRecord.getSchema().getField("newKeyStringField").schema().getType(), STRING);
+        assertEquals(keyAvroRecord.get("newKeyStringField"), new Utf8("key1"));
+
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals(valueAvroRecord.getSchema().getFields().size(), 4);
+        assertEquals(valueAvroRecord.get("valueField1"), new Utf8("value1"));
+        assertEquals(valueAvroRecord.get("valueField2"), new Utf8("value2"));
+        assertEquals(valueAvroRecord.get("valueField3"), new Utf8("value3"));
+
+        assertTrue(valueAvroRecord.hasField("newValueStringField"));
+        assertEquals(
+                valueAvroRecord.getSchema().getField("newValueStringField").schema().getType(),
+                STRING);
+        assertEquals(valueAvroRecord.get("newValueStringField"), new Utf8("value1"));
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test
+    void testKeyValueJson() throws Exception {
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Arrays.asList(
+                                        ComputeField.builder()
+                                                .scopedName("value.newValueStringField")
+                                                .expression("value.valueField1")
+                                                .type(ComputeFieldType.STRING)
+                                                .build(),
+                                        ComputeField.builder()
+                                                .scopedName("key.newKeyStringField")
+                                                .expression("key.keyField1")
+                                                .type(ComputeFieldType.STRING)
+                                                .build()))
+                        .build();
+
+        Record<?> outputRecord = Utils.process(Utils.createTestJsonKeyValueRecord(), step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        JsonNode key = (JsonNode) messageValue.getKey();
+        assertEquals(key.get("keyField1").asText(), "key1");
+        assertEquals(key.get("keyField2").asText(), "key2");
+        assertEquals(key.get("keyField3").asText(), "key3");
+        assertEquals(key.get("newKeyStringField").asText(), "key1");
+
+        JsonNode value = (JsonNode) messageValue.getValue();
+        assertEquals(value.get("valueField1").asText(), "value1");
+        assertEquals(value.get("valueField2").asText(), "value2");
+        assertEquals(value.get("valueField3").asText(), "value3");
+        assertEquals(value.get("newValueStringField").asText(), "value1");
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test(dataProvider = "primitiveSchemaTypesProvider")
+    void testPrimitiveSchemaTypes(
+            String expression,
+            ComputeFieldType newSchema,
+            Object expectedValue,
+            Schema<?> expectedSchema)
+            throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject("", SchemaType.STRING, new byte[] {}),
+                        "test-key");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Collections.singletonList(
+                                        ComputeField.builder()
+                                                .scopedName("value")
+                                                .expression(expression)
+                                                .type(newSchema)
+                                                .build()))
+                        .build();
+
+        Record<GenericObject> outputRecord = Utils.process(record, step);
+
+        assertEquals(outputRecord.getSchema(), expectedSchema);
+        assertEquals(outputRecord.getValue(), expectedValue);
+    }
+
+    @Test(dataProvider = "primitiveInferredSchemaTypesProvider")
+    void testPrimitiveInferredSchemaTypes(
+            Object input,
+            Schema<?> inputSchema,
+            String expression,
+            Object expectedValue,
+            Schema<?> expectedSchema)
+            throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        inputSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                input, inputSchema.getSchemaInfo().getType(), new byte[] {}),
+                        "");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Collections.singletonList(
+                                        ComputeField.builder()
+                                                .scopedName("value")
+                                                .expression(expression)
+                                                .build()))
+                        .build();
+
+        Record<GenericObject> outputRecord = Utils.process(record, step);
+
+        assertEquals(outputRecord.getSchema(), expectedSchema);
+        assertEquals(outputRecord.getValue(), expectedValue);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    void testNullInferredSchemaType() throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                "input", SchemaType.STRING, new byte[] {}),
+                        "");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Collections.singletonList(
+                                        ComputeField.builder()
+                                                .scopedName("value")
+                                                .expression("null")
+                                                .build()))
+                        .build();
+
+        Utils.process(record, step);
+    }
+
+    @Test
+    void testKeyValuePrimitivesModified() throws Exception {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Arrays.asList(
+                                        ComputeField.builder()
+                                                .scopedName("key")
+                                                .expression("88")
+                                                .type(ComputeFieldType.INT32)
+                                                .build(),
+                                        ComputeField.builder()
+                                                .scopedName("value")
+                                                .expression("'newValue'")
+                                                .type(ComputeFieldType.STRING)
+                                                .build()))
+                        .build();
+
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(messageSchema.getKeySchema(), Schema.INT32);
+        assertEquals(messageSchema.getValueSchema(), Schema.STRING);
+
+        assertEquals(messageValue.getKey(), 88);
+        assertEquals(messageValue.getValue(), "newValue");
+    }
+
+    @Test
+    void testPrimitivesNotModified() throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                "value", SchemaType.STRING, new byte[] {}),
+                        "test-key");
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Collections.singletonList(
+                                        ComputeField.builder()
+                                                .scopedName("value.newField")
+                                                .expression("newValue")
+                                                .type(ComputeFieldType.STRING)
+                                                .build()))
+                        .build();
+
+        Record<GenericObject> outputRecord = Utils.process(record, step);
+
+        assertSame(outputRecord.getSchema(), record.getSchema());
+        assertSame(outputRecord.getValue(), record.getValue().getNativeObject());
+    }
+
+    @Test
+    void testKeyValuePrimitivesNotModified() throws Exception {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        ComputeStep step =
+                ComputeStep.builder()
+                        .fields(
+                                Arrays.asList(
+                                        ComputeField.builder()
+                                                .scopedName("value.newField")
+                                                .expression("newValue")
+                                                .type(ComputeFieldType.STRING)
+                                                .build(),
+                                        ComputeField.builder()
+                                                .scopedName("key.newField")
+                                                .expression("newValue")
+                                                .type(ComputeFieldType.STRING)
+                                                .build()))
+                        .build();
+
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
+        KeyValue<?, ?> recordValue = ((KeyValue<?, ?>) record.getValue().getNativeObject());
+        assertSame(messageSchema.getKeySchema(), recordSchema.getKeySchema());
+        assertSame(messageSchema.getValueSchema(), recordSchema.getValueSchema());
+        assertSame(messageValue.getKey(), recordValue.getKey());
+        assertSame(messageValue.getValue(), recordValue.getValue());
+    }
+
+    @Test(dataProvider = "destinationTopicProvider")
+    void testAvroComputeDestinationTopic(String topic) throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .schema(genericSchema)
+                        .value(genericRecord)
+                        .destinationTopic(topic)
+                        .build();
+
+        List<ComputeField> fields = buildComputeFields("value", false, false, false);
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("destinationTopic")
+                        .expression("destinationTopic == 'targetTopic' ? 'route' : 'dont-route'")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+
+        assertEquals(
+                outputRecord.getDestinationTopic().orElseThrow(),
+                topic.equals("targetTopic") ? "route" : "dont-route");
+        assertEquals(read.get("firstName"), new Utf8("Jane"));
+    }
+
+    @Test
+    void testAvroComputeMessageKey() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .schema(genericSchema)
+                        .value(genericRecord)
+                        .key("old")
+                        .build();
+
+        List<ComputeField> fields = buildComputeFields("value", false, false, false);
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("messageKey")
+                        .expression("'new'")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+
+        assertTrue(outputRecord.getKey().isPresent());
+        assertEquals(outputRecord.getKey().get(), "new");
+        assertEquals(read.get("firstName"), new Utf8("Jane"));
+    }
+
+    @Test
+    void testAvroComputeHeaderProperties() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .schema(genericSchema)
+                        .value(genericRecord)
+                        .properties(Map.of("existingKey", "v1", "nonExistingKey", "v2"))
+                        .build();
+
+        List<ComputeField> fields = new ArrayList<>();
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("properties.existingKey")
+                        .expression("'c1'")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName("properties.newKey")
+                        .expression("'c2'")
+                        .type(ComputeFieldType.STRING)
+                        .build());
+        ComputeStep step = ComputeStep.builder().fields(fields).build();
+        Record<?> outputRecord = Utils.process(record, step);
+
+        assertEquals(outputRecord.getProperties().size(), 3);
+        assertTrue(outputRecord.getProperties().containsKey("existingKey"));
+        assertTrue(outputRecord.getProperties().containsKey("nonExistingKey"));
+        assertTrue(outputRecord.getProperties().containsKey("newKey"));
+        assertEquals(outputRecord.getProperties().get("existingKey"), "c1");
+        assertEquals(outputRecord.getProperties().get("nonExistingKey"), "v2");
+        assertEquals(outputRecord.getProperties().get("newKey"), "c2");
+    }
+
+    @DataProvider(name = "destinationTopicProvider")
+    public static Object[] destinationTopicProvider() {
+        return new Object[] {"targetTopic", "randomTopic"};
+    }
+
+    /**
+     * @return {"expression", "new schema", "expected value", "expectedSchema"}
+     */
+    @DataProvider(name = "primitiveSchemaTypesProvider")
+    public static Object[][] primitiveSchemaTypesProvider() {
+        return new Object[][] {
+            {"'newValue'", ComputeFieldType.STRING, "newValue", Schema.STRING},
+            {"'4'", ComputeFieldType.INT8, (byte) 4, Schema.INT8},
+            {"'4'", ComputeFieldType.INT16, (short) 4, Schema.INT16},
+            {"'4'", ComputeFieldType.INT32, 4, Schema.INT32},
+            {"'4'", ComputeFieldType.INT64, 4L, Schema.INT64},
+            {"'3.2'", ComputeFieldType.FLOAT, 3.2F, Schema.FLOAT},
+            {"'3.2'", ComputeFieldType.DOUBLE, 3.2D, Schema.DOUBLE},
+            {"true", ComputeFieldType.BOOLEAN, true, Schema.BOOL},
+            {"'2008-02-07'", ComputeFieldType.DATE, LocalDate.parse("2008-02-07"), Schema.DATE},
+            {
+                "'2008-02-07'",
+                ComputeFieldType.LOCAL_DATE,
+                LocalDate.parse("2008-02-07"),
+                Schema.LOCAL_DATE
+            },
+            {"'03:04:05'", ComputeFieldType.TIME, Time.valueOf("03:04:05"), Schema.TIME},
+            {
+                "'03:04:05'",
+                ComputeFieldType.LOCAL_TIME,
+                LocalTime.parse("03:04:05"),
+                Schema.LOCAL_TIME
+            },
+            {
+                "'2009-01-02T01:02:03Z'",
+                ComputeFieldType.INSTANT,
+                Instant.parse("2009-01-02T01:02:03Z"),
+                Schema.INSTANT
+            },
+            {
+                "'2009-01-02T01:02:03Z'",
+                ComputeFieldType.DATETIME,
+                Instant.parse("2009-01-02T01:02:03Z"),
+                Schema.INSTANT
+            },
+            {
+                "'2009-01-02T01:02:03Z'",
+                ComputeFieldType.TIMESTAMP,
+                Timestamp.from(Instant.parse("2009-01-02T01:02:03Z")),
+                Schema.TIMESTAMP
+            },
+            {
+                "'2009-01-02T01:02:03'",
+                ComputeFieldType.LOCAL_DATE_TIME,
+                LocalDateTime.parse("2009-01-02T01:02:03"),
+                Schema.LOCAL_DATE_TIME
+            },
+            {
+                "'newValue'.bytes",
+                ComputeFieldType.BYTES,
+                "newValue".getBytes(StandardCharsets.UTF_8),
+                Schema.BYTES
+            },
+        };
+    }
+
+    @DataProvider(name = "primitiveInferredSchemaTypesProvider")
+    public static Object[][] primitiveInferredSchemaTypesProvider() {
+        LocalDateTime now = LocalDateTime.now();
+        return new Object[][] {
+            {"", Schema.STRING, "'newValue'", "newValue", Schema.STRING},
+            {"", Schema.STRING, "42", 42L, Schema.INT64},
+            {"", Schema.STRING, "42.0", 42.0D, Schema.DOUBLE},
+            {"", Schema.STRING, "true", true, Schema.BOOL},
+            {
+                "",
+                Schema.STRING,
+                "'newValue'.bytes",
+                "newValue".getBytes(StandardCharsets.UTF_8),
+                Schema.BYTES
+            },
+            {(byte) 42, Schema.INT8, "value", (byte) 42, Schema.INT8},
+            {(short) 42, Schema.INT16, "value", (short) 42, Schema.INT16},
+            {42, Schema.INT32, "value", 42, Schema.INT32},
+            {new Date(42), Schema.DATE, "value", new Date(42), Schema.DATE},
+            {new Timestamp(42), Schema.TIMESTAMP, "value", new Timestamp(42), Schema.TIMESTAMP},
+            {new Time(42), Schema.TIME, "value", new Time(42), Schema.TIME},
+            {now, Schema.LOCAL_DATE_TIME, "value", now, Schema.LOCAL_DATE_TIME},
+            {now.toLocalDate(), Schema.LOCAL_DATE, "value", now.toLocalDate(), Schema.LOCAL_DATE},
+            {now.toLocalTime(), Schema.LOCAL_TIME, "value", now.toLocalTime(), Schema.LOCAL_TIME},
+            {
+                now.toInstant(ZoneOffset.UTC),
+                Schema.INSTANT,
+                "value",
+                now.toInstant(ZoneOffset.UTC),
+                Schema.INSTANT
+            },
+        };
+    }
+
+    private void assertOptionalFieldNull(
+            GenericData.Record record, String fieldName, org.apache.avro.Schema.Type expectedType) {
+        assertOptionalField(record, fieldName, expectedType, null);
+    }
+
+    private List<ComputeField> buildComputeFields(
+            String scope, boolean optional, boolean nullify, boolean inferType) {
+        List<ComputeField> fields = new ArrayList<>();
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newStringField")
+                        .expression(nullify ? "null" : "'Hotaru'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.STRING)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newInt8Field")
+                        .expression(nullify ? "null" : "127")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INT8)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newInt16Field")
+                        .expression(nullify ? "null" : "32767")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INT16)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newInt32Field")
+                        .expression(nullify ? "null" : "2147483647")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INT32)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newInt64Field")
+                        .expression(nullify ? "null" : "9223372036854775807")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INT64)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newFloatField")
+                        .expression(
+                                nullify ? "null" : "340282346638528859999999999999999999999.999999")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.FLOAT)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newDoubleField")
+                        .expression(nullify ? "null" : "1.79769313486231570e+308")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.DOUBLE)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newBooleanField")
+                        .expression(nullify ? "null" : "1 == 1")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.BOOLEAN)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newDateField")
+                        .expression(nullify ? "null" : "'2007-12-03'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.DATE)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newDateField2")
+                        .expression(nullify ? "null" : "13850")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.DATE)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newLocalDateField")
+                        .expression(nullify ? "null" : "'2007-12-03'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.LOCAL_DATE)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newLocalDateField2")
+                        .expression(nullify ? "null" : "13850")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.DATE)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newTimeField")
+                        .expression(nullify ? "null" : "'10:15:30'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.TIME)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newTimeField2")
+                        .expression(nullify ? "null" : "36930000")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.TIME)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newLocalTimeField")
+                        .expression(nullify ? "null" : "'10:15:30'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.LOCAL_TIME)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newLocalTimeField2")
+                        .expression(nullify ? "null" : "36930000")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.TIME)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newTimestampField")
+                        .expression(nullify ? "null" : "'2007-12-03T10:15:30+00:00'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INSTANT)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newTimestampField2")
+                        .expression(nullify ? "null" : "1196676930000")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INSTANT)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newInstantField")
+                        .expression(nullify ? "null" : "'2007-12-03T10:15:30+00:00'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.TIMESTAMP)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newInstantField2")
+                        .expression(nullify ? "null" : "1196676930000")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INSTANT)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newLocalDateTimeField")
+                        .expression(nullify ? "null" : "'2007-12-03T10:15:30'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.LOCAL_DATE_TIME)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newLocalDateTimeField2")
+                        .expression(nullify ? "null" : "1196676930000")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.INSTANT)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newDateTimeField")
+                        .expression(nullify ? "null" : "'2007-12-03T10:15:30+00:00'")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.DATETIME)
+                        .build());
+        fields.add(
+                ComputeField.builder()
+                        .scopedName(scope + "." + "newBytesField")
+                        .expression(nullify ? "null" : "'Hotaru'.bytes")
+                        .optional(optional)
+                        .type(inferType ? null : ComputeFieldType.BYTES)
+                        .build());
+
+        return fields;
+    }
+
+    private org.apache.avro.generic.GenericRecord createDecimalRecord(BigDecimal decimal) {
+        decimal.unscaledValue().toByteArray();
+        org.apache.avro.generic.GenericRecord decimalRecord = new GenericData.Record(decimalType);
+        decimalRecord.put(
+                CQL_DECIMAL_BIGINT, ByteBuffer.wrap(decimal.unscaledValue().toByteArray()));
+        decimalRecord.put(CQL_DECIMAL_SCALE, decimal.scale());
+        return decimalRecord;
+    }
+
+    private org.apache.avro.Schema.Field createDecimalField(String name) {
+        org.apache.avro.Schema.Field decimalField =
+                new org.apache.avro.Schema.Field(name, decimalType);
+        org.apache.avro.Schema.Field optionalDecimalField =
+                new org.apache.avro.Schema.Field(
+                        name,
+                        org.apache.avro.SchemaBuilder.unionOf()
+                                .nullType()
+                                .and()
+                                .type(decimalField.schema())
+                                .endUnion(),
+                        null,
+                        org.apache.avro.Schema.Field.NULL_DEFAULT_VALUE);
+
+        return optionalDecimalField;
+    }
+
+    private static class CqlDecimalLogicalType extends LogicalType {
+        public CqlDecimalLogicalType() {
+            super(CQL_DECIMAL);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeStepTest.java
@@ -72,9 +72,9 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.Test;
 
 public class ComputeStepTest {
 
@@ -611,56 +611,60 @@ public class ComputeStepTest {
 
     @Test
     void testAvroNullsNotAllowed() throws Exception {
-        assertThrows(AvroRuntimeException.class, () -> {
-            RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
-            recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        assertThrows(
+                AvroRuntimeException.class,
+                () -> {
+                    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+                    recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
 
-            SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
-            GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+                    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+                    GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
 
-            GenericRecord genericRecord =
-                    genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+                    GenericRecord genericRecord =
+                            genericSchema.newRecordBuilder().set("firstName", "Jane").build();
 
-            Record<GenericObject> record =
-                    new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+                    Record<GenericObject> record =
+                            new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
 
-            ComputeStep step =
-                    ComputeStep.builder()
-                            .fields(
-                                    Collections.singletonList(
-                                            ComputeField.builder()
-                                                    .scopedName("value.newLongField")
-                                                    .expression("null")
-                                                    .optional(false)
-                                                    .type(ComputeFieldType.INT64)
-                                                    .build()))
-                            .build();
-            Utils.process(record, step);
-        });
+                    ComputeStep step =
+                            ComputeStep.builder()
+                                    .fields(
+                                            Collections.singletonList(
+                                                    ComputeField.builder()
+                                                            .scopedName("value.newLongField")
+                                                            .expression("null")
+                                                            .optional(false)
+                                                            .type(ComputeFieldType.INT64)
+                                                            .build()))
+                                    .build();
+                    Utils.process(record, step);
+                });
     }
 
     @Test
     void testAvroNullInferredType() throws Exception {
-        assertThrows(UnsupportedOperationException.class, () -> {
-        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> {
+                    RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
 
-        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
-        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+                    SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+                    GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
 
-        GenericRecord genericRecord = genericSchema.newRecordBuilder().build();
+                    GenericRecord genericRecord = genericSchema.newRecordBuilder().build();
 
-        Record<GenericObject> record =
-                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+                    Record<GenericObject> record =
+                            new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
 
-        List<ComputeField> fields = new ArrayList<>();
-        fields.add(
-                ComputeField.builder()
-                        .scopedName("value.newStringField")
-                        .expression("null")
-                        .build());
-        ComputeStep step = ComputeStep.builder().fields(fields).build();
-        Utils.process(record, step);
-        });
+                    List<ComputeField> fields = new ArrayList<>();
+                    fields.add(
+                            ComputeField.builder()
+                                    .scopedName("value.newStringField")
+                                    .expression("null")
+                                    .build());
+                    ComputeStep step = ComputeStep.builder().fields(fields).build();
+                    Utils.process(record, step);
+                });
     }
 
     @Test
@@ -938,26 +942,28 @@ public class ComputeStepTest {
 
     @Test
     void testNullInferredSchemaType() throws Exception {
-        assertThrows(UnsupportedOperationException.class, () -> {
-            Record<GenericObject> record =
-                    new Utils.TestRecord<>(
-                            Schema.STRING,
-                            AutoConsumeSchema.wrapPrimitiveObject(
-                                    "input", SchemaType.STRING, new byte[]{}),
-                            "");
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> {
+                    Record<GenericObject> record =
+                            new Utils.TestRecord<>(
+                                    Schema.STRING,
+                                    AutoConsumeSchema.wrapPrimitiveObject(
+                                            "input", SchemaType.STRING, new byte[] {}),
+                                    "");
 
-            ComputeStep step =
-                    ComputeStep.builder()
-                            .fields(
-                                    Collections.singletonList(
-                                            ComputeField.builder()
-                                                    .scopedName("value")
-                                                    .expression("null")
-                                                    .build()))
-                            .build();
+                    ComputeStep step =
+                            ComputeStep.builder()
+                                    .fields(
+                                            Collections.singletonList(
+                                                    ComputeField.builder()
+                                                            .scopedName("value")
+                                                            .expression("null")
+                                                            .build()))
+                                    .build();
 
-            Utils.process(record, step);
-        });
+                    Utils.process(record, step);
+                });
     }
 
     @Test

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropFieldStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropFieldStepTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class DropFieldStepTest {
+
+    @Test
+    void testAvro() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        DropFieldStep step =
+                DropFieldStep.builder().valueFields(Arrays.asList("firstName", "lastName")).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(outputRecord.getKey().orElse(null), "test-key");
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertEquals(read.get("age"), 42);
+        assertNull(read.getSchema().getField("firstName"));
+        assertNull(read.getSchema().getField("lastName"));
+    }
+
+    @Test
+    void testJson() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.JSON);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        DropFieldStep step =
+                DropFieldStep.builder().valueFields(Arrays.asList("firstName", "lastName")).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(outputRecord.getKey().orElse(null), "test-key");
+
+        JsonNode read = (JsonNode) outputRecord.getValue();
+        assertEquals(read.get("age").asInt(), 42);
+        assertNull(read.get("firstName"));
+        assertNull(read.get("lastName"));
+    }
+
+    @Test
+    void testStringJson() throws Exception {
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                value, SchemaType.STRING, new byte[] {}),
+                        "test-key");
+
+        DropFieldStep step =
+                DropFieldStep.builder().valueFields(Collections.singletonList("value1")).build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(
+                outputRecord.getValue(),
+                "{\"valueField1\":\"value1\",\"valueField2\":\"value2\","
+                        + "\"valueField3\":\"value3\"}");
+    }
+
+    @Test
+    void testBytesJson() throws Exception {
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.BYTES,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                value.getBytes(StandardCharsets.UTF_8),
+                                SchemaType.BYTES,
+                                new byte[] {}),
+                        "test-key");
+
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .valueFields(Collections.singletonList("valueField1"))
+                        .build();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertEquals(
+                new String((byte[]) outputRecord.getValue(), StandardCharsets.UTF_8),
+                "{\"valueField2\":\"value2\",\"valueField3\":\"value3\"}");
+    }
+
+    @Test
+    void testKeyValueAvro() throws Exception {
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .keyFields(Arrays.asList("keyField1", "keyField2"))
+                        .valueFields(Arrays.asList("valueField1", "valueField2"))
+                        .build();
+        Record<?> outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyAvroRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(keyAvroRecord.get("keyField3"), new Utf8("key3"));
+        assertNull(keyAvroRecord.getSchema().getField("keyField1"));
+        assertNull(keyAvroRecord.getSchema().getField("keyField2"));
+
+        GenericData.Record valueAvroRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals(valueAvroRecord.get("valueField3"), new Utf8("value3"));
+        assertNull(valueAvroRecord.getSchema().getField("valueField1"));
+        assertNull(valueAvroRecord.getSchema().getField("valueField2"));
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test
+    void testKeyValueJson() throws Exception {
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .keyFields(Arrays.asList("keyField1", "keyField2"))
+                        .valueFields(Arrays.asList("valueField1", "valueField2"))
+                        .build();
+        Record<?> outputRecord = Utils.process(Utils.createTestJsonKeyValueRecord(), step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        JsonNode key = (JsonNode) messageValue.getKey();
+        assertEquals(key.get("keyField3").asText(), "key3");
+        assertNull(key.get("keyField1"));
+        assertNull(key.get("keyField2"));
+
+        JsonNode value = (JsonNode) messageValue.getValue();
+        assertEquals(value.get("valueField3").asText(), "value3");
+        assertNull(value.get("valueField1"));
+        assertNull(value.get("valueField2"));
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test
+    void testKeyValueStringJson() throws Exception {
+        Schema<KeyValue<String, String>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.STRING, KeyValueEncodingType.SEPARATED);
+
+        String key = "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}";
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                new KeyValue<>(key, value), SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .keyFields(Arrays.asList("keyField1", "keyField2"))
+                        .valueFields(Arrays.asList("valueField1", "valueField2"))
+                        .build();
+
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(messageValue.getKey(), "{\"keyField3\":\"key3\"}");
+        assertEquals(messageValue.getValue(), "{\"valueField3\":\"value3\"}");
+    }
+
+    @Test
+    void testKeyValueBytesJson() throws Exception {
+        Schema<KeyValue<byte[], byte[]>> keyValueSchema =
+                Schema.KeyValue(Schema.BYTES, Schema.BYTES, KeyValueEncodingType.SEPARATED);
+
+        String key = "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}";
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                new KeyValue<>(
+                                        key.getBytes(StandardCharsets.UTF_8),
+                                        value.getBytes(StandardCharsets.UTF_8)),
+                                SchemaType.KEY_VALUE,
+                                new byte[] {}),
+                        null);
+
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .keyFields(Arrays.asList("keyField1", "keyField2"))
+                        .valueFields(Arrays.asList("valueField1", "valueField2"))
+                        .build();
+
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(
+                new String((byte[]) messageValue.getKey(), StandardCharsets.UTF_8),
+                "{\"keyField3\":\"key3\"}");
+        assertEquals(
+                new String((byte[]) messageValue.getValue(), StandardCharsets.UTF_8),
+                "{\"valueField3\":\"value3\"}");
+    }
+
+    @Test
+    void testKeyValueAvroCached() throws Exception {
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .keyFields(Arrays.asList("keyField1", "keyField2"))
+                        .valueFields(Arrays.asList("valueField1", "valueField2"))
+                        .build();
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+
+        outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
+        KeyValueSchema<?, ?> newMessageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+
+        // Schema was modified by process operation
+        KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
+        assertNotSame(
+                messageSchema.getKeySchema().getNativeSchema().orElseThrow(),
+                recordSchema.getKeySchema().getNativeSchema().orElseThrow());
+        assertNotSame(
+                messageSchema.getValueSchema().getNativeSchema().orElseThrow(),
+                recordSchema.getValueSchema().getNativeSchema().orElseThrow());
+
+        // Multiple process output the same cached schema
+        assertSame(
+                messageSchema.getKeySchema().getNativeSchema().orElseThrow(),
+                newMessageSchema.getKeySchema().getNativeSchema().orElseThrow());
+        assertSame(
+                messageSchema.getValueSchema().getNativeSchema().orElseThrow(),
+                newMessageSchema.getValueSchema().getNativeSchema().orElseThrow());
+    }
+
+    @Test
+    void testPrimitives() throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                "value", SchemaType.STRING, new byte[] {}),
+                        "test-key");
+
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .keyFields(Collections.singletonList("key"))
+                        .valueFields(Collections.singletonList("value"))
+                        .build();
+        Record<GenericObject> outputRecord = Utils.process(record, step);
+
+        assertSame(outputRecord.getSchema(), record.getSchema());
+        assertSame(outputRecord.getValue(), record.getValue().getNativeObject());
+    }
+
+    @Test
+    void testKeyValuePrimitives() throws Exception {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        DropFieldStep step =
+                DropFieldStep.builder()
+                        .keyFields(Collections.singletonList("key"))
+                        .valueFields(Collections.singletonList("value"))
+                        .build();
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
+        KeyValue<?, ?> recordValue = ((KeyValue<?, ?>) record.getValue().getNativeObject());
+        assertSame(messageSchema.getKeySchema(), recordSchema.getKeySchema());
+        assertSame(messageSchema.getValueSchema(), recordSchema.getValueSchema());
+        assertSame(messageValue.getKey(), recordValue.getKey());
+        assertSame(messageValue.getValue(), recordValue.getValue());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropFieldStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropFieldStepTest.java
@@ -15,10 +15,10 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotSame;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.charset.StandardCharsets;
@@ -39,7 +39,7 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class DropFieldStepTest {
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.testng.Assert.assertNull;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class DropTest {
+
+    @Test
+    void testAvro() throws Exception {
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema.newRecordBuilder().set("firstName", "Jane").build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+
+        DropStep step = new DropStep();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertNull(outputRecord);
+    }
+
+    @Test
+    void testKeyValueAvro() throws Exception {
+        DropStep step = new DropStep();
+        Record<?> outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
+        assertNull(outputRecord);
+    }
+
+    @Test
+    void testPrimitives() throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                "value", SchemaType.STRING, new byte[] {}),
+                        "test-key");
+
+        DropStep step = new DropStep();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertNull(outputRecord);
+    }
+
+    @Test
+    void testKeyValuePrimitives() throws Exception {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        DropStep step = new DropStep();
+        Record<?> outputRecord = Utils.process(record, step);
+        assertNull(outputRecord);
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/DropTest.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import static org.testng.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
@@ -29,7 +29,7 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class DropTest {
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/FlattenStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/FlattenStepTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static com.datastax.oss.streaming.ai.FlattenStep.AVRO_READ_OFFSET_PROP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class FlattenStepTest {
+
+    @Test
+    void testRegularKeyValueNotModified() throws Exception {
+        // given
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+
+        // when
+        Record<?> outputRecord = Utils.process(record, FlattenStep.builder().build());
+
+        // then (key & value remain unchanged)
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        GenericData.Record valueRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+        assertEquals(keyRecord.getSchema().getFields().size(), 3);
+        assertEquals(keyRecord.get("keyField1"), new Utf8("key1"));
+        assertEquals(keyRecord.get("keyField2"), new Utf8("key2"));
+        assertEquals(keyRecord.get("keyField3"), new Utf8("key3"));
+
+        assertEquals(valueRecord.getSchema().getFields().size(), 3);
+        assertEquals(valueRecord.get("valueField1"), new Utf8("value1"));
+        assertEquals(valueRecord.get("valueField2"), new Utf8("value2"));
+        assertEquals(valueRecord.get("valueField3"), new Utf8("value3"));
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test
+    void testNestedKeyValueFlattened() throws Exception {
+        // given
+        Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+        // when
+        Record<?> outputRecord = Utils.process(nestedKVRecord, FlattenStep.builder().build());
+
+        // then
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        GenericData.Record valueRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+        // Assert value flattened
+        GenericData.Record key =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getKey())
+                                .getAvroRecord();
+        assertSchemasFlattened(keyRecord, key);
+        assertValuesFlattened(keyRecord, key);
+
+        // Assert value flattened
+        GenericData.Record value =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getValue())
+                                .getAvroRecord();
+        assertSchemasFlattened(valueRecord, value);
+        assertValuesFlattened(valueRecord, value);
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test
+    void testNestedValueFlattened() throws Exception {
+        // given
+        Record<GenericObject> record = Utils.createNestedAvroRecord(4, "myKey");
+
+        // when
+        Record<?> outputRecord = Utils.process(record, FlattenStep.builder().part("value").build());
+
+        // then
+        assertEquals(outputRecord.getKey(), Optional.of("myKey"));
+
+        GenericData.Record valueRecord =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+
+        // Assert value flattened
+        GenericData.Record value = (GenericData.Record) record.getValue().getNativeObject();
+        assertSchemasFlattened(valueRecord, value);
+        assertValuesFlattened(valueRecord, value);
+    }
+
+    @Test
+    void testNestedKeyValueFlattenedWithCustomDelimiter() throws Exception {
+        // given
+        Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+        // when
+        Record<?> outputRecord =
+                Utils.process(
+                        nestedKVRecord,
+                        FlattenStep.builder().delimiter("_CUSTOM_DELIMITER_").build());
+
+        // then
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        GenericData.Record valueRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+        // Assert value flattened
+        GenericData.Record key =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getKey())
+                                .getAvroRecord();
+        assertSchemasFlattened(keyRecord, key, "_CUSTOM_DELIMITER_");
+        assertValuesFlattened(keyRecord, key, "_CUSTOM_DELIMITER_");
+
+        // Assert value flattened
+        GenericData.Record value =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getValue())
+                                .getAvroRecord();
+        assertSchemasFlattened(valueRecord, value, "_CUSTOM_DELIMITER_");
+        assertValuesFlattened(valueRecord, value, "_CUSTOM_DELIMITER_");
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test
+    void testNestedKeyValueKeyOnlyFlattened() throws Exception {
+        // given
+        Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+        // when
+        Record<?> outputRecord =
+                Utils.process(nestedKVRecord, FlattenStep.builder().part("key").build());
+
+        // then
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        GenericData.Record valueRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+        // Assert key flattened
+        GenericData.Record key =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getKey())
+                                .getAvroRecord();
+        assertSchemasFlattened(keyRecord, key);
+        assertValuesFlattened(keyRecord, key);
+
+        // Assert value unchanged
+        GenericData.Record value =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getValue())
+                                .getAvroRecord();
+        assertEquals(valueRecord, value);
+
+        assertEquals(messageSchema.getKeyValueEncodingType(), KeyValueEncodingType.SEPARATED);
+    }
+
+    @Test
+    void testNestedKeyValueValueOnlyFlattened() throws Exception {
+        // given
+        Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+        // when
+        Record<?> outputRecord =
+                Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
+
+        // then
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record keyRecord =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        GenericData.Record valueRecord =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+
+        // Assert key unchanged
+        GenericData.Record key =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getKey())
+                                .getAvroRecord();
+        assertEquals(keyRecord, key);
+
+        // Assert value flattened
+        GenericData.Record value =
+                (GenericData.Record)
+                        ((GenericAvroRecord)
+                                        ((KeyValue<?, ?>)
+                                                        nestedKVRecord.getValue().getNativeObject())
+                                                .getValue())
+                                .getAvroRecord();
+        assertSchemasFlattened(valueRecord, value);
+        assertValuesFlattened(valueRecord, value);
+    }
+
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Unsupported part for Flatten: invalid")
+    void testNestedKeyValueInvalidType() throws Exception {
+        // given
+        Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+
+        // then
+        Utils.process(nestedKVRecord, FlattenStep.builder().part("invalid").build());
+    }
+
+    @Test(
+            expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Unsupported schema type for Flatten: JSON")
+    void testNestedKeyValueNonAvroSchema() throws Exception {
+        // given
+        Record<GenericObject> nestedKVRecord = Utils.createNestedJSONRecord(4, "myKey");
+
+        // then
+        Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
+    }
+
+    @Test(
+            expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Flatten requires non-null schemas!")
+    void testNestedSchemalessValue() throws Exception {
+        // given
+        Record<GenericObject> nestedKVRecord =
+                new Utils.TestRecord<>(
+                        null,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                "value", SchemaType.STRING, new byte[] {}),
+                        "myKey");
+
+        // then
+        Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
+    }
+
+    private void assertSchemasFlattened(
+            GenericData.Record actual, GenericData.Record expected, String delimiter) {
+        assertEquals(actual.getSchema().getFields().size(), 11);
+        assertTopLevelSchema(actual.getSchema(), expected.getSchema());
+        assertField(
+                actual.getSchema().getField("level1String"),
+                expected.getSchema().getField("level1String"));
+        Schema.Field expectedL1 = expected.getSchema().getField("level1Record");
+        assertField(
+                actual.getSchema()
+                        .getField(String.format("level1Record%1$slevel2String", delimiter)),
+                expectedL1.schema().getField("level2String"));
+        Schema.Field expectedL2 = expectedL1.schema().getField("level2Record");
+        assertField(
+                actual.getSchema()
+                        .getField(
+                                String.format(
+                                        "level1Record%1$slevel2Record%1$slevel3String", delimiter)),
+                expectedL2.schema().getField("level3String"));
+        Schema.Field expectedL3 = expectedL2.schema().getField("level3Record");
+        assertField(
+                actual.getSchema()
+                        .getField(
+                                String.format(
+                                        "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4String",
+                                        delimiter)),
+                expectedL3.schema().getField("level4String"));
+        assertField(
+                actual.getSchema()
+                        .getField(
+                                String.format(
+                                        "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Integer",
+                                        delimiter)),
+                expectedL3.schema().getField("level4Integer"));
+        assertField(
+                actual.getSchema()
+                        .getField(
+                                String.format(
+                                        "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Double",
+                                        delimiter)),
+                expectedL3.schema().getField("level4Double"));
+        assertField(
+                actual.getSchema()
+                        .getField(
+                                String.format(
+                                        "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4StringWithPropsAndAlias",
+                                        delimiter)),
+                expectedL3.schema().getField("level4StringWithPropsAndAlias"));
+        assertField(
+                actual.getSchema()
+                        .getField(
+                                String.format(
+                                        "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Union",
+                                        delimiter)),
+                expectedL3.schema().getField("level4Union"));
+    }
+
+    private void assertSchemasFlattened(GenericData.Record actual, GenericData.Record expected) {
+        assertSchemasFlattened(actual, expected, "_");
+    }
+
+    private void assertValuesFlattened(
+            GenericData.Record actual, GenericData.Record expected, String delimiter) {
+        assertEquals(actual.getSchema().getFields().size(), 11);
+
+        assertEquals(actual.get("level1String"), new Utf8((String) expected.get("level1String")));
+        GenericData.Record expectedL1 = (GenericData.Record) expected.get("level1Record");
+        assertEquals(
+                actual.get(String.format("level1Record%1$slevel2String", delimiter)),
+                new Utf8((String) expectedL1.get("level2String")));
+        GenericData.Record expectedL2 = (GenericData.Record) expectedL1.get("level2Record");
+        assertEquals(
+                actual.get(
+                        String.format("level1Record%1$slevel2Record%1$slevel3String", delimiter)),
+                new Utf8((String) expectedL2.get("level3String")));
+        GenericData.Record expectedL3 = (GenericData.Record) expectedL2.get("level3Record");
+        assertEquals(
+                actual.get(
+                        String.format(
+                                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4String",
+                                delimiter)),
+                new Utf8((String) expectedL3.get("level4String")));
+        assertEquals(
+                actual.get(
+                        String.format(
+                                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Integer",
+                                delimiter)),
+                expectedL3.get("level4Integer"));
+        assertEquals(
+                actual.get(
+                        String.format(
+                                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Double",
+                                delimiter)),
+                expectedL3.get("level4Double"));
+        assertEquals(
+                actual.get(
+                        String.format(
+                                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4StringWithPropsAndAlias",
+                                delimiter)),
+                new Utf8((String) expectedL3.get("level4StringWithPropsAndAlias")));
+        assertEquals(
+                actual.get(
+                        String.format(
+                                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Union",
+                                delimiter)),
+                new Utf8((String) expectedL3.get("level4Union")));
+        assertNull(
+                actual.get(
+                        String.format(
+                                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4Null",
+                                delimiter)));
+        assertNull(
+                actual.get(
+                        String.format(
+                                "level1Record%1$slevel2Record%1$slevel3Record%1$slevel4NullRecord%1$signored",
+                                delimiter)));
+    }
+
+    private void assertValuesFlattened(GenericData.Record actual, GenericData.Record expected) {
+        assertValuesFlattened(actual, expected, "_");
+    }
+
+    private void assertField(Schema.Field actual, Schema.Field expected) {
+        assertEquals(actual.schema(), expected.schema());
+        assertEquals(actual.doc(), expected.doc());
+        assertEquals(actual.defaultVal(), expected.defaultVal());
+        assertEquals(actual.getObjectProps(), expected.getObjectProps());
+        assertEquals(actual.aliases(), expected.aliases());
+    }
+
+    private void assertTopLevelSchema(Schema actual, Schema expected) {
+        assertEquals(actual.getName(), expected.getName());
+        assertEquals(actual.getNamespace(), expected.getNamespace());
+        assertEquals(actual.getDoc(), expected.getDoc());
+        assertEquals(
+                actual.getObjectProps(),
+                expected.getObjectProps().entrySet().stream()
+                        .filter(e -> !AVRO_READ_OFFSET_PROP.equals(e.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/FlattenStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/FlattenStepTest.java
@@ -36,7 +36,6 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
 import org.junit.jupiter.api.Test;
 
-
 public class FlattenStepTest {
 
     @Test
@@ -260,43 +259,65 @@ public class FlattenStepTest {
 
     @Test
     void testNestedKeyValueInvalidType() throws Exception {
-        assertEquals("Unsupported part for Flatten: invalid",
-        assertThrows(IllegalArgumentException.class, () -> {
-            // given
-            Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+        assertEquals(
+                "Unsupported part for Flatten: invalid",
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> {
+                                    // given
+                                    Record<GenericObject> nestedKVRecord =
+                                            Utils.createNestedAvroKeyValueRecord(4);
 
-            // then
-            Utils.process(nestedKVRecord, FlattenStep.builder().part("invalid").build());
-        }).getMessage());
+                                    // then
+                                    Utils.process(
+                                            nestedKVRecord,
+                                            FlattenStep.builder().part("invalid").build());
+                                })
+                        .getMessage());
     }
 
     @Test
     void testNestedKeyValueNonAvroSchema() throws Exception {
-        assertEquals("Unsupported schema type for Flatten: JSON",
-                assertThrows(IllegalStateException.class, () -> {
-        // given
-        Record<GenericObject> nestedKVRecord = Utils.createNestedJSONRecord(4, "myKey");
+        assertEquals(
+                "Unsupported schema type for Flatten: JSON",
+                assertThrows(
+                                IllegalStateException.class,
+                                () -> {
+                                    // given
+                                    Record<GenericObject> nestedKVRecord =
+                                            Utils.createNestedJSONRecord(4, "myKey");
 
-        // then
-        Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
-                }).getMessage());
+                                    // then
+                                    Utils.process(
+                                            nestedKVRecord,
+                                            FlattenStep.builder().part("value").build());
+                                })
+                        .getMessage());
     }
 
     @Test
     void testNestedSchemalessValue() throws Exception {
-        assertEquals("Flatten requires non-null schemas!",
-                assertThrows(IllegalStateException.class, () -> {
-        // given
-        Record<GenericObject> nestedKVRecord =
-                new Utils.TestRecord<>(
-                        null,
-                        AutoConsumeSchema.wrapPrimitiveObject(
-                                "value", SchemaType.STRING, new byte[] {}),
-                        "myKey");
+        assertEquals(
+                "Flatten requires non-null schemas!",
+                assertThrows(
+                                IllegalStateException.class,
+                                () -> {
+                                    // given
+                                    Record<GenericObject> nestedKVRecord =
+                                            new Utils.TestRecord<>(
+                                                    null,
+                                                    AutoConsumeSchema.wrapPrimitiveObject(
+                                                            "value",
+                                                            SchemaType.STRING,
+                                                            new byte[] {}),
+                                                    "myKey");
 
-        // then
-        Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
-                }).getMessage());
+                                    // then
+                                    Utils.process(
+                                            nestedKVRecord,
+                                            FlattenStep.builder().part("value").build());
+                                })
+                        .getMessage());
     }
 
     private void assertSchemasFlattened(

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/FlattenStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/FlattenStepTest.java
@@ -16,8 +16,9 @@
 package com.datastax.oss.streaming.ai;
 
 import static com.datastax.oss.streaming.ai.FlattenStep.AVRO_READ_OFFSET_PROP;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
 import java.util.Optional;
@@ -33,7 +34,8 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class FlattenStepTest {
 
@@ -256,32 +258,34 @@ public class FlattenStepTest {
         assertValuesFlattened(valueRecord, value);
     }
 
-    @Test(
-            expectedExceptions = IllegalArgumentException.class,
-            expectedExceptionsMessageRegExp = "Unsupported part for Flatten: invalid")
+    @Test
     void testNestedKeyValueInvalidType() throws Exception {
-        // given
-        Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
+        assertEquals("Unsupported part for Flatten: invalid",
+        assertThrows(IllegalArgumentException.class, () -> {
+            // given
+            Record<GenericObject> nestedKVRecord = Utils.createNestedAvroKeyValueRecord(4);
 
-        // then
-        Utils.process(nestedKVRecord, FlattenStep.builder().part("invalid").build());
+            // then
+            Utils.process(nestedKVRecord, FlattenStep.builder().part("invalid").build());
+        }).getMessage());
     }
 
-    @Test(
-            expectedExceptions = IllegalStateException.class,
-            expectedExceptionsMessageRegExp = "Unsupported schema type for Flatten: JSON")
+    @Test
     void testNestedKeyValueNonAvroSchema() throws Exception {
+        assertEquals("Unsupported schema type for Flatten: JSON",
+                assertThrows(IllegalStateException.class, () -> {
         // given
         Record<GenericObject> nestedKVRecord = Utils.createNestedJSONRecord(4, "myKey");
 
         // then
         Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
+                }).getMessage());
     }
 
-    @Test(
-            expectedExceptions = IllegalStateException.class,
-            expectedExceptionsMessageRegExp = "Flatten requires non-null schemas!")
+    @Test
     void testNestedSchemalessValue() throws Exception {
+        assertEquals("Flatten requires non-null schemas!",
+                assertThrows(IllegalStateException.class, () -> {
         // given
         Record<GenericObject> nestedKVRecord =
                 new Utils.TestRecord<>(
@@ -292,6 +296,7 @@ public class FlattenStepTest {
 
         // then
         Utils.process(nestedKVRecord, FlattenStep.builder().part("value").build());
+                }).getMessage());
     }
 
     private void assertSchemasFlattened(

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/MergeKeyValueStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/MergeKeyValueStepTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
+import org.apache.avro.generic.GenericData;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class MergeKeyValueStepTest {
+
+    @Test
+    void testKeyValueAvro() throws Exception {
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Record<?> outputRecord = Utils.process(record, new MergeKeyValueStep());
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        GenericData.Record value =
+                Utils.getRecord(messageSchema.getValueSchema(), (byte[]) messageValue.getValue());
+        assertEquals(
+                value.toString(),
+                "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\", "
+                        + "\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}");
+
+        GenericData.Record key =
+                Utils.getRecord(messageSchema.getKeySchema(), (byte[]) messageValue.getKey());
+        assertEquals(
+                key.toString(),
+                "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}");
+    }
+
+    @Test
+    void testKeyValueJson() throws Exception {
+        Record<GenericObject> record = Utils.createTestJsonKeyValueRecord();
+        Record<?> outputRecord = Utils.process(record, new MergeKeyValueStep());
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(
+                messageSchema.getKeySchema().getNativeSchema().orElseThrow().toString(),
+                "{\"type\":\"record\","
+                        + "\"name\":\"record\",\"fields\":[{\"name\":\"keyField1\",\"type\":\"string\"},{\"name\":\"keyField2\","
+                        + "\"type\":\"string\"},{\"name\":\"keyField3\",\"type\":\"string\"}]}");
+
+        assertEquals(
+                messageSchema.getValueSchema().getNativeSchema().orElseThrow().toString(),
+                "{\"type\":\"record\","
+                        + "\"name\":\"record\",\"fields\":[{\"name\":\"keyField1\",\"type\":\"string\"},{\"name\":\"keyField2\","
+                        + "\"type\":\"string\"},{\"name\":\"keyField3\",\"type\":\"string\"},{\"name\":\"valueField1\","
+                        + "\"type\":\"string\"},{\"name\":\"valueField2\",\"type\":\"string\"},{\"name\":\"valueField3\","
+                        + "\"type\":\"string\"}]}");
+
+        JsonNode value = (JsonNode) messageValue.getValue();
+        assertEquals(value.get("keyField1").asText(), "key1");
+        assertEquals(value.get("keyField2").asText(), "key2");
+        assertEquals(value.get("keyField3").asText(), "key3");
+        assertEquals(value.get("valueField1").asText(), "value1");
+        assertEquals(value.get("valueField2").asText(), "value2");
+        assertEquals(value.get("valueField3").asText(), "value3");
+
+        JsonNode key = (JsonNode) messageValue.getKey();
+        assertEquals(key.get("keyField1").asText(), "key1");
+        assertEquals(key.get("keyField2").asText(), "key2");
+        assertEquals(key.get("keyField3").asText(), "key3");
+    }
+
+    @Test
+    void testKeyValueStringJson() throws Exception {
+        Schema<KeyValue<String, String>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.STRING, KeyValueEncodingType.SEPARATED);
+
+        String key = "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}";
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+
+        KeyValue<String, String> keyValue = new KeyValue<>(key, value);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        Record<?> outputRecord = Utils.process(record, new MergeKeyValueStep());
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(
+                messageValue.getValue(),
+                "{\"valueField1\":\"value1\",\"valueField2\":\"value2\","
+                        + "\"valueField3\":\"value3\",\"keyField1\":\"key1\",\"keyField2\":\"key2\",\"keyField3\":\"key3\"}");
+    }
+
+    @Test
+    void testKeyValueBytesJson() throws Exception {
+        Schema<KeyValue<byte[], byte[]>> keyValueSchema =
+                Schema.KeyValue(Schema.BYTES, Schema.BYTES, KeyValueEncodingType.SEPARATED);
+
+        String key = "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}";
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+
+        KeyValue<byte[], byte[]> keyValue =
+                new KeyValue<>(
+                        key.getBytes(StandardCharsets.UTF_8),
+                        value.getBytes(StandardCharsets.UTF_8));
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        Record<?> outputRecord = Utils.process(record, new MergeKeyValueStep());
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        assertEquals(
+                new String((byte[]) messageValue.getValue(), StandardCharsets.UTF_8),
+                "{\"valueField1\":\"value1\",\"valueField2\":\"value2\",\"valueField3\":\"value3\","
+                        + "\"keyField1\":\"key1\",\"keyField2\":\"key2\",\"keyField3\":\"key3\"}");
+    }
+
+    @Test
+    void testPrimitive() throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                "test-message", SchemaType.STRING, new byte[] {}),
+                        "test-key");
+        Record<GenericObject> outputRecord = Utils.process(record, new MergeKeyValueStep());
+
+        assertSame(outputRecord.getSchema(), record.getSchema());
+        assertSame(outputRecord.getValue(), record.getValue().getNativeObject());
+        assertEquals(outputRecord.getKey(), record.getKey());
+    }
+
+    @Test
+    void testKeyValuePrimitives() throws Exception {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        Record<?> outputRecord = Utils.process(record, new MergeKeyValueStep());
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+        KeyValue<?, ?> messageValue = (KeyValue<?, ?>) outputRecord.getValue();
+
+        KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
+        KeyValue<?, ?> recordValue = ((KeyValue<?, ?>) record.getValue().getNativeObject());
+        assertSame(messageSchema.getKeySchema(), recordSchema.getKeySchema());
+        assertSame(messageSchema.getValueSchema(), recordSchema.getValueSchema());
+        assertSame(messageValue.getKey(), recordValue.getKey());
+        assertSame(messageValue.getValue(), recordValue.getValue());
+    }
+
+    @Test
+    void testKeyValueAvroCached() throws Exception {
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+
+        MergeKeyValueStep step = new MergeKeyValueStep();
+        Record<?> outputRecord = Utils.process(record, step);
+        KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+
+        outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
+        KeyValueSchema<?, ?> newMessageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
+
+        // Schema was modified by process operation
+        KeyValueSchema<?, ?> recordSchema = (KeyValueSchema) record.getSchema();
+        assertNotSame(
+                messageSchema.getValueSchema().getNativeSchema().orElseThrow(),
+                recordSchema.getValueSchema().getNativeSchema().orElseThrow());
+
+        // Multiple process output the same cached schema
+        assertSame(
+                messageSchema.getValueSchema().getNativeSchema().orElseThrow(),
+                newMessageSchema.getValueSchema().getNativeSchema().orElseThrow());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/MergeKeyValueStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/MergeKeyValueStepTest.java
@@ -15,9 +15,9 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotSame;
-import static org.testng.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.charset.StandardCharsets;
@@ -30,7 +30,7 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class MergeKeyValueStepTest {
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,7 +41,7 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class QueryStepTest {
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.testng.Assert.assertEquals;
+
+import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class QueryStepTest {
+
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void testPrimitive() throws Exception {
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .key("test-key")
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        "test-message", SchemaType.STRING, new byte[] {}))
+                        .schema(Schema.STRING)
+                        .eventTime(42L)
+                        .topicName("test-input-topic")
+                        .destinationTopic("test-output-topic")
+                        .properties(Map.of("test-key", "test-value"))
+                        .build();
+
+        List<String> fields =
+                Arrays.asList("value", "destinationTopic", "messageKey", "topicName", "eventTime");
+        QueryStepDataSource dataSource =
+                new QueryStepDataSource() {
+                    @Override
+                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                        assertEquals(query, "select 1");
+                        List<Object> expectedParams =
+                                List.of(
+                                        "test-message",
+                                        "test-output-topic",
+                                        "test-key",
+                                        "test-input-topic",
+                                        42L);
+                        assertEquals(params, expectedParams);
+                        return List.of(Map.of());
+                    }
+                };
+        QueryStep queryStep =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select 1")
+                        .fields(fields)
+                        .build();
+
+        Utils.process(record, queryStep);
+    }
+
+    @Test
+    void testAvro() throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        RecordSchemaBuilder recordSchemaBuilder = SchemaBuilder.record("record");
+        recordSchemaBuilder.field("firstName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("lastName").type(SchemaType.STRING);
+        recordSchemaBuilder.field("age").type(SchemaType.INT32);
+        recordSchemaBuilder.field("date").type(SchemaType.DATE);
+        recordSchemaBuilder.field("timestamp").type(SchemaType.TIMESTAMP);
+        recordSchemaBuilder.field("time").type(SchemaType.TIME);
+
+        SchemaInfo schemaInfo = recordSchemaBuilder.build(SchemaType.AVRO);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schemaInfo);
+
+        GenericRecord genericRecord =
+                genericSchema
+                        .newRecordBuilder()
+                        .set("firstName", "Jane")
+                        .set("lastName", "Doe")
+                        .set("age", 42)
+                        .set("date", (int) LocalDate.of(2023, 1, 2).toEpochDay())
+                        .set("timestamp", Instant.parse("2023-01-02T23:04:05.006Z").toEpochMilli())
+                        .set(
+                                "time",
+                                (int) (LocalTime.parse("23:04:05.006").toNanoOfDay() / 1_000_000))
+                        .build();
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericRecord, "test-key");
+        QueryStepDataSource dataSource =
+                new QueryStepDataSource() {
+                    @Override
+                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                        assertEquals(query, "select 1");
+                        List<Object> expectedParams =
+                                List.of("Jane", "Doe", 42, 19359, 1672700645006L, 83045006);
+                        assertEquals(params, expectedParams);
+                        return List.of(Map.of());
+                    }
+                };
+        List<String> fields =
+                Arrays.asList(
+                        "value.firstName",
+                        "value.lastName",
+                        "value.age",
+                        "value.date",
+                        "value.timestamp",
+                        "value.time");
+        QueryStep queryStep =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select 1")
+                        .fields(fields)
+                        .build();
+
+        Utils.process(record, queryStep);
+    }
+
+    @Test
+    void testJson() throws Exception {
+        Schema<PoJo> schema = Schema.JSON(PoJo.class);
+        GenericSchema<GenericRecord> genericSchema = Schema.generic(schema.getSchemaInfo());
+        GenericObject genericObject =
+                new GenericObject() {
+                    @Override
+                    public SchemaType getSchemaType() {
+                        return SchemaType.JSON;
+                    }
+
+                    @Override
+                    public Object getNativeObject() {
+                        return OBJECT_MAPPER.valueToTree(
+                                new PoJo("a", 42, true, List.of("b", "c"), List.of(43, 44)));
+                    }
+                };
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(genericSchema, genericObject, "my-key");
+
+        QueryStepDataSource dataSource =
+                new QueryStepDataSource() {
+                    @Override
+                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                        assertEquals(query, "select 1");
+                        List<Object> expectedParams =
+                                List.of("a", 42.0, true, List.of("b", "c"), List.of(43.0, 44.0));
+                        assertEquals(params, expectedParams);
+                        return List.of(Map.of());
+                    }
+                };
+
+        List<String> fields =
+                Arrays.asList(
+                        "value.a", "value.b", "value.c", "value.stringList", "value.numberList");
+
+        QueryStep queryStep =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select 1")
+                        .fields(fields)
+                        .build();
+
+        Utils.process(record, queryStep);
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class PoJo {
+        String a;
+        Integer b;
+        Boolean c;
+        List<String> stringList;
+        List<Integer> numberList;
+    }
+
+    @Test
+    void testKVStringJson() throws Exception {
+        Schema<KeyValue<String, String>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.STRING, KeyValueEncodingType.SEPARATED);
+
+        String key = "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}";
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+
+        KeyValue<String, String> keyValue = new KeyValue<>(key, value);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        QueryStepDataSource dataSource =
+                new QueryStepDataSource() {
+                    @Override
+                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                        assertEquals(query, "select 1");
+                        List<Object> expectedParams = List.of("value1", "key2");
+                        assertEquals(params, expectedParams);
+                        return List.of(Map.of());
+                    }
+                };
+        List<String> fields = Arrays.asList("value.valueField1", "key.keyField2");
+        QueryStep queryStep =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select 1")
+                        .fields(fields)
+                        .build();
+
+        Utils.process(record, queryStep);
+    }
+
+    @Test
+    void testKVAvro() throws Exception {
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        QueryStepDataSource dataSource =
+                new QueryStepDataSource() {
+                    @Override
+                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                        assertEquals(query, "select 1");
+                        List<Object> expectedParams = List.of("value1", "key2");
+                        assertEquals(params, expectedParams);
+                        return List.of(Map.of());
+                    }
+                };
+        List<String> fields = Arrays.asList("value.valueField1", "key.keyField2");
+        QueryStep queryStep =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select 1")
+                        .fields(fields)
+                        .build();
+
+        Utils.process(record, queryStep);
+    }
+
+    @Test
+    void testOnlyFirst() throws Exception {
+        Schema<KeyValue<String, String>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.STRING, KeyValueEncodingType.SEPARATED);
+
+        String key = "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}";
+        String value =
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": \"value3\"}";
+
+        KeyValue<String, String> keyValue = new KeyValue<>(key, value);
+
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        keyValueSchema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                keyValue, SchemaType.KEY_VALUE, new byte[] {}),
+                        null);
+
+        List<String> fields = List.of();
+        QueryStepDataSource dataSource =
+                new QueryStepDataSource() {
+                    @Override
+                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                        List<Object> expectedParams = List.of();
+                        assertEquals(params, expectedParams);
+                        switch (query) {
+                            case "select a,b from test":
+                                return List.of(
+                                        Map.of("a", "10", "b", "foo"),
+                                        Map.of("a", "20", "b", "bar"));
+                            case "select a,b from test where 1=0":
+                                return List.of(Map.of());
+                            default:
+                                throw new RuntimeException("Unexpected query: " + query);
+                        }
+                    }
+                };
+
+        QueryStep queryStepFindSomeResults =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select a,b from test")
+                        .onlyFirst(true)
+                        .fields(fields)
+                        .build();
+        Record<?> result = Utils.process(record, queryStepFindSomeResults);
+        KeyValue<String, String> keyValueResult = (KeyValue<String, String>) result.getValue();
+        Map<String, Object> parsed =
+                new ObjectMapper().readValue(keyValueResult.getValue(), Map.class);
+        assertEquals(
+                parsed,
+                Map.of(
+                        "valueField1", "value1",
+                        "valueField2", "value2",
+                        "valueField3", "value3",
+                        "result", Map.of("b", "foo", "a", "10")));
+
+        QueryStep queryStepFindNoResults =
+                QueryStep.builder()
+                        .dataSource(dataSource)
+                        .outputFieldName("value.result")
+                        .query("select a,b from test where 1=0")
+                        .onlyFirst(true)
+                        .fields(fields)
+                        .build();
+        Record<KeyValue<String, String>> resultNoResults =
+                Utils.process(record, queryStepFindNoResults);
+        KeyValue<String, String> keyValueResultNoResults = resultNoResults.getValue();
+        Map<String, Object> parsedNoResults =
+                new ObjectMapper().readValue(keyValueResultNoResults.getValue(), Map.class);
+        assertEquals(
+                parsedNoResults,
+                Map.of(
+                        "valueField1",
+                        "value1",
+                        "valueField2",
+                        "value2",
+                        "valueField3",
+                        "value3",
+                        "result",
+                        Map.of()));
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/UnwrapKeyValueStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/UnwrapKeyValueStepTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class UnwrapKeyValueStepTest {
+
+    @Test
+    void testKeyValueUnwrapValue() throws Exception {
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Record<?> outputRecord = Utils.process(record, new UnwrapKeyValueStep(false));
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertEquals(
+                read.toString(),
+                "{\"valueField1\": \"value1\", \"valueField2\": \"value2\", \"valueField3\": "
+                        + "\"value3\"}");
+    }
+
+    @Test
+    void testKeyValueUnwrapKey() throws Exception {
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        Record<?> outputRecord = Utils.process(record, new UnwrapKeyValueStep(true));
+
+        GenericData.Record read =
+                Utils.getRecord(outputRecord.getSchema(), (byte[]) outputRecord.getValue());
+        assertEquals(
+                read.toString(),
+                "{\"keyField1\": \"key1\", \"keyField2\": \"key2\", \"keyField3\": \"key3\"}");
+    }
+
+    @Test
+    void testPrimitive() throws Exception {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        Schema.STRING,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                "test-message", SchemaType.STRING, new byte[] {}),
+                        "test-key");
+        Record<GenericObject> outputRecord = Utils.process(record, new UnwrapKeyValueStep(false));
+
+        assertSame(outputRecord.getSchema(), record.getSchema());
+        assertSame(outputRecord.getValue(), record.getValue().getNativeObject());
+        assertEquals(outputRecord.getKey(), record.getKey());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/UnwrapKeyValueStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/UnwrapKeyValueStepTest.java
@@ -15,8 +15,8 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.pulsar.client.api.Schema;
@@ -24,7 +24,7 @@ import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnwrapKeyValueStepTest {
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/Utils.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/Utils.java
@@ -16,10 +16,10 @@
 package com.datastax.oss.streaming.ai;
 
 import static com.datastax.oss.streaming.ai.FlattenStep.AVRO_READ_OFFSET_PROP;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datastax.oss.streaming.ai.model.TransformSchemaType;
 import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/Utils.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/Utils.java
@@ -1,0 +1,1051 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai;
+
+import static com.datastax.oss.streaming.ai.FlattenStep.AVRO_READ_OFFSET_PROP;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.datastax.oss.streaming.ai.model.TransformSchemaType;
+import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.functions.api.utils.FunctionRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+public class Utils {
+
+    public static <T> Record<T> process(Record<GenericObject> record, TransformStep step)
+            throws Exception {
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+        step.process(transformContext);
+        return send(context, transformContext);
+    }
+
+    public static GenericData.Record getRecord(Schema<?> schema, byte[] value) throws IOException {
+        DatumReader<GenericData.Record> reader =
+                new GenericDatumReader<>(
+                        (org.apache.avro.Schema) schema.getNativeSchema().orElseThrow());
+        Decoder decoder = DecoderFactory.get().binaryDecoder(value, null);
+        return reader.read(null, decoder);
+    }
+
+    public static Record<GenericObject> createTestAvroKeyValueRecord() {
+        return createTestStructKeyValueRecord(SchemaType.AVRO);
+    }
+
+    public static Record<GenericObject> createTestJsonKeyValueRecord() {
+        return createTestStructKeyValueRecord(SchemaType.JSON);
+    }
+
+    public static Record<GenericObject> createTestStructKeyValueRecord(SchemaType schemaType) {
+        RecordSchemaBuilder keySchemaBuilder =
+                org.apache.pulsar.client.api.schema.SchemaBuilder.record("record");
+        keySchemaBuilder.field("keyField1").type(SchemaType.STRING);
+        keySchemaBuilder.field("keyField2").type(SchemaType.STRING);
+        keySchemaBuilder.field("keyField3").type(SchemaType.STRING);
+        GenericSchema<GenericRecord> keySchema = Schema.generic(keySchemaBuilder.build(schemaType));
+
+        RecordSchemaBuilder valueSchemaBuilder =
+                org.apache.pulsar.client.api.schema.SchemaBuilder.record("record");
+        valueSchemaBuilder.field("valueField1").type(SchemaType.STRING);
+        valueSchemaBuilder.field("valueField2").type(SchemaType.STRING);
+        valueSchemaBuilder.field("valueField3").type(SchemaType.STRING);
+        GenericSchema<GenericRecord> valueSchema =
+                Schema.generic(valueSchemaBuilder.build(schemaType));
+
+        GenericRecord keyRecord =
+                keySchema
+                        .newRecordBuilder()
+                        .set("keyField1", "key1")
+                        .set("keyField2", "key2")
+                        .set("keyField3", "key3")
+                        .build();
+
+        GenericRecord valueRecord =
+                valueSchema
+                        .newRecordBuilder()
+                        .set("valueField1", "value1")
+                        .set("valueField2", "value2")
+                        .set("valueField3", "value3")
+                        .build();
+
+        Schema<KeyValue<GenericRecord, GenericRecord>> keyValueSchema =
+                Schema.KeyValue(keySchema, valueSchema, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<GenericRecord, GenericRecord> keyValue = new KeyValue<>(keyRecord, valueRecord);
+
+        GenericObject genericObject =
+                new GenericObject() {
+                    @Override
+                    public SchemaType getSchemaType() {
+                        return SchemaType.KEY_VALUE;
+                    }
+
+                    @Override
+                    public Object getNativeObject() {
+                        return keyValue;
+                    }
+                };
+
+        return new TestRecord<>(keyValueSchema, genericObject, null);
+    }
+
+    public static Record<GenericObject> createNestedAvroRecord(int levels, String key) {
+        GenericAvroRecord valueRecord = createNestedAvroRecord(levels);
+
+        Schema<org.apache.avro.generic.GenericRecord> pulsarValueSchema =
+                new Utils.NativeSchemaWrapper(
+                        valueRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
+
+        return new Utils.TestRecord<>(pulsarValueSchema, valueRecord, key);
+    }
+
+    public static Record<GenericObject> createNestedJSONRecord(int levels, String key) {
+        GenericAvroRecord valueRecord = createNestedAvroRecord(levels);
+
+        Schema<org.apache.avro.generic.GenericRecord> pulsarValueSchema =
+                new Utils.NativeSchemaWrapper(
+                        valueRecord.getAvroRecord().getSchema(), SchemaType.JSON);
+
+        return new Utils.TestRecord<>(pulsarValueSchema, valueRecord, key);
+    }
+
+    public static Record<GenericObject> createNestedAvroKeyValueRecord(int levels) {
+        GenericAvroRecord keyRecord = createNestedAvroRecord(levels);
+        GenericAvroRecord valueRecord = createNestedAvroRecord(levels);
+
+        GenericObject genericObject =
+                new GenericObject() {
+                    @Override
+                    public SchemaType getSchemaType() {
+                        return SchemaType.KEY_VALUE;
+                    }
+
+                    @Override
+                    public Object getNativeObject() {
+                        return new KeyValue<>(keyRecord, valueRecord);
+                    }
+                };
+
+        Schema<org.apache.avro.generic.GenericRecord> pulsarKeySchema =
+                new Utils.NativeSchemaWrapper(
+                        keyRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
+        Schema<org.apache.avro.generic.GenericRecord> pulsarValueSchema =
+                new Utils.NativeSchemaWrapper(
+                        valueRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
+
+        Schema<
+                        KeyValue<
+                                org.apache.avro.generic.GenericRecord,
+                                org.apache.avro.generic.GenericRecord>>
+                keyValueSchema =
+                        Schema.KeyValue(
+                                pulsarKeySchema, pulsarValueSchema, KeyValueEncodingType.SEPARATED);
+        Map<String, String> props = new HashMap<>();
+        props.put("p1", "v1");
+        props.put("p2", "v2");
+
+        return TestRecord.<GenericObject>builder()
+                .schema(keyValueSchema)
+                .value(genericObject)
+                .key("key1")
+                .topicName("topic-1")
+                .destinationTopic("dest-topic-1")
+                .eventTime(1662493532L)
+                .properties(props)
+                .build();
+    }
+
+    /**
+     * Returns a nested Avro record with a certain number of levels. Example for levels = 4: {
+     * "level1KeyField1": "level1_Key1", "level1KeyField2": { "level2KeyField1": "level2_Key1",
+     * "level2KeyField2": { "level3KeyField1": "level3_Key1", "level3KeyField2": {
+     * "level4KeyField1": "level4_Key1", "level4KeyField2": "level4_Key2" } } } }
+     */
+    public static GenericAvroRecord createNestedAvroRecord(int levels) {
+        // Create the last, unnested level
+        List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+        org.apache.avro.Schema nullAndString =
+                SchemaBuilder.unionOf().stringType().and().nullType().endUnion();
+        org.apache.avro.Schema nullLevel =
+                org.apache.avro.Schema.createRecord(
+                        "nullLevel",
+                        "doc ",
+                        "ns",
+                        false,
+                        List.of(
+                                new org.apache.avro.Schema.Field(
+                                        "ignored",
+                                        org.apache.avro.Schema.create(
+                                                org.apache.avro.Schema.Type.STRING))));
+        org.apache.avro.Schema nullAndRecord =
+                SchemaBuilder.unionOf().nullType().and().type(nullLevel).endUnion();
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "String",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
+                        "stringDoc",
+                        "stringDefault"));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "Integer",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
+                        "integerDoc",
+                        3));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "Double",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.DOUBLE),
+                        "doubleDoc",
+                        5.5D));
+        org.apache.avro.Schema arraySchema =
+                org.apache.avro.Schema.createArray(
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+        fields.add(
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "Array",
+                        arraySchema,
+                        "arrayDoc",
+                        Collections.emptyList()));
+        org.apache.avro.Schema.Field stringWithProps =
+                new org.apache.avro.Schema.Field(
+                        "level" + levels + "StringWithPropsAndAlias",
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+        stringWithProps.addProp("p1", "v1");
+        stringWithProps.addProp("p2", "v2");
+        stringWithProps.addProp(AVRO_READ_OFFSET_PROP, "5");
+        stringWithProps.addAlias("a1");
+        fields.add(stringWithProps);
+        fields.add(new org.apache.avro.Schema.Field("level" + levels + "Union", nullAndString));
+        fields.add(new org.apache.avro.Schema.Field("level" + levels + "Null", nullAndString));
+        fields.add(
+                new org.apache.avro.Schema.Field("level" + levels + "NullRecord", nullAndRecord));
+        org.apache.avro.Schema lastLevelSchema =
+                org.apache.avro.Schema.createRecord("nested" + levels, "doc ", "ns", false, fields);
+        org.apache.avro.generic.GenericRecord lastLevelRecord =
+                new GenericData.Record(lastLevelSchema);
+        lastLevelRecord.put("level" + levels + "String", "level" + levels + "_" + "1");
+        lastLevelRecord.put("level" + levels + "Integer", 9);
+        lastLevelRecord.put("level" + levels + "Double", 8.8D);
+        lastLevelRecord.put(
+                "level" + levels + "Array",
+                List.of("level" + levels + "_" + "1", "level" + levels + "_" + "2"));
+        lastLevelRecord.put(
+                "level" + levels + "StringWithPropsAndAlias", "level" + levels + "_" + "WithProps");
+        lastLevelRecord.put("level" + levels + "Union", "level" + levels + "_" + "2");
+        lastLevelRecord.put("level" + levels + "Null", null);
+        lastLevelRecord.put("level" + levels + "NullRecord", null);
+
+        org.apache.avro.Schema nextLevelSchema = lastLevelSchema;
+        org.apache.avro.generic.GenericRecord nextLevelRecord = lastLevelRecord;
+        // Create the nested levels one by one, working backwards from the last level up to the top
+        // level
+        for (int level = levels - 1; level > 0; level--) {
+            fields = new ArrayList<>();
+            fields.add(
+                    new org.apache.avro.Schema.Field(
+                            "level" + level + "String",
+                            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING)));
+            fields.add(
+                    new org.apache.avro.Schema.Field("level" + level + "Record", nextLevelSchema));
+            org.apache.avro.Schema currentLevelSchema =
+                    org.apache.avro.Schema.createRecord(
+                            "nested" + level, "doc ", "ns", false, fields);
+
+            org.apache.avro.generic.GenericRecord currentLevelRecord =
+                    new GenericData.Record(currentLevelSchema);
+            currentLevelRecord.put("level" + level + "String", "level" + level + "_" + "1");
+            currentLevelRecord.put("level" + level + "Record", nextLevelRecord);
+
+            nextLevelSchema = currentLevelSchema;
+            nextLevelRecord = currentLevelRecord;
+        }
+
+        nextLevelSchema.addProp(AVRO_READ_OFFSET_PROP, 5);
+        nextLevelSchema.addProp("t1", 9);
+        List<Field> pulsarFields =
+                fields.stream().map(v -> new Field(v.name(), v.pos())).collect(Collectors.toList());
+        return new GenericAvroRecord(new byte[0], nextLevelSchema, pulsarFields, nextLevelRecord);
+    }
+
+    public static TransformContext createContextWithPrimitiveRecord(
+            Schema<?> schema, Object value, String key) {
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(
+                        schema,
+                        AutoConsumeSchema.wrapPrimitiveObject(
+                                value, schema.getSchemaInfo().getType(), new byte[] {}),
+                        key);
+        return newTransformContext(
+                new Utils.TestContext(record, new HashMap<>()),
+                record.getValue().getNativeObject());
+    }
+
+    static void assertOptionalField(
+            GenericData.Record record,
+            String fieldName,
+            org.apache.avro.Schema.Type expectedType,
+            Object expectedValue) {
+        assertTrue(record.hasField(fieldName));
+        org.apache.avro.Schema.Field field = record.getSchema().getField(fieldName);
+        assertTrue(field.schema().isNullable());
+        assertEquals(field.defaultVal(), org.apache.avro.Schema.NULL_VALUE);
+        assertTrue(field.schema().isUnion());
+        org.apache.avro.Schema nullSchema = field.schema().getTypes().get(0);
+        assertEquals(nullSchema.getType(), org.apache.avro.Schema.Type.NULL);
+        org.apache.avro.Schema typedSchema = field.schema().getTypes().get(1);
+        assertEquals(typedSchema.getType(), expectedType);
+        assertEquals(record.get(fieldName), expectedValue);
+    }
+
+    static void assertNonOptionalField(
+            GenericData.Record record,
+            String fieldName,
+            org.apache.avro.Schema.Type expectedType,
+            Object expectedValue) {
+        assertTrue(record.hasField(fieldName));
+        org.apache.avro.Schema.Field field = record.getSchema().getField(fieldName);
+        assertFalse(field.schema().isNullable());
+        assertNull(field.defaultVal());
+        assertFalse(field.schema().isUnion());
+        assertEquals(field.schema().getType(), expectedType);
+        assertEquals(record.get(fieldName), expectedValue);
+    }
+
+    public static TransformContext newTransformContext(Context context, Object value) {
+        return newTransformContext(context, value, true);
+    }
+
+    public static TransformContext newTransformContext(
+            Context context, Object value, boolean attemptJsonConversion) {
+        Record<?> currentRecord = context.getCurrentRecord();
+        TransformContext transformContext = new TransformContext();
+        transformContext.setInputTopic(currentRecord.getTopicName().orElse(null));
+        transformContext.setOutputTopic(currentRecord.getDestinationTopic().orElse(null));
+        transformContext.setKey(currentRecord.getKey().orElse(null));
+        transformContext.setEventTime(currentRecord.getEventTime().orElse(null));
+
+        if (currentRecord.getProperties() != null) {
+            transformContext.setProperties(new HashMap<>(currentRecord.getProperties()));
+        }
+
+        Schema<?> schema = currentRecord.getSchema();
+        if (schema instanceof KeyValueSchema && value instanceof KeyValue) {
+            KeyValueSchema<?, ?> kvSchema = (KeyValueSchema<?, ?>) schema;
+            KeyValue<?, ?> kv = (KeyValue<?, ?>) value;
+            Schema<?> keySchema = kvSchema.getKeySchema();
+            Schema<?> valueSchema = kvSchema.getValueSchema();
+            transformContext.setKeySchemaType(pulsarSchemaToTransformSchemaType(keySchema));
+            transformContext.setKeyNativeSchema(getNativeSchema(keySchema));
+            transformContext.setKeyObject(
+                    keySchema.getSchemaInfo().getType().isStruct()
+                            ? ((GenericObject) kv.getKey()).getNativeObject()
+                            : kv.getKey());
+            transformContext.setValueSchemaType(pulsarSchemaToTransformSchemaType(valueSchema));
+            transformContext.setValueNativeSchema(getNativeSchema(valueSchema));
+            transformContext.setValueObject(
+                    valueSchema.getSchemaInfo().getType().isStruct()
+                            ? ((GenericObject) kv.getValue()).getNativeObject()
+                            : kv.getValue());
+            transformContext
+                    .getCustomContext()
+                    .put("keyValueEncodingType", kvSchema.getKeyValueEncodingType());
+        } else {
+            transformContext.setValueSchemaType(pulsarSchemaToTransformSchemaType(schema));
+            transformContext.setValueNativeSchema(getNativeSchema(schema));
+            transformContext.setValueObject(value);
+        }
+        if (attemptJsonConversion) {
+            transformContext.setKeyObject(
+                    TransformFunctionUtil.attemptJsonConversion(transformContext.getKeyObject()));
+            transformContext.setValueObject(
+                    TransformFunctionUtil.attemptJsonConversion(transformContext.getValueObject()));
+        }
+        return transformContext;
+    }
+
+    private static Object getNativeSchema(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        return schema.getNativeSchema().orElse(null);
+    }
+
+    private static TransformSchemaType pulsarSchemaToTransformSchemaType(Schema<?> schema) {
+        if (schema == null) {
+            return null;
+        }
+        switch (schema.getSchemaInfo().getType()) {
+            case INT8:
+                return TransformSchemaType.INT8;
+            case INT16:
+                return TransformSchemaType.INT16;
+            case INT32:
+                return TransformSchemaType.INT32;
+            case INT64:
+                return TransformSchemaType.INT64;
+            case FLOAT:
+                return TransformSchemaType.FLOAT;
+            case DOUBLE:
+                return TransformSchemaType.DOUBLE;
+            case BOOLEAN:
+                return TransformSchemaType.BOOLEAN;
+            case STRING:
+                return TransformSchemaType.STRING;
+            case BYTES:
+                return TransformSchemaType.BYTES;
+            case DATE:
+                return TransformSchemaType.DATE;
+            case TIME:
+                return TransformSchemaType.TIME;
+            case TIMESTAMP:
+                return TransformSchemaType.TIMESTAMP;
+            case INSTANT:
+                return TransformSchemaType.INSTANT;
+            case LOCAL_DATE:
+                return TransformSchemaType.LOCAL_DATE;
+            case LOCAL_TIME:
+                return TransformSchemaType.LOCAL_TIME;
+            case LOCAL_DATE_TIME:
+                return TransformSchemaType.LOCAL_DATE_TIME;
+            case JSON:
+                return TransformSchemaType.JSON;
+            case AVRO:
+                return TransformSchemaType.AVRO;
+            case PROTOBUF:
+                return TransformSchemaType.PROTOBUF;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported schema type " + schema.getSchemaInfo().getType());
+        }
+    }
+
+    public static <T> Record<T> send(Context context, TransformContext transformContext)
+            throws IOException {
+        if (transformContext.isDropCurrentRecord()) {
+            return null;
+        }
+        transformContext.convertAvroToBytes();
+        transformContext.convertMapToStringOrBytes();
+
+        Schema outputSchema;
+        Object outputObject;
+        if (transformContext.getKeySchemaType() != null) {
+            KeyValueEncodingType keyValueEncodingType =
+                    (KeyValueEncodingType)
+                            transformContext.getCustomContext().get("keyValueEncodingType");
+            outputSchema =
+                    Schema.KeyValue(
+                            buildSchema(
+                                    transformContext.getKeySchemaType(),
+                                    transformContext.getKeyNativeSchema()),
+                            buildSchema(
+                                    transformContext.getValueSchemaType(),
+                                    transformContext.getValueNativeSchema()),
+                            keyValueEncodingType != null
+                                    ? keyValueEncodingType
+                                    : KeyValueEncodingType.INLINE);
+            Object outputKeyObject = transformContext.getKeyObject();
+            Object outputValueObject = transformContext.getValueObject();
+            outputObject = new KeyValue<>(outputKeyObject, outputValueObject);
+        } else {
+            outputSchema =
+                    buildSchema(
+                            transformContext.getValueSchemaType(),
+                            transformContext.getValueNativeSchema());
+            outputObject = transformContext.getValueObject();
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("output {} schema {}", outputObject, outputSchema);
+        }
+
+        FunctionRecord.FunctionRecordBuilder<T> recordBuilder =
+                context.newOutputRecordBuilder(outputSchema)
+                        .destinationTopic(transformContext.getOutputTopic())
+                        .value(outputObject)
+                        .properties(transformContext.getProperties());
+
+        if (transformContext.getKeySchemaType() == null && transformContext.getKey() != null) {
+            recordBuilder.key(transformContext.getKey());
+        }
+
+        return recordBuilder.build();
+    }
+
+    private static Schema<?> buildSchema(TransformSchemaType schemaType, Object nativeSchema) {
+        if (schemaType == null) {
+            throw new IllegalArgumentException("Schema type should not be null.");
+        }
+        switch (schemaType) {
+            case INT8:
+                return Schema.INT8;
+            case INT16:
+                return Schema.INT16;
+            case INT32:
+                return Schema.INT32;
+            case INT64:
+                return Schema.INT64;
+            case FLOAT:
+                return Schema.FLOAT;
+            case DOUBLE:
+                return Schema.DOUBLE;
+            case BOOLEAN:
+                return Schema.BOOL;
+            case STRING:
+                return Schema.STRING;
+            case BYTES:
+                return Schema.BYTES;
+            case DATE:
+                return Schema.DATE;
+            case TIME:
+                return Schema.TIME;
+            case TIMESTAMP:
+                return Schema.TIMESTAMP;
+            case INSTANT:
+                return Schema.INSTANT;
+            case LOCAL_DATE:
+                return Schema.LOCAL_DATE;
+            case LOCAL_TIME:
+                return Schema.LOCAL_TIME;
+            case LOCAL_DATE_TIME:
+                return Schema.LOCAL_DATE_TIME;
+            case AVRO:
+                return Schema.NATIVE_AVRO(nativeSchema);
+            case JSON:
+                return new JsonNodeSchema((org.apache.avro.Schema) nativeSchema);
+            default:
+                throw new IllegalArgumentException("Unsupported schema type " + schemaType);
+        }
+    }
+
+    @Builder
+    @RequiredArgsConstructor
+    @AllArgsConstructor
+    public static class TestRecord<T> implements Record<T> {
+        private final Schema<?> schema;
+        private final T value;
+        private final String key;
+        private String topicName;
+        private String destinationTopic;
+        private Long eventTime;
+        Map<String, String> properties;
+
+        @Override
+        public Optional<String> getKey() {
+            return Optional.ofNullable(key);
+        }
+
+        @Override
+        public Schema<T> getSchema() {
+            return (Schema<T>) schema;
+        }
+
+        @Override
+        public T getValue() {
+            return value;
+        }
+
+        @Override
+        public Optional<String> getTopicName() {
+            return Optional.ofNullable(topicName);
+        }
+
+        @Override
+        public Optional<String> getDestinationTopic() {
+            return Optional.ofNullable(destinationTopic);
+        }
+
+        @Override
+        public Optional<Long> getEventTime() {
+            return Optional.ofNullable(eventTime);
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+    }
+
+    public static class TestContext implements Context {
+        private final Record<?> currentRecord;
+        private final Map<String, Object> userConfig;
+
+        public TestContext(Record<?> currentRecord, Map<String, Object> userConfig) {
+            this.currentRecord = currentRecord;
+            this.userConfig = userConfig;
+        }
+
+        @Override
+        public Collection<String> getInputTopics() {
+            return null;
+        }
+
+        @Override
+        public String getOutputTopic() {
+            return "test-context-topic";
+        }
+
+        @Override
+        public Record<?> getCurrentRecord() {
+            return currentRecord;
+        }
+
+        @Override
+        public String getOutputSchemaType() {
+            return null;
+        }
+
+        @Override
+        public String getFunctionName() {
+            return null;
+        }
+
+        @Override
+        public String getFunctionId() {
+            return null;
+        }
+
+        @Override
+        public String getFunctionVersion() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getUserConfigMap() {
+            return userConfig;
+        }
+
+        @Override
+        public Optional<Object> getUserConfigValue(String key) {
+            return Optional.ofNullable(userConfig.get(key));
+        }
+
+        @Override
+        public Object getUserConfigValueOrDefault(String key, Object defaultValue) {
+            return null;
+        }
+
+        @Override
+        public PulsarAdmin getPulsarAdmin() {
+            return null;
+        }
+
+        @Override
+        public <X> CompletableFuture<Void> publish(
+                String topicName, X object, String schemaOrSerdeClassName) {
+            return null;
+        }
+
+        @Override
+        public <X> CompletableFuture<Void> publish(String topicName, X object) {
+            return null;
+        }
+
+        @Override
+        public <X> TypedMessageBuilder<X> newOutputMessage(String topicName, Schema<X> schema) {
+            return null;
+        }
+
+        @Override
+        public <X> ConsumerBuilder<X> newConsumerBuilder(Schema<X> schema) {
+            return null;
+        }
+
+        @Override
+        public <X> FunctionRecord.FunctionRecordBuilder<X> newOutputRecordBuilder(
+                Schema<X> schema) {
+            return FunctionRecord.from(
+                    new Context() {
+                        @Override
+                        public Collection<String> getInputTopics() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getOutputTopic() {
+                            return "test-context-topic";
+                        }
+
+                        @Override
+                        public Record<?> getCurrentRecord() {
+                            return currentRecord;
+                        }
+
+                        @Override
+                        public String getOutputSchemaType() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getFunctionName() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getFunctionId() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getFunctionVersion() {
+                            return null;
+                        }
+
+                        @Override
+                        public Map<String, Object> getUserConfigMap() {
+                            return null;
+                        }
+
+                        @Override
+                        public Optional<Object> getUserConfigValue(String key) {
+                            return Optional.empty();
+                        }
+
+                        @Override
+                        public Object getUserConfigValueOrDefault(String key, Object defaultValue) {
+                            return null;
+                        }
+
+                        @Override
+                        public PulsarAdmin getPulsarAdmin() {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> CompletableFuture<Void> publish(
+                                String topicName, O object, String schemaOrSerdeClassName) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> CompletableFuture<Void> publish(String topicName, O object) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> TypedMessageBuilder<O> newOutputMessage(
+                                String topicName, Schema<O> schema) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> ConsumerBuilder<O> newConsumerBuilder(Schema<O> schema) {
+                            return null;
+                        }
+
+                        @Override
+                        public <O> FunctionRecord.FunctionRecordBuilder<O> newOutputRecordBuilder(
+                                Schema<O> schema) {
+                            return null;
+                        }
+
+                        @Override
+                        public String getTenant() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getNamespace() {
+                            return null;
+                        }
+
+                        @Override
+                        public int getInstanceId() {
+                            return 0;
+                        }
+
+                        @Override
+                        public int getNumInstances() {
+                            return 0;
+                        }
+
+                        @Override
+                        public Logger getLogger() {
+                            return LoggerFactory.getILoggerFactory().getLogger("Context");
+                        }
+
+                        @Override
+                        public String getSecret(String secretName) {
+                            return null;
+                        }
+
+                        @Override
+                        public void putState(String key, ByteBuffer value) {}
+
+                        @Override
+                        public CompletableFuture<Void> putStateAsync(String key, ByteBuffer value) {
+                            return null;
+                        }
+
+                        @Override
+                        public ByteBuffer getState(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public CompletableFuture<ByteBuffer> getStateAsync(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public void deleteState(String key) {}
+
+                        @Override
+                        public CompletableFuture<Void> deleteStateAsync(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public void incrCounter(String key, long amount) {}
+
+                        @Override
+                        public CompletableFuture<Void> incrCounterAsync(String key, long amount) {
+                            return null;
+                        }
+
+                        @Override
+                        public long getCounter(String key) {
+                            return 0;
+                        }
+
+                        @Override
+                        public CompletableFuture<Long> getCounterAsync(String key) {
+                            return null;
+                        }
+
+                        @Override
+                        public void recordMetric(String metricName, double value) {}
+                    },
+                    schema);
+        }
+
+        @Override
+        public String getTenant() {
+            return null;
+        }
+
+        @Override
+        public String getNamespace() {
+            return null;
+        }
+
+        @Override
+        public int getInstanceId() {
+            return 0;
+        }
+
+        @Override
+        public int getNumInstances() {
+            return 0;
+        }
+
+        @Override
+        public Logger getLogger() {
+            return LoggerFactory.getILoggerFactory().getLogger("Context");
+        }
+
+        @Override
+        public String getSecret(String secretName) {
+            return null;
+        }
+
+        @Override
+        public void putState(String key, ByteBuffer value) {}
+
+        @Override
+        public CompletableFuture<Void> putStateAsync(String key, ByteBuffer value) {
+            return null;
+        }
+
+        @Override
+        public ByteBuffer getState(String key) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<ByteBuffer> getStateAsync(String key) {
+            return null;
+        }
+
+        @Override
+        public void deleteState(String key) {}
+
+        @Override
+        public CompletableFuture<Void> deleteStateAsync(String key) {
+            return null;
+        }
+
+        @Override
+        public void incrCounter(String key, long amount) {}
+
+        @Override
+        public CompletableFuture<Void> incrCounterAsync(String key, long amount) {
+            return null;
+        }
+
+        @Override
+        public long getCounter(String key) {
+            return 0;
+        }
+
+        @Override
+        public CompletableFuture<Long> getCounterAsync(String key) {
+            return null;
+        }
+
+        @Override
+        public void recordMetric(String metricName, double value) {}
+    }
+
+    public static class NativeSchemaWrapper
+            implements org.apache.pulsar.client.api.Schema<org.apache.avro.generic.GenericRecord> {
+
+        private final SchemaInfo pulsarSchemaInfo;
+        private final org.apache.avro.Schema nativeSchema;
+
+        private final SchemaType pulsarSchemaType;
+
+        private final SpecificDatumWriter<org.apache.avro.generic.GenericRecord> datumWriter;
+
+        public NativeSchemaWrapper(
+                org.apache.avro.Schema nativeSchema, SchemaType pulsarSchemaType) {
+            this.nativeSchema = nativeSchema;
+            this.pulsarSchemaType = pulsarSchemaType;
+            this.pulsarSchemaInfo =
+                    SchemaInfoImpl.builder()
+                            .schema(nativeSchema.toString(false).getBytes(StandardCharsets.UTF_8))
+                            .properties(new HashMap<>())
+                            .type(pulsarSchemaType)
+                            .name(nativeSchema.getName())
+                            .build();
+            this.datumWriter = new SpecificDatumWriter<>(this.nativeSchema);
+        }
+
+        @Override
+        public byte[] encode(org.apache.avro.generic.GenericRecord genericRecord) {
+            try {
+
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                BinaryEncoder binaryEncoder =
+                        new EncoderFactory().binaryEncoder(byteArrayOutputStream, null);
+                datumWriter.write(genericRecord, binaryEncoder);
+                binaryEncoder.flush();
+                return byteArrayOutputStream.toByteArray();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public SchemaInfo getSchemaInfo() {
+            return pulsarSchemaInfo;
+        }
+
+        @Override
+        public NativeSchemaWrapper clone() {
+            return new NativeSchemaWrapper(nativeSchema, pulsarSchemaType);
+        }
+
+        @Override
+        public void validate(byte[] message) {
+            // nothing to do
+        }
+
+        @Override
+        public boolean supportSchemaVersioning() {
+            return true;
+        }
+
+        @Override
+        public void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {}
+
+        @Override
+        public org.apache.avro.generic.GenericRecord decode(byte[] bytes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.apache.avro.generic.GenericRecord decode(byte[] bytes, byte[] schemaVersion) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean requireFetchingSchemaInfo() {
+            return true;
+        }
+
+        @Override
+        public void configureSchemaInfo(
+                String topic, String componentName, SchemaInfo schemaInfo) {}
+
+        @Override
+        public Optional<Object> getNativeSchema() {
+            return Optional.of(nativeSchema);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.datasource;
+
+import com.datastax.oss.streaming.ai.model.config.DataSourceConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class AstraDBDataSourceTest {
+    @Test(enabled = false)
+    void testQueryWithParameters() throws Exception {
+        AstraDBDataSource source = new AstraDBDataSource();
+        DataSourceConfig dataSourceConfig = buildDataSourceConfig();
+        source.initialize(dataSourceConfig);
+
+        String query = "select * from vsearch.products where id=?";
+        List<Object> params = new ArrayList<>();
+        params.add(1);
+        List<Map<String, String>> maps = source.fetchData(query, params);
+        log.info("maps {}", maps);
+    }
+
+    @Test(enabled = false)
+    void testQueryWithVectorSearch() throws Exception {
+        AstraDBDataSource source = new AstraDBDataSource();
+        DataSourceConfig dataSourceConfig = buildDataSourceConfig();
+        source.initialize(dataSourceConfig);
+
+        String query = "SELECT * FROM vsearch.products ORDER BY item_vector ANN OF ? LIMIT 1;";
+        List<Object> params = new ArrayList<>();
+        params.add(Arrays.asList(0.1, 0.2, 0.3, 0.4, 0.5));
+        List<Map<String, String>> maps = source.fetchData(query, params);
+        log.info("maps {}", maps);
+    }
+
+    private static DataSourceConfig buildDataSourceConfig() {
+        DataSourceConfig dataSourceConfig = new DataSourceConfig();
+        dataSourceConfig.setService("astra");
+        dataSourceConfig.setUsername("set-your-client-id");
+        dataSourceConfig.setPassword("set-your-secret");
+        dataSourceConfig.setSecureBundle("xxx-set-base64-encoded-bundle-xxx");
+        return dataSourceConfig;
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/datasource/AstraDBDataSourceTest.java
@@ -21,11 +21,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @Slf4j
 public class AstraDBDataSourceTest {
-    @Test(enabled = false)
+    @Test
+    @Disabled
     void testQueryWithParameters() throws Exception {
         AstraDBDataSource source = new AstraDBDataSource();
         DataSourceConfig dataSourceConfig = buildDataSourceConfig();
@@ -38,7 +40,7 @@ public class AstraDBDataSourceTest {
         log.info("maps {}", maps);
     }
 
-    @Test(enabled = false)
+    @Disabled
     void testQueryWithVectorSearch() throws Exception {
         AstraDBDataSource source = new AstraDBDataSource();
         DataSourceConfig dataSourceConfig = buildDataSourceConfig();

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingServiceTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingServiceTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import java.util.List;
+import junit.framework.TestCase;
+
+// disabled, just for experiments/usage demo
+public abstract class HuggingFaceEmbeddingServiceTest extends TestCase {
+
+    public void testMain() throws Exception {
+        AbstractHuggingFaceEmbeddingService.HuggingFaceConfig conf =
+                AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
+                        .engine("PyTorch")
+                        .modelUrl(
+                                "file:///Users/andreyyegorov/src/djl/model/nlp/text_embedding/ai/djl/huggingface/pytorch/sentence-transformers/all-MiniLM-L6-v2/0.0.1/all-MiniLM-L6-v2.zip")
+                        .build();
+
+        try (EmbeddingsService service = new HuggingFaceEmbeddingService(conf)) {
+            List<List<Double>> result =
+                    service.computeEmbeddings(List.of("hello world", "stranger things"));
+            result.forEach(System.out::println);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceRestEmbeddingServiceTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceRestEmbeddingServiceTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import java.util.List;
+import java.util.Map;
+import junit.framework.TestCase;
+
+// disabled, just for experiments/usage demo
+public abstract class HuggingFaceRestEmbeddingServiceTest extends TestCase {
+
+    public void testMain() throws Exception {
+        HuggingFaceRestEmbeddingService.HuggingFaceApiConfig conf =
+                HuggingFaceRestEmbeddingService.HuggingFaceApiConfig.builder()
+                        .accessKey(System.getenv("HF_API_KEY"))
+                        .model("sentence-transformers/all-MiniLM-L6-v2")
+                        .options(Map.of("wait_for_model", "true"))
+                        .build();
+        try (EmbeddingsService service = new HuggingFaceRestEmbeddingService(conf)) {
+            List<List<Double>> result =
+                    service.computeEmbeddings(List.of("hello world", "stranger things"));
+            result.forEach(System.out::println);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/MockEmbeddingsService.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/MockEmbeddingsService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.embeddings;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MockEmbeddingsService implements EmbeddingsService {
+
+    private final Map<String, List<Double>> embeddingsMapping = new HashMap<>();
+
+    public void setEmbeddingsForText(String text, List<Double> embeddings) {
+        embeddingsMapping.put(text, embeddings);
+    }
+
+    @Override
+    public List<List<Double>> computeEmbeddings(List<String> texts) {
+        return texts.stream()
+                .map(text -> embeddingsMapping.get(text))
+                .collect(java.util.stream.Collectors.toList());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluatorTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluatorTest.java
@@ -15,7 +15,8 @@
  */
 package com.datastax.oss.streaming.ai.jstl;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.datastax.oss.streaming.ai.TransformContext;
 import com.datastax.oss.streaming.ai.Utils;
@@ -25,18 +26,22 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import org.apache.pulsar.client.api.Schema;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 public class JstlEvaluatorTest {
-    @Test(
-            dataProvider = "methodInvocationExpressionProvider",
-            expectedExceptions = MethodNotFoundException.class)
+
+    @ParameterizedTest
+    @MethodSource("methodInvocationExpressionProvider")
     void testMethodInvocationsDisabled(String expression, TransformContext context) {
-        new JstlEvaluator<>(String.format("${%s}", expression), String.class).evaluate(context);
+        assertThrows(MethodNotFoundException.class, () -> {
+            new JstlEvaluator<>(String.format("${%s}", expression), String.class).evaluate(context);
+        });
     }
 
-    @Test(dataProvider = "functionExpressionProvider")
+    @ParameterizedTest
+    @MethodSource("functionExpressionProvider")
     void testFunctions(String expression, TransformContext context, Object expectedValue) {
         assertEquals(
                 expectedValue,
@@ -89,7 +94,6 @@ public class JstlEvaluatorTest {
     /**
      * @return {"expression", "transform context"}
      */
-    @DataProvider(name = "methodInvocationExpressionProvider")
     public static Object[][] methodInvocationExpressionProvider() {
         TransformContext primitiveStringContext =
                 Utils.createContextWithPrimitiveRecord(Schema.STRING, "test-message", "header-key");
@@ -106,7 +110,6 @@ public class JstlEvaluatorTest {
     /**
      * @return {"expression", "context", "expected value"}
      */
-    @DataProvider(name = "functionExpressionProvider")
     public static Object[][] functionExpressionProvider() {
         TransformContext primitiveBytesContext =
                 Utils.createContextWithPrimitiveRecord(

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluatorTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluatorTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.Utils;
+import jakarta.el.MethodNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.apache.pulsar.client.api.Schema;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class JstlEvaluatorTest {
+    @Test(
+            dataProvider = "methodInvocationExpressionProvider",
+            expectedExceptions = MethodNotFoundException.class)
+    void testMethodInvocationsDisabled(String expression, TransformContext context) {
+        new JstlEvaluator<>(String.format("${%s}", expression), String.class).evaluate(context);
+    }
+
+    @Test(dataProvider = "functionExpressionProvider")
+    void testFunctions(String expression, TransformContext context, Object expectedValue) {
+        assertEquals(
+                expectedValue,
+                new JstlEvaluator<>(String.format("${%s}", expression), Object.class)
+                        .evaluate(context));
+    }
+
+    @Test
+    void testPrimitiveValue() {
+        TransformContext primitiveStringContext =
+                Utils.createContextWithPrimitiveRecord(Schema.STRING, "test-message", "");
+
+        String value =
+                new JstlEvaluator<>("${value}", String.class).evaluate(primitiveStringContext);
+
+        assertEquals("test-message", value);
+    }
+
+    @Test
+    void testNowFunction() {
+        TransformContext primitiveStringContext =
+                Utils.createContextWithPrimitiveRecord(Schema.STRING, "test-message", "");
+
+        long expectedMillis = 123L;
+        Clock clock = Clock.fixed(Instant.ofEpochMilli(expectedMillis), ZoneOffset.UTC);
+        JstlFunctions.setClock(clock);
+
+        long actualMillis =
+                new JstlEvaluator<>("${fn:now()}", Long.class).evaluate(primitiveStringContext);
+
+        assertEquals(expectedMillis, actualMillis);
+    }
+
+    @Test
+    void testTimestampAddFunctionsNow() {
+        TransformContext primitiveStringContext =
+                Utils.createContextWithPrimitiveRecord(Schema.STRING, "test-message", "");
+
+        long nowMillis = 5000L;
+        long millisToAdd = -3333L * 1000L;
+        Clock clock = Clock.fixed(Instant.ofEpochMilli(nowMillis), ZoneOffset.UTC);
+        JstlFunctions.setClock(clock);
+        long actualMillis =
+                new JstlEvaluator<>("${fn:timestampAdd(fn:now(), -3333, 'seconds')}", Long.class)
+                        .evaluate(primitiveStringContext);
+
+        assertEquals(nowMillis + millisToAdd, actualMillis);
+    }
+
+    /**
+     * @return {"expression", "transform context"}
+     */
+    @DataProvider(name = "methodInvocationExpressionProvider")
+    public static Object[][] methodInvocationExpressionProvider() {
+        TransformContext primitiveStringContext =
+                Utils.createContextWithPrimitiveRecord(Schema.STRING, "test-message", "header-key");
+
+        return new Object[][] {
+            {"value.contains('test')", primitiveStringContext},
+            {"value.toUpperCase() == 'TEST-MESSAGE'", primitiveStringContext},
+            {"value.toUpperCase().toLowerCase() == 'test-message'", primitiveStringContext},
+            {"value.substring(0, 4) == 'test'", primitiveStringContext},
+            {"value.contains('random')", primitiveStringContext},
+        };
+    }
+
+    /**
+     * @return {"expression", "context", "expected value"}
+     */
+    @DataProvider(name = "functionExpressionProvider")
+    public static Object[][] functionExpressionProvider() {
+        TransformContext primitiveBytesContext =
+                Utils.createContextWithPrimitiveRecord(
+                        Schema.BYTES, "Test-Message ".getBytes(StandardCharsets.UTF_8), "");
+        TransformContext primitiveInstantContext =
+                Utils.createContextWithPrimitiveRecord(
+                        Schema.INSTANT, Instant.parse("2017-01-02T00:01:02Z"), "");
+        TransformContext chronoUnitBytesContext =
+                Utils.createContextWithPrimitiveRecord(
+                        Schema.BYTES, "millis".getBytes(StandardCharsets.UTF_8), "");
+        long millis = Instant.parse("2017-01-02T00:01:02Z").toEpochMilli();
+        return new Object[][] {
+            {"fn:uppercase('test')", primitiveBytesContext, "TEST"},
+            {"fn:uppercase(value) == 'TEST-MESSAGE '", primitiveBytesContext, true},
+            {"fn:uppercase(null)", primitiveBytesContext, null},
+            {"fn:lowercase('TEST')", primitiveBytesContext, "test"},
+            {"fn:lowercase(value) == 'test-message '", primitiveBytesContext, true},
+            {"fn:lowercase(null)", primitiveBytesContext, null},
+            {"fn:coalesce(null, 'another-value')", primitiveBytesContext, "another-value"},
+            {"fn:coalesce('value', 'another-value')", primitiveBytesContext, "value"},
+            {"fn:coalesce(fn:str(value), 'another-value')", primitiveBytesContext, "Test-Message "},
+            {"fn:contains(value, 'Test')", primitiveBytesContext, true},
+            {"fn:contains(value, 'random')", primitiveBytesContext, false},
+            {"fn:contains(null, 'random')", primitiveBytesContext, false},
+            {"fn:contains(value, null)", primitiveBytesContext, false},
+            {"fn:contains(value, null)", primitiveBytesContext, false},
+            {"fn:trim('    trimmed      ')", primitiveBytesContext, "trimmed"},
+            {"fn:trim(value)", primitiveBytesContext, "Test-Message"},
+            {"fn:trim(null)", primitiveBytesContext, null},
+            {"fn:concat(value, 'suffix')", primitiveBytesContext, "Test-Message suffix"},
+            {"fn:concat(value, null)", primitiveBytesContext, "Test-Message "},
+            {"fn:concat(null, 'suffix')", primitiveBytesContext, "suffix"},
+            {"fn:concat('prefix-', value)", primitiveBytesContext, "prefix-Test-Message "},
+            {"fn:replace(value, '.*-', '')", primitiveBytesContext, "Message "},
+            {"fn:replace('Test-Message test', value, '')", primitiveBytesContext, "test"},
+            {
+                "fn:replace('Something test', '.* ', value)",
+                primitiveBytesContext,
+                "Test-Message test"
+            },
+            {"fn:replace(null, '.* ', '')", primitiveBytesContext, null},
+            {"fn:replace('test', null, '')", primitiveBytesContext, "test"},
+            {"fn:replace('test', '.*', null)", primitiveBytesContext, "test"},
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', 1, 'years')",
+                primitiveBytesContext,
+                Instant.parse("2018-01-02T00:01:02Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', -1, 'months')",
+                primitiveBytesContext,
+                Instant.parse("2016-12-02T00:01:02Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', 1, 'days')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-03T00:01:02Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', -1, 'hours')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-01T23:01:02Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', 1, 'minutes')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:02:02Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', -1, 'seconds')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:01:01Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', 1, 'millis')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:01:02.001Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', 1000000, 'nanos')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:01:02.001Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", 1, 'years')",
+                primitiveBytesContext,
+                Instant.parse("2018-01-02T00:01:02Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", -1, 'months')",
+                primitiveBytesContext,
+                Instant.parse("2016-12-02T00:01:02Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", 1, 'days')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-03T00:01:02Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", -1, 'hours')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-01T23:01:02Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", 1, 'minutes')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:02:02Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", -1, 'seconds')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:01:01Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", 1, 'millis')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:01:02.001Z")
+            },
+            {
+                "fn:timestampAdd(" + millis + ", 1000000, 'nanos')",
+                primitiveBytesContext,
+                Instant.parse("2017-01-02T00:01:02.001Z")
+            },
+            {
+                "fn:timestampAdd(value, '1', 'millis')",
+                primitiveInstantContext,
+                Instant.parse("2017-01-02T00:01:02.001Z")
+            },
+            {
+                "fn:timestampAdd('2017-01-02T00:01:02Z', 1, value)",
+                chronoUnitBytesContext,
+                Instant.parse("2017-01-02T00:01:02.001Z")
+            },
+        };
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluatorTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlEvaluatorTest.java
@@ -26,18 +26,21 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import org.apache.pulsar.client.api.Schema;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.Test;
 
 public class JstlEvaluatorTest {
 
     @ParameterizedTest
     @MethodSource("methodInvocationExpressionProvider")
     void testMethodInvocationsDisabled(String expression, TransformContext context) {
-        assertThrows(MethodNotFoundException.class, () -> {
-            new JstlEvaluator<>(String.format("${%s}", expression), String.class).evaluate(context);
-        });
+        assertThrows(
+                MethodNotFoundException.class,
+                () -> {
+                    new JstlEvaluator<>(String.format("${%s}", expression), String.class)
+                            .evaluate(context);
+                });
     }
 
     @ParameterizedTest

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlFunctionsTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlFunctionsTest.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.streaming.ai.jstl;
 
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -34,7 +33,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -127,7 +125,6 @@ public class JstlFunctionsTest {
         assertEquals(fixedInstant, JstlFunctions.now());
     }
 
-
     @ParameterizedTest
     @MethodSource("millisTimestampAddProvider")
     void testAddDateMillis(long input, int delta, String unit, Instant expected) {
@@ -176,10 +173,14 @@ public class JstlFunctionsTest {
 
     @Test
     void testInvalidAddDate() {
-        assertEquals("Cannot convert [7] of type [class java.lang.Byte] to [class java.time.Instant]",
-                assertThrows(jakarta.el.ELException.class, () -> {
-                    JstlFunctions.dateadd((byte) 7, 0, "days");
-                }).getMessage());
+        assertEquals(
+                "Cannot convert [7] of type [class java.lang.Byte] to [class java.time.Instant]",
+                assertThrows(
+                                jakarta.el.ELException.class,
+                                () -> {
+                                    JstlFunctions.dateadd((byte) 7, 0, "days");
+                                })
+                        .getMessage());
     }
 
     /**
@@ -399,13 +400,16 @@ public class JstlFunctionsTest {
         };
     }
 
-
     @Test
     void testAddDateInvalidUnit() {
-        assertEquals("Invalid unit: lightyear. Should be one of [years, months, days, hours, minutes, seconds, millis]",
-        assertThrows(IllegalArgumentException.class, () -> {
-            JstlFunctions.timestampAdd(0L, 0, "lightyear");
-        }).getMessage());
+        assertEquals(
+                "Invalid unit: lightyear. Should be one of [years, months, days, hours, minutes, seconds, millis]",
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> {
+                                    JstlFunctions.timestampAdd(0L, 0, "lightyear");
+                                })
+                        .getMessage());
     }
 
     @Test

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlFunctionsTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlFunctionsTest.java
@@ -1,0 +1,517 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class JstlFunctionsTest {
+
+    @Test
+    void testUpperCase() {
+        assertEquals("UPPERCASE", JstlFunctions.uppercase("uppercase"));
+    }
+
+    @Test
+    void testUpperCaseInteger() {}
+
+    @Test
+    void testUpperCaseNull() {
+        assertNull(JstlFunctions.uppercase(null));
+    }
+
+    @Test
+    void testLowerCase() {
+        assertEquals("lowercase", JstlFunctions.lowercase("LOWERCASE"));
+    }
+
+    @Test
+    void testLowerCaseInteger() {
+        assertEquals("10", JstlFunctions.uppercase(10));
+    }
+
+    @Test
+    void testLowerCaseNull() {
+        assertNull(JstlFunctions.uppercase(null));
+    }
+
+    @Test
+    void testContains() {
+        assertTrue(JstlFunctions.contains("full text", "l t"));
+        assertTrue(JstlFunctions.contains("full text", "full"));
+        assertTrue(JstlFunctions.contains("full text", "text"));
+
+        assertFalse(JstlFunctions.contains("full text", "lt"));
+        assertFalse(JstlFunctions.contains("full text", "fll"));
+        assertFalse(JstlFunctions.contains("full text", "txt"));
+    }
+
+    @Test
+    void testContainsInteger() {
+        assertTrue(JstlFunctions.contains(123, "2"));
+        assertTrue(JstlFunctions.contains("123", 3));
+        assertTrue(JstlFunctions.contains(123, 3));
+        assertTrue(JstlFunctions.contains("123", "3"));
+
+        assertFalse(JstlFunctions.contains(123, "4"));
+        assertFalse(JstlFunctions.contains("123", 4));
+        assertFalse(JstlFunctions.contains(123, 4));
+        assertFalse(JstlFunctions.contains("123", "4"));
+    }
+
+    @Test
+    void testContainsNull() {
+        assertFalse(JstlFunctions.contains("null", null));
+        assertFalse(JstlFunctions.contains(null, "null"));
+        assertFalse(JstlFunctions.contains(null, null));
+    }
+
+    @Test
+    void testConcat() {
+        assertEquals("full text", JstlFunctions.concat("full ", "text"));
+    }
+
+    @Test
+    void testConcatInteger() {
+        assertEquals("12", JstlFunctions.concat(1, 2));
+        assertEquals("12", JstlFunctions.concat("1", 2));
+        assertEquals("12", JstlFunctions.concat(1, "2"));
+    }
+
+    @Test
+    void testConcatNull() {
+        assertEquals("text", JstlFunctions.concat(null, "text"));
+        assertEquals("full ", JstlFunctions.concat("full ", null));
+        assertEquals("", JstlFunctions.concat(null, null));
+    }
+
+    @Test
+    void testNow() {
+        Instant fixedInstant = Instant.now();
+        Clock clock = Clock.fixed(fixedInstant, ZoneOffset.UTC);
+        JstlFunctions.setClock(clock);
+        assertEquals(fixedInstant, JstlFunctions.now());
+    }
+
+    @Test(dataProvider = "millisTimestampAddProvider")
+    void testAddDateMillis(long input, int delta, String unit, Instant expected) {
+        assertEquals(expected, JstlFunctions.timestampAdd(input, delta, unit));
+    }
+
+    @Test(dataProvider = "utcTimestampAddProvider")
+    void testAddDateUTC(String input, int delta, String unit, Instant expected) {
+        assertEquals(expected, JstlFunctions.timestampAdd(input, delta, unit));
+    }
+
+    @Test(dataProvider = "nonUtcTimestampAddProvider")
+    void testAddDateNonUTC(String input, int delta, String unit, Instant expected) {
+        assertEquals(expected, JstlFunctions.timestampAdd(input, delta, unit));
+    }
+
+    @Test
+    void testAddDateDeltaConversion() {
+        assertEquals(
+                Instant.parse("2022-10-02T02:02:03Z"),
+                JstlFunctions.timestampAdd(
+                        "2022-10-02T01:02:03Z", LocalTime.of(1, 0, 0), "millis"));
+    }
+
+    @Test
+    void testAddDateUnitConversion() {
+        assertEquals(
+                Instant.parse("2022-10-02T02:02:03Z"),
+                JstlFunctions.timestampAdd(
+                        "2022-10-02T01:02:03Z", 1, "hours".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test(dataProvider = "toBigDecimalProvider")
+    void testToBigDecimal(Object value, Object scale, BigDecimal expected) {
+        assertEquals(expected, JstlFunctions.toBigDecimal(value, scale));
+    }
+
+    @Test(dataProvider = "toBigDecimalWithoutScaleProvider")
+    void testToBigDecimalWithoutScale(Object value, BigDecimal expected) {
+        assertEquals(expected, JstlFunctions.toBigDecimal(value));
+    }
+
+    @Test(
+            expectedExceptions = jakarta.el.ELException.class,
+            expectedExceptionsMessageRegExp =
+                    "Cannot convert \\[7\\] of type \\[class java.lang.Byte\\] to \\[class java.time.Instant\\]")
+    void testInvalidAddDate() {
+        JstlFunctions.dateadd((byte) 7, 0, "days");
+    }
+
+    /**
+     * @return {"value convertible to BigInteger, scale, "expected BigDecimal value"}
+     */
+    @DataProvider(name = "toBigDecimalProvider")
+    public static Object[][] toBigDecimalProvider() {
+        BigDecimal bigDecimal = new BigDecimal("12.34567890123456789012345678901234567890");
+        BigDecimal smallDecimal = new BigDecimal("1234.5678");
+        return new Object[][] {
+            {
+                new BigInteger("1234567890123456789012345678901234567890").toByteArray(),
+                38,
+                bigDecimal
+            },
+            {"1234567890123456789012345678901234567890", "38", bigDecimal},
+            {12345678, 4, smallDecimal},
+            {12345678L, 4, smallDecimal},
+        };
+    }
+
+    /**
+     * @return {"value convertible to double, "expected BigDecimal value"}
+     */
+    @DataProvider(name = "toBigDecimalWithoutScaleProvider")
+    public static Object[][] toBigDecimalWithoutScaleProvider() {
+        BigDecimal bigDecimal = BigDecimal.valueOf(12.34567890123456789012345678901234567890d);
+        BigDecimal smallDecimal = BigDecimal.valueOf(1234.5678f);
+        BigDecimal unscaledDecimal = BigDecimal.valueOf(1234567d);
+        return new Object[][] {
+            {"12.34567890123456789012345678901234567890", bigDecimal},
+            {12.34567890123456789012345678901234567890d, bigDecimal},
+            {1234.5678f, smallDecimal},
+            {1234567, unscaledDecimal},
+            {1234567L, unscaledDecimal},
+        };
+    }
+
+    /**
+     * @return {"input date in epoch millis", "delta", "unit", "expected value (in epoch millis)"}
+     */
+    @DataProvider(name = "millisTimestampAddProvider")
+    public static Object[][] millisTimestampAddProvider() {
+        Instant instant = Instant.parse("2022-10-02T01:02:03Z");
+        long millis = instant.toEpochMilli();
+        return new Object[][] {
+            {millis, 0, "years", instant},
+            {millis, 5, "years", Instant.parse("2027-10-02T01:02:03Z")},
+            {millis, -3, "years", Instant.parse("2019-10-02T01:02:03Z")},
+            {millis, 0, "months", instant},
+            {millis, 5, "months", Instant.parse("2023-03-02T01:02:03Z")},
+            {millis, -3, "months", Instant.parse("2022-07-02T01:02:03Z")},
+            {millis, 0, "days", instant},
+            {millis, 5, "days", Instant.parse("2022-10-07T01:02:03Z")},
+            {millis, -3, "days", Instant.parse("2022-09-29T01:02:03Z")},
+            {millis, 0, "hours", instant},
+            {millis, 5, "hours", Instant.parse("2022-10-02T06:02:03Z")},
+            {millis, -3, "hours", Instant.parse("2022-10-01T22:02:03Z")},
+            {millis, 0, "minutes", instant},
+            {millis, 5, "minutes", Instant.parse("2022-10-02T01:07:03Z")},
+            {millis, -3, "minutes", Instant.parse("2022-10-02T00:59:03Z")},
+            {millis, 0, "seconds", instant},
+            {millis, 5, "seconds", Instant.parse("2022-10-02T01:02:08Z")},
+            {millis, -3, "seconds", Instant.parse("2022-10-02T01:02:00Z")},
+            {millis, 0, "millis", instant},
+            {millis, 5, "millis", Instant.parse("2022-10-02T01:02:03.005Z")},
+            {millis, -3, "millis", Instant.parse("2022-10-02T01:02:02.997Z")},
+            {millis, 0, "nanos", instant},
+            {millis, 5_000_000, "nanos", Instant.parse("2022-10-02T01:02:03.005Z")},
+            {millis, -3_000_000, "nanos", Instant.parse("2022-10-02T01:02:02.997Z")},
+        };
+    }
+
+    /**
+     * @return {"input date", "delta", "unit", "expected value"}
+     */
+    @DataProvider(name = "utcTimestampAddProvider")
+    public static Object[][] utcTimestampAddProvider() {
+        String utcDateTime = "2022-10-02T01:02:03Z";
+        Instant instant = Instant.parse("2022-10-02T01:02:03Z");
+        return new Object[][] {
+            {utcDateTime, 0, "years", instant},
+            {utcDateTime, 5, "years", Instant.parse("2027-10-02T01:02:03Z")},
+            {utcDateTime, -3, "years", Instant.parse("2019-10-02T01:02:03Z")},
+            {utcDateTime, 0, "months", instant},
+            {utcDateTime, 5, "months", Instant.parse("2023-03-02T01:02:03Z")},
+            {utcDateTime, -3, "months", Instant.parse("2022-07-02T01:02:03Z")},
+            {utcDateTime, 0, "days", instant},
+            {utcDateTime, 5, "days", Instant.parse("2022-10-07T01:02:03Z")},
+            {utcDateTime, -3, "days", Instant.parse("2022-09-29T01:02:03Z")},
+            {utcDateTime, 0, "hours", instant},
+            {utcDateTime, 5, "hours", Instant.parse("2022-10-02T06:02:03Z")},
+            {utcDateTime, -3, "hours", Instant.parse("2022-10-01T22:02:03Z")},
+            {utcDateTime, 0, "minutes", instant},
+            {utcDateTime, 5, "minutes", Instant.parse("2022-10-02T01:07:03Z")},
+            {utcDateTime, -3, "minutes", Instant.parse("2022-10-02T00:59:03Z")},
+            {utcDateTime, 0, "seconds", instant},
+            {utcDateTime, 5, "seconds", Instant.parse("2022-10-02T01:02:08Z")},
+            {utcDateTime, -3, "seconds", Instant.parse("2022-10-02T01:02:00Z")},
+            {utcDateTime, 0, "millis", instant},
+            {utcDateTime, 5, "millis", Instant.parse("2022-10-02T01:02:03.005Z")},
+            {utcDateTime, -3, "millis", Instant.parse("2022-10-02T01:02:02.997Z")},
+            {utcDateTime, 0, "nanos", instant},
+            {utcDateTime, 5_000_000, "nanos", Instant.parse("2022-10-02T01:02:03.005Z")},
+            {utcDateTime, -3_000_000, "nanos", Instant.parse("2022-10-02T01:02:02.997Z")},
+        };
+    }
+
+    /**
+     * @return {"input date", "delta", "unit", "expected value (in epoch millis)"}
+     */
+    @DataProvider(name = "nonUtcTimestampAddProvider")
+    public static Object[][] nonUtcTimestampAddProvider() {
+        String nonUtcDateTime = "2022-10-02T01:02:03+02:00";
+        long twoHoursMillis = Duration.ofHours(2).toMillis();
+        Instant instant = Instant.parse("2022-10-02T01:02:03Z");
+        return new Object[][] {
+            {nonUtcDateTime, 0, "years", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5,
+                "years",
+                Instant.parse("2027-10-02T01:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3,
+                "years",
+                Instant.parse("2019-10-02T01:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {nonUtcDateTime, 0, "months", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5,
+                "months",
+                Instant.parse("2023-03-02T01:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3,
+                "months",
+                Instant.parse("2022-07-02T01:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {nonUtcDateTime, 0, "days", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5,
+                "days",
+                Instant.parse("2022-10-07T01:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3,
+                "days",
+                Instant.parse("2022-09-29T01:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {nonUtcDateTime, 0, "hours", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5,
+                "hours",
+                Instant.parse("2022-10-02T06:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3,
+                "hours",
+                Instant.parse("2022-10-01T22:02:03Z").minusMillis(twoHoursMillis)
+            },
+            {nonUtcDateTime, 0, "minutes", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5,
+                "minutes",
+                Instant.parse("2022-10-02T01:07:03Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3,
+                "minutes",
+                Instant.parse("2022-10-02T00:59:03Z").minusMillis(twoHoursMillis)
+            },
+            {nonUtcDateTime, 0, "seconds", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5,
+                "seconds",
+                Instant.parse("2022-10-02T01:02:08Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3,
+                "seconds",
+                Instant.parse("2022-10-02T01:02:00Z").minusMillis(twoHoursMillis)
+            },
+            {nonUtcDateTime, 0, "millis", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5,
+                "millis",
+                Instant.parse("2022-10-02T01:02:03.005Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3,
+                "millis",
+                Instant.parse("2022-10-02T01:02:02.997Z").minusMillis(twoHoursMillis)
+            },
+            {nonUtcDateTime, 0, "nanos", instant.minusMillis(twoHoursMillis)},
+            {
+                nonUtcDateTime,
+                5_000_000,
+                "nanos",
+                Instant.parse("2022-10-02T01:02:03.005Z").minusMillis(twoHoursMillis)
+            },
+            {
+                nonUtcDateTime,
+                -3_000_000,
+                "nanos",
+                Instant.parse("2022-10-02T01:02:02.997Z").minusMillis(twoHoursMillis)
+            },
+        };
+    }
+
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp =
+                    "Invalid unit: lightyear. Should be one of \\[years, months, days, hours, minutes, seconds, millis\\]")
+    void testAddDateInvalidUnit() {
+        JstlFunctions.timestampAdd(0L, 0, "lightyear");
+    }
+
+    @Test
+    void testCast() {
+        assertEquals(1.2, JstlFunctions.toDouble("1.2"));
+        assertEquals(null, JstlFunctions.toDouble(null));
+        assertEquals(1, JstlFunctions.toInt("1.2"));
+        assertEquals(null, JstlFunctions.toInt(null));
+    }
+
+    @Test
+    void testSplit() {
+        assertEquals(List.of("1", "2"), JstlFunctions.split("1,2", ","));
+        assertEquals(List.of(), JstlFunctions.split("", ","));
+        assertEquals(null, JstlFunctions.split(null, ","));
+    }
+
+    @Test
+    void testUnpack() {
+        assertEquals(
+                map("field1", "1", "field2", "2"), JstlFunctions.unpack("1,2", "field1,field2"));
+        assertEquals(
+                map("field1", null, "field2", null), JstlFunctions.unpack("", "field1,field2"));
+        assertEquals(null, JstlFunctions.unpack(null, "field1,field2"));
+
+        assertEquals(
+                map("field1", "1", "field2", "2", "field3", null),
+                JstlFunctions.unpack("1,2", "field1,field2,field3"));
+        assertEquals(
+                map("field1", "1", "field2", null), JstlFunctions.unpack("1", "field1,field2"));
+
+        assertEquals(
+                map("field1", "1", "field2", "2"),
+                JstlFunctions.unpack(JstlFunctions.split("1:2", ":"), "field1,field2"));
+
+        assertEquals(
+                map("field1", 1f, "field2", 2f),
+                JstlFunctions.unpack(List.of(1f, 2f), "field1,field2"));
+    }
+
+    @Test
+    void testToJson() throws Exception {
+        assertEquals("{\"field1\":1}", JstlFunctions.toJson(Map.of("field1", 1)));
+        assertEquals("null", JstlFunctions.toJson(null));
+        assertEquals("\"\"", JstlFunctions.toJson(""));
+        assertEquals("[1,2,3]", JstlFunctions.toJson(List.of(1, 2, 3)));
+    }
+
+    @Test
+    void testFromJson() throws Exception {
+        assertEquals(Map.of("field1", 1), JstlFunctions.fromJson("{\"field1\":1}"));
+        assertEquals(null, JstlFunctions.fromJson(null));
+        assertEquals(null, JstlFunctions.fromJson("null"));
+        assertEquals(null, JstlFunctions.fromJson(""));
+        assertEquals("", JstlFunctions.fromJson("\"\""));
+        assertEquals(List.of(1, 2, 3), JstlFunctions.fromJson("[1,2,3]"));
+    }
+
+    private static Map<String, Object> map(
+            String key, Object nullableValue, String key2, Object nullableValue2) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(key, nullableValue);
+        map.put(key2, nullableValue2);
+        return map;
+    }
+
+    private static Map<String, Object> map(
+            String key,
+            Object nullableValue,
+            String key2,
+            Object nullableValue2,
+            String key3,
+            Object nullableValue3) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(key, nullableValue);
+        map.put(key2, nullableValue2);
+        map.put(key3, nullableValue3);
+        return map;
+    }
+
+    @Test
+    void testFilterQueryResults() {
+
+        // the query step always produces a list<map<string,string>> result
+        // this test verifies that it is possible to filter the result using the JSTL filter
+        // function
+        List<Map<String, String>> queryResult = new ArrayList<>();
+        queryResult.add(Map.of("name", "product1", "price", "1.2", "similarity", "0.9"));
+        queryResult.add(Map.of("name", "product2", "price", "1.7", "similarity", "0.1"));
+
+        {
+            List<Object> filter =
+                    JstlFunctions.filter(queryResult, "fn:toDouble(record.similarity) >= 0.5");
+            assertEquals(1, filter.size());
+            assertEquals("product1", ((Map<String, String>) filter.get(0)).get("name"));
+        }
+
+        {
+            List<Object> filter =
+                    JstlFunctions.filter(queryResult, "fn:toDouble(record.similarity) < 0.5");
+            assertEquals(1, filter.size());
+            assertEquals("product2", ((Map<String, String>) filter.get(0)).get("name"));
+        }
+
+        {
+            List<Object> filter = JstlFunctions.filter(queryResult, "false");
+            assertEquals(0, filter.size());
+        }
+
+        {
+            List<Object> filter = JstlFunctions.filter(queryResult, "true");
+            assertEquals(2, filter.size());
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapterTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapterTest.java
@@ -16,9 +16,9 @@
 package com.datastax.oss.streaming.ai.jstl;
 
 import static com.datastax.oss.streaming.ai.Utils.newTransformContext;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datastax.oss.streaming.ai.TransformContext;
 import com.datastax.oss.streaming.ai.Utils;
@@ -39,7 +39,7 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class JstlTransformContextAdapterTest {
     private static final org.apache.avro.Schema dateType =

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapterTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTransformContextAdapterTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import static com.datastax.oss.streaming.ai.Utils.newTransformContext;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.Utils;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.Test;
+
+public class JstlTransformContextAdapterTest {
+    private static final org.apache.avro.Schema dateType =
+            LogicalTypes.date()
+                    .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
+
+    @Test
+    void testAdapterForKeyValueRecord() {
+        // given
+        Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
+        /*
+         Actual key: { "keyField1": "key1", "keyField2": "key2", "keyField3": "key3" }
+
+         <p>Actual value: { "valueField1": "value1", "valueField2": "value2", "valueField3": "value3"
+         }
+        */
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+
+        // when
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+        // then
+        assertTrue(adapter.getKey() instanceof Map);
+        Map<String, Object> keyMap = (Map<String, Object>) adapter.getKey();
+        assertEquals(keyMap.get("keyField1"), "key1");
+        assertEquals(keyMap.get("keyField2"), "key2");
+        assertEquals(keyMap.get("keyField3"), "key3");
+        assertNull(keyMap.get("keyField4"));
+
+        assertTrue(adapter.adaptValue() instanceof Map);
+        Map<String, Object> valueMap = (Map<String, Object>) adapter.adaptValue();
+        assertEquals(valueMap.get("valueField1"), "value1");
+        assertEquals(valueMap.get("valueField2"), "value2");
+        assertEquals(valueMap.get("valueField3"), "value3");
+
+        assertTrue(adapter.getKey() instanceof Map);
+        assertNull(keyMap.get("valueField4"));
+    }
+
+    @Test
+    void testAdapterForPrimitiveKeyValueRecord() {
+        // given
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        TransformContext transformContext =
+                Utils.createContextWithPrimitiveRecord(keyValueSchema, keyValue, "header-key");
+
+        // when
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+        assertEquals(adapter.getKey(), "key");
+        assertEquals(adapter.adaptValue(), 42);
+        assertEquals(adapter.getHeader().get("messageKey"), "header-key");
+    }
+
+    @Test
+    void testAdapterForPrimitiveRecord() {
+        // given
+        TransformContext transformContext =
+                Utils.createContextWithPrimitiveRecord(Schema.STRING, "test-message", "header-key");
+
+        // when
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+        // then
+        assertEquals(adapter.getHeader().get("messageKey"), "header-key");
+        assertEquals(adapter.getKey(), "header-key");
+
+        assertEquals(adapter.adaptValue(), "test-message");
+        assertEquals(adapter.adaptValue(), "test-message");
+    }
+
+    @Test
+    void testAdapterForNestedValueRecord() {
+        // given
+        Record<GenericObject> record = Utils.createNestedAvroRecord(4, "header-key");
+        /*
+         Actual key: "header-key"
+
+         <p>Actual value: "level1String": "level1_1", "level1Record": { "level2String": "level2_1",
+         "level2Record": { "level3String": "level3_1", "level3Record": { "level4String": "level4_1",
+         "level4Integer": 9, "level4Double": 8.8, "level4StringWithProps": "level4_WithProps",
+         "level4Union": "level4_2" } } } }
+        */
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+
+        // when
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+        // then
+        assertEquals(adapter.getHeader().get("messageKey"), "header-key");
+        assertEquals(adapter.getKey(), "header-key");
+        assertTrue(adapter.adaptValue() instanceof Map);
+        Map<String, Object> valueMap = (Map<String, Object>) adapter.adaptValue();
+        assertNestedRecord(valueMap);
+    }
+
+    @Test
+    void testAdapterForNestedKeyValueRecord() {
+        // given
+        Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(4);
+        /*
+         Actual key: { "level1String": "level1_1", "level1Record": { "level2String": "level2_1",
+         "level2Record": { "level3String": "level3_1", "level3Record": { "level4String": "level4_1",
+         "level4Integer": 9, "level4Double": 8.8, "level4StringWithProps": "level4_WithProps",
+         "level4Union": "level4_2" } } } }
+
+         <p>Actual value: "level1String": "level1_1", "level1Record": { "level2String": "level2_1",
+         "level2Record": { "level3String": "level3_1", "level3Record": { "level4String": "level4_1",
+         "level4Integer": 9, "level4Double": 8.8, "level4StringWithProps": "level4_WithProps",
+         "level4Union": "level4_2" } } } }
+        */
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+
+        // when
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+        // then
+        assertTrue(adapter.getKey() instanceof Map);
+        assertNestedRecord((Map<String, Object>) adapter.getKey());
+
+        assertTrue(adapter.adaptValue() instanceof Map);
+        assertNestedRecord((Map<String, Object>) adapter.adaptValue());
+    }
+
+    @Test
+    void testAdapterForRecordHeaders() {
+        // given
+        Map<String, String> props = new HashMap<>();
+        props.put("p1", "v1");
+        props.put("p2", "v2");
+        Record<GenericObject> record =
+                Utils.TestRecord.<GenericObject>builder()
+                        .schema(Schema.STRING)
+                        .value(
+                                AutoConsumeSchema.wrapPrimitiveObject(
+                                        "test-message", SchemaType.STRING, new byte[] {}))
+                        .key("test-key")
+                        .topicName("test-topic")
+                        .destinationTopic("test-dest-topic")
+                        .eventTime(1662493532L)
+                        .properties(props)
+                        .build();
+
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+
+        // when
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+        // then
+        assertEquals(adapter.getHeader().get("messageKey"), "test-key");
+        assertEquals(adapter.getHeader().get("topicName"), "test-topic");
+        assertEquals(adapter.getHeader().get("destinationTopic"), "test-dest-topic");
+        assertEquals(adapter.getHeader().get("eventTime"), 1662493532L);
+        assertTrue(adapter.getHeader().get("properties") instanceof Map);
+        Map<String, Object> headerProps = (Map) adapter.getHeader().get("properties");
+        assertEquals(headerProps.get("p1"), "v1");
+        assertEquals(headerProps.get("p2"), "v2");
+        assertNull(headerProps.get("p3"));
+    }
+
+    @Test
+    public void testAdapterForLogicalTypes() {
+        // given
+        List<org.apache.avro.Schema.Field> fields =
+                List.of(
+                        createDateField("dateField", false),
+                        createDateField("optionalDateField", true));
+        org.apache.avro.Schema avroSchema =
+                org.apache.avro.Schema.createRecord("avro_date", "", "ns", false, fields);
+        org.apache.avro.generic.GenericRecord genericRecord = new GenericData.Record(avroSchema);
+
+        LocalDate date = LocalDate.parse("2023-04-01");
+        LocalDate optionalDate = LocalDate.parse("2023-04-02");
+        genericRecord.put("dateField", (int) date.toEpochDay());
+        genericRecord.put("optionalDateField", (int) optionalDate.toEpochDay());
+
+        List<Field> pulsarFields =
+                fields.stream().map(v -> new Field(v.name(), v.pos())).collect(Collectors.toList());
+        GenericAvroRecord valueRecord =
+                new GenericAvroRecord(new byte[0], avroSchema, pulsarFields, genericRecord);
+        Schema<org.apache.avro.generic.GenericRecord> pulsarValueSchema =
+                new Utils.NativeSchemaWrapper(
+                        valueRecord.getAvroRecord().getSchema(), SchemaType.AVRO);
+        Record<GenericObject> record =
+                new Utils.TestRecord<>(pulsarValueSchema, valueRecord, "key");
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+
+        // when
+        JstlTransformContextAdapter adapter = new JstlTransformContextAdapter(transformContext);
+
+        // then
+        assertTrue(adapter.adaptValue() instanceof Map);
+        Map<String, Object> map = (Map) adapter.adaptValue();
+        assertEquals(map.get("dateField"), date);
+        assertEquals(map.get("optionalDateField"), optionalDate);
+    }
+
+    private org.apache.avro.Schema.Field createDateField(String name, boolean optional) {
+        org.apache.avro.Schema.Field dateField = new org.apache.avro.Schema.Field(name, dateType);
+        if (optional) {
+            dateField =
+                    new org.apache.avro.Schema.Field(
+                            name,
+                            SchemaBuilder.unionOf()
+                                    .nullType()
+                                    .and()
+                                    .type(dateField.schema())
+                                    .endUnion(),
+                            null,
+                            org.apache.avro.Schema.Field.NULL_DEFAULT_VALUE);
+        }
+        return dateField;
+    }
+
+    void assertNestedRecord(Map<String, Object> root) {
+        assertTrue(root.get("level1Record") instanceof Map);
+        Map<String, Object> l1Map = (Map) root.get("level1Record");
+        assertEquals(l1Map.get("level2String"), "level2_1");
+
+        assertTrue(l1Map.get("level2Record") instanceof Map);
+        Map<String, Object> l2Map = (Map) l1Map.get("level2Record");
+        assertEquals(l2Map.get("level3String"), "level3_1");
+
+        assertTrue(l2Map.get("level3Record") instanceof Map);
+        Map<String, Object> l3Map = (Map) l2Map.get("level3Record");
+        assertEquals(l3Map.get("level4String"), "level4_1");
+        assertEquals(l3Map.get("level4Integer"), 9);
+        assertEquals(l3Map.get("level4Double"), 8.8D);
+
+        assertNull(l3Map.get("level4Record"));
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverterTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverterTest.java
@@ -35,9 +35,9 @@ import java.util.Date;
 import java.util.TimeZone;
 import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.Schema;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.Test;
 
 public class JstlTypeConverterTest {
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverterTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverterTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl;
+
+import static org.testng.AssertJUnit.assertNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.TimeZone;
+import org.apache.avro.util.Utf8;
+import org.apache.pulsar.client.api.Schema;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class JstlTypeConverterTest {
+
+    private static final JstlTypeConverter converter = JstlTypeConverter.INSTANCE;
+
+    @Test
+    void testNullConversion() {
+        assertNull(converter.coerceToType(null, byte[].class));
+        assertNull(converter.coerceToType(null, String.class));
+        assertNull(converter.coerceToType(null, int.class));
+        assertNull(converter.coerceToType(null, long.class));
+        assertNull(converter.coerceToType(null, float.class));
+        assertNull(converter.coerceToType(null, double.class));
+        assertNull(converter.coerceToType(null, boolean.class));
+        assertNull(converter.coerceToType(null, Date.class));
+        assertNull(converter.coerceToType(null, Timestamp.class));
+        assertNull(converter.coerceToType(null, Time.class));
+        assertNull(converter.coerceToType(null, LocalDateTime.class));
+        assertNull(converter.coerceToType(null, LocalDate.class));
+        assertNull(converter.coerceToType(null, LocalTime.class));
+        assertNull(converter.coerceToType(null, Instant.class));
+        assertNull(converter.coerceToType(null, OffsetDateTime.class));
+        assertNull(converter.coerceToType(null, BigDecimal.class));
+    }
+
+    @DataProvider(name = "conversions")
+    public static Object[][] conversions() {
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+        byte byteValue = (byte) 42;
+        short shortValue = (short) 42;
+        int intValue = 42;
+        long longValue = 42L;
+        float floatValue = 42.8F;
+        double doubleValue = 42.8D;
+        long dateTimeMillis = 1672700645000L;
+        long midnightMillis = 1672617600000L;
+        long numberOfDays = 19359L;
+        long timeMillis = 83045000L;
+        double timeMillisWithNanos = 83045000.000006D;
+        Date date = new Date(dateTimeMillis);
+        Instant instant = Instant.ofEpochSecond(1672700645, 6);
+        Timestamp timestamp = Timestamp.from(instant);
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(2023, 1, 2, 23, 4, 5, 6, ZoneOffset.UTC);
+        LocalDateTime localDateTime = LocalDateTime.of(2023, 1, 2, 23, 4, 5, 6);
+        LocalDate localDate = LocalDate.of(2023, 1, 2);
+        LocalTime localTime = LocalTime.of(23, 4, 5, 6);
+        Time time = new Time(timeMillis);
+        LocalDateTime localDateTimeWithoutNanos =
+                LocalDateTime.ofEpochSecond(dateTimeMillis / 1000, 0, ZoneOffset.UTC);
+        BigInteger bigInteger = new BigInteger("345781342432523452345");
+        BigDecimal bigDecimal = new BigDecimal("435897983457.83421");
+        return new Object[][] {
+            // Bytes
+            {new byte[] {1, 2, 3}, byte[].class, new byte[] {1, 2, 3}},
+            {"test", byte[].class, "test".getBytes(StandardCharsets.UTF_8)},
+            {true, byte[].class, new byte[] {1}},
+            {byteValue, byte[].class, new byte[] {byteValue}},
+            {shortValue, byte[].class, Schema.INT16.encode(shortValue)},
+            {intValue, byte[].class, Schema.INT32.encode(intValue)},
+            {longValue, byte[].class, Schema.INT64.encode(longValue)},
+            {floatValue, byte[].class, Schema.FLOAT.encode(floatValue)},
+            {doubleValue, byte[].class, Schema.DOUBLE.encode(doubleValue)},
+            {date, byte[].class, Schema.DATE.encode(date)},
+            {timestamp, byte[].class, Schema.TIMESTAMP.encode(timestamp)},
+            {time, byte[].class, Schema.TIME.encode(time)},
+            {localDateTime, byte[].class, Schema.LOCAL_DATE_TIME.encode(localDateTime)},
+            {instant, byte[].class, Schema.INSTANT.encode(instant)},
+            {offsetDateTime, byte[].class, Schema.INSTANT.encode(instant)},
+            {localDate, byte[].class, Schema.LOCAL_DATE.encode(localDate)},
+            {localTime, byte[].class, Schema.LOCAL_TIME.encode(localTime)},
+
+            // String
+            {"test".getBytes(StandardCharsets.UTF_8), String.class, "test"},
+            {"test", String.class, "test"},
+            {true, String.class, "true"},
+            {byteValue, String.class, "42"},
+            {shortValue, String.class, "42"},
+            {intValue, String.class, "42"},
+            {longValue, String.class, "42"},
+            {floatValue, String.class, "42.8"},
+            {doubleValue, String.class, "42.8"},
+            {date, String.class, "2023-01-02T23:04:05Z"},
+            {timestamp, String.class, "2023-01-02T23:04:05.000000006Z"},
+            {time, String.class, "23:04:05"},
+            {localDateTime, String.class, "2023-01-02T23:04:05.000000006"},
+            {instant, String.class, "2023-01-02T23:04:05.000000006Z"},
+            {offsetDateTime, String.class, "2023-01-02T23:04:05.000000006Z"},
+            {localDate, String.class, "2023-01-02"},
+            {localTime, String.class, "23:04:05.000000006"},
+
+            // Utf8String
+            {new Utf8("test"), String.class, "test"},
+            {new Utf8("1"), Integer.class, 1},
+
+            // Boolean
+            {new byte[] {byteValue}, Boolean.class, true},
+            {"true", Boolean.class, true},
+            {true, Boolean.class, true},
+
+            // Byte
+            {new byte[] {byteValue}, Byte.class, byteValue},
+            {"42", Byte.class, byteValue},
+            {byteValue, Byte.class, byteValue},
+            {shortValue, Byte.class, byteValue},
+            {intValue, Byte.class, byteValue},
+            {longValue, Byte.class, byteValue},
+            {floatValue, Byte.class, byteValue},
+            {doubleValue, Byte.class, byteValue},
+
+            // Short
+            {Schema.INT16.encode(shortValue), Short.class, shortValue},
+            {"42", Short.class, shortValue},
+            {byteValue, Short.class, shortValue},
+            {shortValue, Short.class, shortValue},
+            {intValue, Short.class, shortValue},
+            {longValue, Short.class, shortValue},
+            {floatValue, Short.class, shortValue},
+            {doubleValue, Short.class, shortValue},
+
+            // Integer
+            {Schema.INT32.encode(intValue), Integer.class, intValue},
+            {"42", Integer.class, intValue},
+            {byteValue, Integer.class, intValue},
+            {shortValue, Integer.class, intValue},
+            {intValue, Integer.class, intValue},
+            {longValue, Integer.class, intValue},
+            {floatValue, Integer.class, intValue},
+            {doubleValue, Integer.class, intValue},
+            {localDate, Integer.class, (int) numberOfDays},
+
+            // Long
+            {Schema.INT64.encode(longValue), Long.class, longValue},
+            {"42", Long.class, longValue},
+            {byteValue, Long.class, longValue},
+            {shortValue, Long.class, longValue},
+            {intValue, Long.class, longValue},
+            {longValue, Long.class, longValue},
+            {floatValue, Long.class, longValue},
+            {doubleValue, Long.class, longValue},
+            {date, Long.class, dateTimeMillis},
+            {timestamp, Long.class, dateTimeMillis},
+            {time, Long.class, timeMillis},
+            {localDateTime, Long.class, dateTimeMillis},
+            {instant, Long.class, dateTimeMillis},
+            {offsetDateTime, Long.class, dateTimeMillis},
+            {localTime, Long.class, timeMillis},
+            {localDate, Long.class, numberOfDays},
+
+            // Float
+            {Schema.FLOAT.encode(floatValue), Float.class, floatValue},
+            {"42.8", Float.class, floatValue},
+            {byteValue, Float.class, 42F},
+            {shortValue, Float.class, 42F},
+            {intValue, Float.class, 42F},
+            {longValue, Float.class, 42F},
+            {floatValue, Float.class, floatValue},
+            {doubleValue, Float.class, floatValue},
+            {localDate, Float.class, (float) numberOfDays},
+
+            // Double
+            {Schema.DOUBLE.encode(doubleValue), Double.class, doubleValue},
+            {"42.8", Double.class, doubleValue},
+            {byteValue, Double.class, 42D},
+            {shortValue, Double.class, 42D},
+            {intValue, Double.class, 42D},
+            {longValue, Double.class, 42D},
+            {floatValue, Double.class, (double) floatValue},
+            {doubleValue, Double.class, doubleValue},
+            {date, Double.class, (double) dateTimeMillis},
+            {timestamp, Double.class, (double) dateTimeMillis},
+            {time, Double.class, (double) timeMillis},
+            {localDateTime, Double.class, (double) dateTimeMillis},
+            {instant, Double.class, (double) dateTimeMillis},
+            {offsetDateTime, Double.class, (double) dateTimeMillis},
+            {localTime, Double.class, timeMillisWithNanos},
+            {localDate, Double.class, (double) numberOfDays},
+
+            // Date
+            {Schema.DATE.encode(date), Date.class, date},
+            {"2023-01-02T23:04:05.000000006Z", Date.class, date},
+            {dateTimeMillis, Date.class, date},
+            {(double) dateTimeMillis, Date.class, date},
+            {date, Date.class, date},
+            {timestamp, Date.class, date},
+            {localDateTime, Date.class, date},
+            {instant, Date.class, date},
+            {offsetDateTime, Date.class, date},
+            {localDate, Date.class, new Date(midnightMillis)},
+
+            // Timestamp
+            {Schema.TIMESTAMP.encode(timestamp), Timestamp.class, new Timestamp(dateTimeMillis)},
+            {"2023-01-02T23:04:05.000000006Z", Timestamp.class, timestamp},
+            {dateTimeMillis, Timestamp.class, new Timestamp(dateTimeMillis)},
+            {(double) dateTimeMillis, Timestamp.class, new Timestamp(dateTimeMillis)},
+            {date, Timestamp.class, new Timestamp(dateTimeMillis)},
+            {timestamp, Timestamp.class, timestamp},
+            {localDateTime, Timestamp.class, timestamp},
+            {instant, Timestamp.class, timestamp},
+            {offsetDateTime, Timestamp.class, timestamp},
+            {offsetDateTime, Timestamp.class, timestamp},
+            {localDate, Timestamp.class, new Timestamp(midnightMillis)},
+
+            // Time
+            {Schema.TIME.encode(time), Time.class, time},
+            {"23:04:05.000000006", Time.class, time},
+            {dateTimeMillis, Time.class, new Time(dateTimeMillis)},
+            {(double) dateTimeMillis, Time.class, new Time(dateTimeMillis)},
+            {date, Time.class, new Time(dateTimeMillis)},
+            {timestamp, Time.class, time},
+            {localDateTime, Time.class, time},
+            {instant, Time.class, time},
+            {offsetDateTime, Time.class, time},
+            {localDate, Time.class, new Time(midnightMillis)},
+            {time, Time.class, time},
+            {localTime, Time.class, time},
+
+            // LocalTime
+            {Schema.LOCAL_TIME.encode(localTime), LocalTime.class, localTime},
+            {"23:04:05.000000006", LocalTime.class, localTime},
+            {dateTimeMillis, LocalTime.class, LocalTime.of(23, 4, 5)},
+            {timeMillisWithNanos, LocalTime.class, localTime},
+            {date, LocalTime.class, LocalTime.of(23, 4, 5)},
+            {timestamp, LocalTime.class, localTime},
+            {localDateTime, LocalTime.class, localTime},
+            {instant, LocalTime.class, localTime},
+            {offsetDateTime, LocalTime.class, localTime},
+            {localDate, LocalTime.class, LocalTime.ofSecondOfDay(0)},
+            {time, LocalTime.class, LocalTime.of(23, 4, 5)},
+            {localTime, LocalTime.class, localTime},
+
+            // LocalDate
+            {Schema.LOCAL_DATE.encode(localDate), LocalDate.class, localDate},
+            {"2023-01-02", LocalDate.class, localDate},
+            {(int) numberOfDays, LocalDate.class, localDate},
+            {numberOfDays, LocalDate.class, localDate},
+            {(float) numberOfDays, LocalDate.class, localDate},
+            {(double) numberOfDays, LocalDate.class, localDate},
+            {date, LocalDate.class, localDate},
+            {timestamp, LocalDate.class, localDate},
+            {localDateTime, LocalDate.class, localDate},
+            {instant, LocalDate.class, localDate},
+            {offsetDateTime, LocalDate.class, localDate},
+            {localDate, LocalDate.class, localDate},
+
+            // LocalDateTime
+            {Schema.LOCAL_DATE_TIME.encode(localDateTime), LocalDateTime.class, localDateTime},
+            {"2023-01-02T23:04:05.000000006", LocalDateTime.class, localDateTime},
+            {(double) dateTimeMillis, LocalDateTime.class, localDateTimeWithoutNanos},
+            {date, LocalDateTime.class, localDateTimeWithoutNanos},
+            {timestamp, LocalDateTime.class, localDateTime},
+            {localDateTime, LocalDateTime.class, localDateTime},
+            {instant, LocalDateTime.class, localDateTime},
+            {offsetDateTime, LocalDateTime.class, localDateTime},
+            {localDate, LocalDateTime.class, LocalDateTime.of(localDate, LocalTime.MIDNIGHT)},
+
+            // Instant
+            {Schema.INSTANT.encode(instant), Instant.class, instant},
+            {"2023-01-02T23:04:05.000000006Z", Instant.class, instant},
+            {"2023-01-02", Instant.class, localDate.atStartOfDay(ZoneOffset.UTC).toInstant()},
+            {dateTimeMillis, Instant.class, Instant.ofEpochMilli(dateTimeMillis)},
+            {(double) dateTimeMillis, Instant.class, Instant.ofEpochMilli(dateTimeMillis)},
+            {date, Instant.class, Instant.ofEpochMilli(dateTimeMillis)},
+            {timestamp, Instant.class, instant},
+            {localDateTime, Instant.class, instant},
+            {instant, Instant.class, instant},
+            {offsetDateTime, Instant.class, instant},
+            {localDate, Instant.class, instant.truncatedTo(ChronoUnit.DAYS)},
+
+            // OffsetDateTime
+            {Schema.INSTANT.encode(instant), OffsetDateTime.class, offsetDateTime},
+            {"2023-01-02T23:04:05.000000006Z", OffsetDateTime.class, offsetDateTime},
+            {
+                "2023-01-02",
+                OffsetDateTime.class,
+                localDate.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime()
+            },
+            {
+                dateTimeMillis,
+                OffsetDateTime.class,
+                OffsetDateTime.of(localDateTimeWithoutNanos, ZoneOffset.UTC)
+            },
+            {
+                (double) dateTimeMillis,
+                OffsetDateTime.class,
+                OffsetDateTime.of(localDateTimeWithoutNanos, ZoneOffset.UTC)
+            },
+            {
+                date,
+                OffsetDateTime.class,
+                OffsetDateTime.of(localDateTimeWithoutNanos, ZoneOffset.UTC)
+            },
+            {timestamp, OffsetDateTime.class, offsetDateTime},
+            {localDateTime, OffsetDateTime.class, offsetDateTime},
+            {offsetDateTime, OffsetDateTime.class, offsetDateTime},
+            {localDate, OffsetDateTime.class, offsetDateTime.truncatedTo(ChronoUnit.DAYS)},
+            {instant, OffsetDateTime.class, offsetDateTime},
+
+            // BigDecimal
+            {bigInteger, BigInteger.class, bigInteger},
+            {"345781342432523452345", BigInteger.class, bigInteger},
+            {Integer.MAX_VALUE, BigInteger.class, BigInteger.valueOf(Integer.MAX_VALUE)},
+            {Long.MAX_VALUE, BigInteger.class, BigInteger.valueOf(Long.MAX_VALUE)},
+
+            // BigDecimal
+            {bigDecimal, BigDecimal.class, bigDecimal},
+            {"435897983457.83421", BigDecimal.class, bigDecimal},
+            {Integer.MAX_VALUE, BigDecimal.class, BigDecimal.valueOf(Integer.MAX_VALUE)},
+            {Long.MAX_VALUE, BigDecimal.class, BigDecimal.valueOf(Long.MAX_VALUE)},
+            {Float.MAX_VALUE, BigDecimal.class, BigDecimal.valueOf(Float.MAX_VALUE)},
+            {Double.MAX_VALUE, BigDecimal.class, BigDecimal.valueOf(Double.MAX_VALUE)},
+        };
+    }
+
+    @Test(dataProvider = "conversions")
+    public void testNonNullConversions(Object o, Class<?> type, Object expected) {
+        Object converted = converter.coerceToType(o, type);
+        Assert.assertEquals(converted.getClass(), type);
+        if (type.equals(Time.class)) {
+            // j.s.Time equality is weird...
+            Assert.assertEquals(((Time) converted).toLocalTime(), ((Time) expected).toLocalTime());
+        } else {
+            Assert.assertEquals(converted, expected);
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverterTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/JstlTypeConverterTest.java
@@ -15,7 +15,9 @@
  */
 package com.datastax.oss.streaming.ai.jstl;
 
-import static org.testng.AssertJUnit.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -33,9 +35,9 @@ import java.util.Date;
 import java.util.TimeZone;
 import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.Schema;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 public class JstlTypeConverterTest {
 
@@ -61,7 +63,6 @@ public class JstlTypeConverterTest {
         assertNull(converter.coerceToType(null, BigDecimal.class));
     }
 
-    @DataProvider(name = "conversions")
     public static Object[][] conversions() {
         TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
         byte byteValue = (byte) 42;
@@ -349,15 +350,20 @@ public class JstlTypeConverterTest {
         };
     }
 
-    @Test(dataProvider = "conversions")
+    @ParameterizedTest
+    @MethodSource("conversions")
     public void testNonNullConversions(Object o, Class<?> type, Object expected) {
         Object converted = converter.coerceToType(o, type);
-        Assert.assertEquals(converted.getClass(), type);
+        assertEquals(converted.getClass(), type);
         if (type.equals(Time.class)) {
             // j.s.Time equality is weird...
-            Assert.assertEquals(((Time) converted).toLocalTime(), ((Time) expected).toLocalTime());
+            assertEquals(((Time) converted).toLocalTime(), ((Time) expected).toLocalTime());
         } else {
-            Assert.assertEquals(converted, expected);
+            if (converted instanceof byte[]) {
+                assertArrayEquals((byte[]) converted, (byte[]) expected);
+            } else {
+                assertEquals(converted, expected);
+            }
         }
     }
 }

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/predicate/JstlPredicateTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/predicate/JstlPredicateTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.jstl.predicate;
+
+import static com.datastax.oss.streaming.ai.Utils.newTransformContext;
+import static org.testng.AssertJUnit.assertEquals;
+
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.Utils;
+import java.util.HashMap;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericObject;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.functions.api.Record;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class JstlPredicateTest {
+
+    @Test(dataProvider = "keyValuePredicates")
+    void testKeyValueAvro(String when, boolean match) {
+        JstlPredicate predicate = new JstlPredicate(when);
+
+        Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(2);
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+
+        assertEquals(predicate.test(transformContext), match);
+    }
+
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "invalid when:.*")
+    void testInvalidWhen() {
+        JstlPredicate predicate = new JstlPredicate("`invalid");
+
+        Record<GenericObject> record = Utils.createNestedAvroKeyValueRecord(2);
+        Utils.TestContext context = new Utils.TestContext(record, new HashMap<>());
+        TransformContext transformContext =
+                newTransformContext(context, record.getValue().getNativeObject());
+
+        predicate.test(transformContext);
+    }
+
+    @Test(dataProvider = "primitiveKeyValuePredicates")
+    void testPrimitiveKeyValueAvro(String when, TransformContext context, boolean match) {
+        JstlPredicate predicate = new JstlPredicate(when);
+        assertEquals(predicate.test(context), match);
+    }
+
+    @Test(dataProvider = "nestedKeyValuePredicates")
+    void testNestedKeyValueAvro(String when, TransformContext context, boolean match) {
+        JstlPredicate predicate = new JstlPredicate(when);
+        assertEquals(predicate.test(context), match);
+    }
+
+    @Test(dataProvider = "primitivePredicates")
+    void testPrimitiveValueAvro(String when, TransformContext context, boolean match) {
+        JstlPredicate predicate = new JstlPredicate(when);
+        assertEquals(predicate.test(context), match);
+    }
+
+    /**
+     * @return {"expression", "transform context" "expected match boolean"}
+     */
+    @DataProvider(name = "primitiveKeyValuePredicates")
+    public static Object[][] primitiveKeyValuePredicates() {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        TransformContext primitiveKVContext =
+                Utils.createContextWithPrimitiveRecord(keyValueSchema, keyValue, "");
+
+        return new Object[][] {
+            // match
+            {"key=='key' && value==42", primitiveKVContext, true},
+            // no-match
+            {"key=='key' && value<42", primitiveKVContext, false},
+        };
+    }
+
+    /**
+     * @return {"expression", "transform context" "expected match boolean"}
+     */
+    @DataProvider(name = "primitivePredicates")
+    public static Object[][] primitivePredicates() {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key", 42);
+
+        TransformContext primitiveStringContext =
+                Utils.createContextWithPrimitiveRecord(Schema.STRING, "test-message", "header-key");
+        TransformContext primitiveIntContext =
+                Utils.createContextWithPrimitiveRecord(Schema.INT32, 33, "header-key");
+        TransformContext primitiveKVContext =
+                Utils.createContextWithPrimitiveRecord(keyValueSchema, keyValue, "header-key");
+
+        return new Object[][] {
+            // match
+            {"value=='test-message'", primitiveStringContext, true},
+            {"messageKey=='header-key'", primitiveStringContext, true},
+            {"key=='header-key'", primitiveStringContext, true},
+            {"value==33", primitiveIntContext, true},
+            {"value eq 33", primitiveIntContext, true},
+            {"value eq 32 + 1", primitiveIntContext, true},
+            {"value eq 34 - 1", primitiveIntContext, true},
+            {"value eq 66 / 2", primitiveIntContext, true},
+            {"value eq 66 div 2", primitiveIntContext, true},
+            {"value % 10 == 3", primitiveIntContext, true},
+            {"value mod 10 == 3", primitiveIntContext, true},
+            {"value>32", primitiveIntContext, true},
+            {"value gt 32", primitiveIntContext, true},
+            {"value<=33 && key=='header-key'", primitiveIntContext, true},
+            {"key=='key' && value==42", primitiveKVContext, true},
+            {"key=='key' and value==42", primitiveKVContext, true},
+            {"key=='key1' || value==42", primitiveKVContext, true},
+            {"key=='key1' or value==42", primitiveKVContext, true},
+            {"key=='key' && value==42", primitiveKVContext, true},
+            // no-match
+            {"value=='test-message-'", primitiveStringContext, false},
+            {"key!='header-key'", primitiveStringContext, false},
+            {"key ne 'header-key'", primitiveStringContext, false},
+            {"value==34", primitiveIntContext, false},
+            {"value>33", primitiveIntContext, false},
+            {"value<=20 && key=='test-key'", primitiveIntContext, false},
+            {"value le 20 && key=='test-key'", primitiveIntContext, false},
+        };
+    }
+
+    /**
+     * @return {"expression", "transform context" "expected match boolean"}
+     */
+    @DataProvider(name = "nestedKeyValuePredicates")
+    public static Object[][] nestedKeyValuePredicates() {
+        Schema<KeyValue<String, Integer>> keyValueSchema =
+                Schema.KeyValue(Schema.STRING, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        Schema<KeyValue<KeyValue<String, Integer>, Integer>> nestedKeySchema =
+                Schema.KeyValue(keyValueSchema, Schema.INT32, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, Integer> keyValue = new KeyValue<>("key1", 42);
+
+        KeyValue<KeyValue<String, Integer>, Integer> nestedKeyKV = new KeyValue<>(keyValue, 3);
+
+        GenericObject genericNestedKeyObject =
+                new GenericObject() {
+                    @Override
+                    public SchemaType getSchemaType() {
+                        return SchemaType.KEY_VALUE;
+                    }
+
+                    @Override
+                    public Object getNativeObject() {
+                        return nestedKeyKV;
+                    }
+                };
+
+        Record<GenericObject> nestedKeyRecord =
+                new Utils.TestRecord<>(nestedKeySchema, genericNestedKeyObject, null);
+
+        TransformContext nestedKeyContext =
+                newTransformContext(
+                        new Utils.TestContext(nestedKeyRecord, new HashMap<>()),
+                        nestedKeyRecord.getValue().getNativeObject());
+
+        Schema<KeyValue<String, KeyValue<String, Integer>>> nestedValueSchema =
+                Schema.KeyValue(Schema.STRING, keyValueSchema, KeyValueEncodingType.SEPARATED);
+
+        KeyValue<String, KeyValue<String, Integer>> nestedValueKV =
+                new KeyValue<>("key1", keyValue);
+
+        GenericObject genericNestedValueObject =
+                new GenericObject() {
+                    @Override
+                    public SchemaType getSchemaType() {
+                        return SchemaType.KEY_VALUE;
+                    }
+
+                    @Override
+                    public Object getNativeObject() {
+                        return nestedValueKV;
+                    }
+                };
+
+        Record<GenericObject> nestedValueRecord =
+                new Utils.TestRecord<>(nestedValueSchema, genericNestedValueObject, null);
+
+        TransformContext nestedValueContext =
+                newTransformContext(
+                        new Utils.TestContext(nestedValueRecord, new HashMap<>()),
+                        nestedValueRecord.getValue().getNativeObject());
+        return new Object[][] {
+            // match
+            {"key.key=='key1'", nestedKeyContext, true},
+            {"key.value==42", nestedKeyContext, true},
+            {"value==3", nestedKeyContext, true},
+            {"value.key=='key1'", nestedValueContext, true},
+            {"value.value==42", nestedValueContext, true},
+            {"key=='key1'", nestedValueContext, true},
+            // no match
+            {"key.key=='key2'", nestedKeyContext, false},
+            {"key.value<42", nestedKeyContext, false},
+            {"value==4", nestedKeyContext, false},
+            {"value.key=='key2'", nestedValueContext, false},
+            {"value.value<42", nestedValueContext, false},
+            {"key=='key2'", nestedValueContext, false},
+        };
+    }
+
+    /**
+     * @return {"expression", "expected match boolean"}
+     */
+    @DataProvider(name = "keyValuePredicates")
+    public static Object[][] keyValuePredicates() {
+        return new Object[][] {
+            // match
+            {"key.level1String == 'level1_1'", true},
+            {"key.level1Record.level2String == 'level2_1'", true},
+            {"key.level1Record.level2Integer == 9", true},
+            {"key.level1Record.level2Double == 8.8", true},
+            {"key.level1Record.level2Array[0] == 'level2_1'", true},
+            {"value.level1Record.level2Integer > 8", true},
+            {"value.level1Record.level2Double < 8.9", true},
+            {"value.level1Record.level2Array[0] == 'level2_1'", true},
+            {"messageKey == 'key1'", true},
+            {"destinationTopic == 'dest-topic-1'", true},
+            {"topicName == 'topic-1'", true},
+            {"properties.p1 == 'v1'", true},
+            {"properties.p2 == 'v2'", true},
+            // no match
+            {"key.level1String == 'leVel1_1'", false},
+            {"key.level1Record.random == 'level2_1'", false},
+            {"key.level1Record.level2Integer != 9", false},
+            {"key.level1Record.level2Double < 8.8", false},
+            {"key.level1Record.level2Array[0] == 'non_existing_item'", false},
+            {"key.randomKey == 'k1'", false},
+            {"value.level1Record.level2Integer > 10", false},
+            {"value.level1Record.level2Double < 0", false},
+            {"value.randomValue < 0", false},
+            {"messageKey == 'key2'", false},
+            {"topicName != 'topic-1'", false},
+            {"properties.p2 == 'v3'", false},
+            {"randomHeader == 'h1'", false}
+        };
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/predicate/JstlPredicateTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/jstl/predicate/JstlPredicateTest.java
@@ -26,11 +26,10 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericObject;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
-import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.functions.api.Record;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.Test;
 
 public class JstlPredicateTest {
 
@@ -49,10 +48,14 @@ public class JstlPredicateTest {
 
     @Test
     void testInvalidWhen() {
-        assertEquals("invalid when: `invalid",
-                assertThrows(IllegalArgumentException.class, () -> {
-            new JstlPredicate("`invalid");
-        }).getMessage());
+        assertEquals(
+                "invalid when: `invalid",
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> {
+                                    new JstlPredicate("`invalid");
+                                })
+                        .getMessage());
     }
 
     @ParameterizedTest

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/model/ComputeFieldTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/model/ComputeFieldTest.java
@@ -24,14 +24,18 @@ public class ComputeFieldTest {
 
     @Test
     void testInvalidComputeFieldName() {
-        assertEquals("Invalid compute field name: newStringField. It should be prefixed with 'key.' or 'value.' or 'properties.' or be one of [key, value, destinationTopic, messageKey]",
-        assertThrows(IllegalArgumentException.class, () -> {
-            ComputeField.builder()
-                    .scopedName("newStringField")
-                    .expression("'Hotaru'")
-                    .type(ComputeFieldType.STRING)
-                    .build();
-        }).getMessage());
+        assertEquals(
+                "Invalid compute field name: newStringField. It should be prefixed with 'key.' or 'value.' or 'properties.' or be one of [key, value, destinationTopic, messageKey]",
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> {
+                                    ComputeField.builder()
+                                            .scopedName("newStringField")
+                                            .expression("'Hotaru'")
+                                            .type(ComputeFieldType.STRING)
+                                            .build();
+                                })
+                        .getMessage());
     }
 
     @Test

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/model/ComputeFieldTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/model/ComputeFieldTest.java
@@ -15,21 +15,23 @@
  */
 package com.datastax.oss.streaming.ai.model;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class ComputeFieldTest {
 
-    @Test(
-            expectedExceptions = IllegalArgumentException.class,
-            expectedExceptionsMessageRegExp = "Invalid compute field name: newStringField\\..*")
+    @Test
     void testInvalidComputeFieldName() {
-        ComputeField.builder()
-                .scopedName("newStringField")
-                .expression("'Hotaru'")
-                .type(ComputeFieldType.STRING)
-                .build();
+        assertEquals("Invalid compute field name: newStringField. It should be prefixed with 'key.' or 'value.' or 'properties.' or be one of [key, value, destinationTopic, messageKey]",
+        assertThrows(IllegalArgumentException.class, () -> {
+            ComputeField.builder()
+                    .scopedName("newStringField")
+                    .expression("'Hotaru'")
+                    .type(ComputeFieldType.STRING)
+                    .build();
+        }).getMessage());
     }
 
     @Test

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/model/ComputeFieldTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/model/ComputeFieldTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.streaming.ai.model;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class ComputeFieldTest {
+
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Invalid compute field name: newStringField\\..*")
+    void testInvalidComputeFieldName() {
+        ComputeField.builder()
+                .scopedName("newStringField")
+                .expression("'Hotaru'")
+                .type(ComputeFieldType.STRING)
+                .build();
+    }
+
+    @Test
+    void testValidKeyComputeFieldName() {
+        ComputeField field =
+                ComputeField.builder()
+                        .scopedName("key.newStringField")
+                        .expression("'Hotaru'")
+                        .type(ComputeFieldType.STRING)
+                        .build();
+
+        assertEquals("newStringField", field.getName());
+        assertEquals("key", field.getScope());
+    }
+
+    @Test
+    void testValidValueComputeFieldName() {
+        ComputeField field =
+                ComputeField.builder()
+                        .scopedName("value.newStringField")
+                        .expression("'Hotaru'")
+                        .type(ComputeFieldType.STRING)
+                        .build();
+
+        assertEquals("newStringField", field.getName());
+        assertEquals("value", field.getScope());
+    }
+
+    @Test
+    void testValidHeaderComputeFieldName() {
+        ComputeField field =
+                ComputeField.builder()
+                        .scopedName("destinationTopic")
+                        .expression("'Hotaru'")
+                        .type(ComputeFieldType.STRING)
+                        .build();
+
+        assertEquals("destinationTopic", field.getName());
+        assertEquals("header", field.getScope());
+    }
+
+    @Test
+    void testPrimitiveValueComputeFieldName() {
+        ComputeField field =
+                ComputeField.builder().scopedName("value").type(ComputeFieldType.STRING).build();
+
+        assertEquals("value", field.getName());
+        assertEquals("primitive", field.getScope());
+    }
+
+    @Test
+    void testPrimitiveKeyComputeFieldName() {
+        ComputeField field =
+                ComputeField.builder().scopedName("key").type(ComputeFieldType.STRING).build();
+
+        assertEquals("key", field.getName());
+        assertEquals("primitive", field.getScope());
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/util/AvroUtilTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/util/AvroUtilTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class AvroUtilTest {
     private static final MyLogicalType MY_LOGICAL_TYPE = new MyLogicalType();

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/util/AvroUtilTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/util/AvroUtilTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.streaming.ai.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.testng.annotations.Test;
+
+public class AvroUtilTest {
+    private static final MyLogicalType MY_LOGICAL_TYPE = new MyLogicalType();
+
+    @Test
+    public void testGetLogicalType() {
+        // given
+        org.apache.avro.Schema myLogicalTypeSchema =
+                MY_LOGICAL_TYPE.addToSchema(
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN));
+
+        // when
+        LogicalType logicalType = AvroUtil.getLogicalType(myLogicalTypeSchema);
+
+        // then
+        assertNotNull(logicalType);
+        assertEquals("my-logical-type", logicalType.getName());
+    }
+
+    @Test
+    public void testGetLogicalTypeUnion() {
+        // given
+        org.apache.avro.Schema myLogicalTypeSchema =
+                MY_LOGICAL_TYPE.addToSchema(
+                        org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN));
+        org.apache.avro.Schema unionSchema =
+                SchemaBuilder.unionOf().nullType().and().type(myLogicalTypeSchema).endUnion();
+
+        // when
+        LogicalType logicalType = AvroUtil.getLogicalType(unionSchema);
+
+        // then
+        assertNotNull(logicalType);
+        assertEquals("my-logical-type", logicalType.getName());
+    }
+
+    public static class MyLogicalType extends LogicalType {
+        MyLogicalType() {
+            super("my-logical-type");
+        }
+
+        @Override
+        public void validate(Schema schema) {
+            super.validate(schema);
+            if (schema.getType() != Schema.Type.BOOLEAN) {
+                throw new IllegalArgumentException(
+                        "Logical type 'my-logical-type' should be stored as a boolean");
+            }
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/resources/readme.md
+++ b/langstream-agents/langstream-ai-agents/src/test/resources/readme.md
@@ -1,0 +1,5 @@
+The test model ConGen-BERT-Mini.zip built with DJL: 
+
+`python3 ./extensions/tokenizers/src/main/python/model_zoo_importer.py -m kornwtp/ConGen-BERT-Mini`
+
+Original model is Apache 2.0 licensed and can be found at https://huggingface.co/kornwtp/ConGen-BERT-Mini

--- a/langstream-pulsar/pom.xml
+++ b/langstream-pulsar/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pulsar</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-original</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -452,36 +452,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>datastax-releases</id>
-      <url>https://repo.aws.dsinternal.org/artifactory/datastax-releases-local</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
-    <repository>
-      <id>datastax-snapshots-local</id>
-      <url>https://repo.aws.dsinternal.org/artifactory/datastax-snapshots-local</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-    <repository>
-      <id>public-datastax-releases</id>
-      <url>https://repo.datastax.com/datastax-public-releases-local</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
   </repositories>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
     <!-- same version of Kafka -->
     <netty.version>4.1.92.Final</netty.version>
     <testcontainers.version>1.18.3</testcontainers.version>
-    <testng.version>7.8.0</testng.version>
     <junit-jupiter.version>5.9.3</junit-jupiter.version>
     <lombok.version>1.18.28</lombok.version>
     <jackson.version>2.14.2</jackson.version>
@@ -232,12 +231,6 @@
         <version>${testcontainers.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.testng</groupId>
-        <artifactId>testng</artifactId>
-        <version>${testng.version}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,13 @@
     <pulsar.version>3.0.0</pulsar.version>
     <kafka.version>3.5.0</kafka.version>
     <confluent.avro>7.4.0</confluent.avro>
+    <!-- Must match version in pulsar -->
     <avro.version>1.10.2</avro.version>
+    <azure-ai-openai.version>1.0.0-beta.2</azure-ai-openai.version>
     <!-- same version of Kafka -->
     <netty.version>4.1.92.Final</netty.version>
     <testcontainers.version>1.18.3</testcontainers.version>
+    <testng.version>7.8.0</testng.version>
     <junit-jupiter.version>5.9.3</junit-jupiter.version>
     <lombok.version>1.18.28</lombok.version>
     <jackson.version>2.14.2</jackson.version>
@@ -60,7 +63,6 @@
     <bouncy-castle.version>1.70</bouncy-castle.version>
     <kindcontainer.version>1.4.1</kindcontainer.version>
     <wiremock.version>3.0.0-beta-10</wiremock.version>
-    <streaming-ai.version>3.1.8</streaming-ai.version>
     <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
     <burningwave.version>0.25.5</burningwave.version>
     <jjwt.version>0.11.5</jjwt.version>
@@ -69,6 +71,10 @@
     <prometheus.version>0.16.0</prometheus.version>
     <jetty.version>11.0.14</jetty.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
+    <djl.version>0.22.1</djl.version>
+    <json-schema-validator.version>1.0.72</json-schema-validator.version>
+    <tomcat-embed-el.version>10.1.4</tomcat-embed-el.version>
+    <commons-collections4.version>4.4</commons-collections4.version>
   </properties>
 
   <scm>
@@ -102,13 +108,13 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pulsar</groupId>
-        <artifactId>pulsar-client</artifactId>
+        <artifactId>pulsar-client-original</artifactId>
         <version>${pulsar.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.datastax.oss</groupId>
-        <artifactId>streaming-ai</artifactId>
-        <version>${streaming-ai.version}</version>
+        <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-functions-api</artifactId>
+        <version>${pulsar.version}</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>
@@ -155,6 +161,55 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>ai.djl</groupId>
+        <artifactId>bom</artifactId>
+        <version>${djl.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>ai.djl.pytorch</groupId>
+        <artifactId>pytorch-jni</artifactId>
+        <version>2.0.0-${djl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ai.djl.pytorch</groupId>
+        <artifactId>pytorch-native-cpu</artifactId>
+        <!--classifier>osx-aarch64</classifier-->
+        <classifier>osx-x86_64</classifier>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.networknt</groupId>
+        <artifactId>json-schema-validator</artifactId>
+        <version>${json-schema-validator.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-ai-openai</artifactId>
+        <version>${azure-ai-openai.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.samskivert</groupId>
+        <artifactId>jmustache</artifactId>
+        <version>${jmustache.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat-embed-el.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>${commons-collections4.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
@@ -179,6 +234,12 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.testng</groupId>
+        <artifactId>testng</artifactId>
+        <version>${testng.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
@@ -199,11 +260,6 @@
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
         <version>${picocli.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.samskivert</groupId>
-        <artifactId>jmustache</artifactId>
-        <version>${jmustache.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
Summary:
- import the code from DataStax Streaming AI to LangStream
- it is Apache 2 Licensed and it is licensed by DataStax, so no LICENSE issues
- convert the test cases to JUnit 5 (from testng)
- reformat with Spotless
- remove the reference to the DataStax Maven repository (it is no more needed)