### PR TITLE
Add option to configure additional runtime pod annotations

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/PodTemplate.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/PodTemplate.java
@@ -19,4 +19,32 @@ import io.fabric8.kubernetes.api.model.Toleration;
 import java.util.List;
 import java.util.Map;
 
-public record PodTemplate(List<Toleration> tolerations, Map<String, String> nodeSelector) {}
+public record PodTemplate(
+        List<Toleration> tolerations,
+        Map<String, String> nodeSelector,
+        Map<String, String> annotations) {
+
+    static PodTemplate merge(PodTemplate primary, PodTemplate secondary) {
+        return new PodTemplate(
+                merge(primary.tolerations(), secondary.tolerations()),
+                merge(primary.nodeSelector(), secondary.nodeSelector()),
+                merge(primary.annotations(), secondary.annotations()));
+    }
+
+    private static Map<String, String> merge(
+            Map<String, String> primary, Map<String, String> secondary) {
+        if (primary == null || primary.isEmpty()) {
+            return secondary;
+        } else {
+            return primary;
+        }
+    }
+
+    private static <T> List<T> merge(List<T> primary, List<T> secondary) {
+        if (primary == null || primary.isEmpty()) {
+            return secondary;
+        } else {
+            return primary;
+        }
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
@@ -264,10 +264,7 @@ public class AgentResourcesFactory {
                 .withPodManagementPolicy("Parallel")
                 .withNewTemplate()
                 .withNewMetadata()
-                .withAnnotations(
-                        Map.of(
-                                "ai.langstream/config-checksum",
-                                spec.getAgentConfigSecretRefChecksum()))
+                .withAnnotations(getPodAnnotations(spec, podTemplate))
                 .withLabels(labels)
                 .endMetadata()
                 .withNewSpec()
@@ -319,6 +316,15 @@ public class AgentResourcesFactory {
                 .endTemplate()
                 .endSpec()
                 .build();
+    }
+
+    private static Map<String, String> getPodAnnotations(AgentSpec spec, PodTemplate podTemplate) {
+        final Map<String, String> annotations = new HashMap<>();
+        annotations.put("ai.langstream/config-checksum", spec.getAgentConfigSecretRefChecksum());
+        if (podTemplate != null && podTemplate.annotations() != null) {
+            annotations.putAll(podTemplate.annotations());
+        }
+        return annotations;
     }
 
     private static String getStsImagePullPolicy(GenerateStatefulsetParams params, AgentSpec spec) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -181,6 +182,7 @@ public class AppResourcesFactory {
                 .withBackoffLimit(1)
                 .withNewTemplate()
                 .withNewMetadata()
+                .withAnnotations(getPodAnnotations(podTemplate))
                 .withLabels(labels)
                 .endMetadata()
                 .withNewSpec()
@@ -209,6 +211,14 @@ public class AppResourcesFactory {
                 .endTemplate()
                 .endSpec()
                 .build();
+    }
+
+    private static Map<String, String> getPodAnnotations(PodTemplate podTemplate) {
+        final Map<String, String> annotations = new HashMap<>();
+        if (podTemplate != null && podTemplate.annotations() != null) {
+            annotations.putAll(podTemplate.annotations());
+        }
+        return annotations;
     }
 
     public static Map<String, String> getLabels(boolean delete, String applicationId) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -241,7 +241,8 @@ class AgentResourcesFactoryTest {
                                         .withValue("langstream")
                                         .withKey("workload")
                                         .build()),
-                        Map.of("workload", "langstream"));
+                        Map.of("workload", "langstream"),
+                        Map.of("ann1", "value1"));
         final StatefulSet statefulSet =
                 AgentResourcesFactory.generateStatefulSet(
                         AgentResourcesFactory.GenerateStatefulsetParams.builder()
@@ -258,6 +259,9 @@ class AgentResourcesFactoryTest {
         assertEquals(
                 Map.of("workload", "langstream"),
                 statefulSet.getSpec().getTemplate().getSpec().getNodeSelector());
+        assertEquals(
+                "value1",
+                statefulSet.getSpec().getTemplate().getMetadata().getAnnotations().get("ann1"));
     }
 
     private AgentCustomResource getCr(String yaml) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -252,7 +252,8 @@ class AppResourcesFactoryTest {
                                         .withValue("langstream")
                                         .withKey("workload")
                                         .build()),
-                        Map.of("workload", "langstream"));
+                        Map.of("workload", "langstream"),
+                        Map.of("ann1", "value1"));
 
         Job job =
                 AppResourcesFactory.generateJob(
@@ -270,6 +271,8 @@ class AppResourcesFactoryTest {
         assertEquals(
                 Map.of("workload", "langstream"),
                 job.getSpec().getTemplate().getSpec().getNodeSelector());
+        assertEquals(
+                "value1", job.getSpec().getTemplate().getMetadata().getAnnotations().get("ann1"));
     }
 
     @ParameterizedTest

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/DeployerConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/DeployerConfiguration.java
@@ -36,6 +36,12 @@ public interface DeployerConfiguration {
     @WithDefault("{}")
     String podTemplate();
 
+    @WithDefault("{}")
+    String appDeployerPodTemplate();
+
+    @WithDefault("{}")
+    String agentPodTemplate();
+
     Optional<String> runtimeImage();
 
     Optional<String> runtimeImagePullPolicy();

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
@@ -29,8 +29,21 @@ public class ResolvedDeployerConfiguration {
         this.agentResources =
                 SerializationUtil.readYaml(
                         configuration.agentResources(), AgentResourceUnitConfiguration.class);
-        this.podTemplate =
+        final PodTemplate commonPodTemplate =
                 SerializationUtil.readYaml(configuration.podTemplate(), PodTemplate.class);
+
+        this.agentPodTemplate =
+                PodTemplate.merge(
+                        SerializationUtil.readYaml(
+                                configuration.agentPodTemplate(), PodTemplate.class),
+                        commonPodTemplate);
+
+        this.appDeployerPodTemplate =
+                PodTemplate.merge(
+                        SerializationUtil.readYaml(
+                                configuration.appDeployerPodTemplate(), PodTemplate.class),
+                        commonPodTemplate);
+
         this.runtimeImage = configuration.runtimeImage().orElse(null);
         this.runtimeImagePullPolicy = configuration.runtimeImagePullPolicy().orElse(null);
     }
@@ -39,7 +52,9 @@ public class ResolvedDeployerConfiguration {
 
     @Getter private AgentResourceUnitConfiguration agentResources;
 
-    @Getter private PodTemplate podTemplate;
+    @Getter private PodTemplate appDeployerPodTemplate;
+
+    @Getter private PodTemplate agentPodTemplate;
 
     @Getter private String runtimeImage;
 

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
@@ -16,7 +16,6 @@
 package ai.langstream.deployer.k8s;
 
 import ai.langstream.deployer.k8s.agents.AgentResourceUnitConfiguration;
-import ai.langstream.deployer.k8s.util.SerializationUtil;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,14 +32,13 @@ public class ResolvedDeployerConfiguration {
 
     private static final ObjectMapper yamlMapper =
             new ObjectMapper(
-                    YAMLFactory.builder()
-                            .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-                            .disable(YAMLGenerator.Feature.SPLIT_LINES)
-                            .build())
+                            YAMLFactory.builder()
+                                    .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                                    .disable(YAMLGenerator.Feature.SPLIT_LINES)
+                                    .build())
                     .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                     .setSerializationInclusion(JsonInclude.Include.NON_NULL);
-
 
     @SneakyThrows
     public ResolvedDeployerConfiguration(DeployerConfiguration configuration) {
@@ -53,8 +51,7 @@ public class ResolvedDeployerConfiguration {
 
         this.agentPodTemplate =
                 PodTemplate.merge(
-                        yamlMapper.readValue(
-                                configuration.agentPodTemplate(), PodTemplate.class),
+                        yamlMapper.readValue(configuration.agentPodTemplate(), PodTemplate.class),
                         commonPodTemplate);
 
         this.appDeployerPodTemplate =

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
@@ -17,30 +17,49 @@ package ai.langstream.deployer.k8s;
 
 import ai.langstream.deployer.k8s.agents.AgentResourceUnitConfiguration;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Map;
 import lombok.Getter;
+import lombok.SneakyThrows;
 
 @ApplicationScoped
 public class ResolvedDeployerConfiguration {
 
+    private static final ObjectMapper yamlMapper =
+            new ObjectMapper(
+                    YAMLFactory.builder()
+                            .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                            .disable(YAMLGenerator.Feature.SPLIT_LINES)
+                            .build())
+                    .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+
+    @SneakyThrows
     public ResolvedDeployerConfiguration(DeployerConfiguration configuration) {
-        this.clusterRuntime = SerializationUtil.readYaml(configuration.clusterRuntime(), Map.class);
+        this.clusterRuntime = yamlMapper.readValue(configuration.clusterRuntime(), Map.class);
         this.agentResources =
-                SerializationUtil.readYaml(
+                yamlMapper.readValue(
                         configuration.agentResources(), AgentResourceUnitConfiguration.class);
         final PodTemplate commonPodTemplate =
-                SerializationUtil.readYaml(configuration.podTemplate(), PodTemplate.class);
+                yamlMapper.readValue(configuration.podTemplate(), PodTemplate.class);
 
         this.agentPodTemplate =
                 PodTemplate.merge(
-                        SerializationUtil.readYaml(
+                        yamlMapper.readValue(
                                 configuration.agentPodTemplate(), PodTemplate.class),
                         commonPodTemplate);
 
         this.appDeployerPodTemplate =
                 PodTemplate.merge(
-                        SerializationUtil.readYaml(
+                        yamlMapper.readValue(
                                 configuration.appDeployerPodTemplate(), PodTemplate.class),
                         commonPodTemplate);
 

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
@@ -102,7 +102,7 @@ public class AgentController extends BaseController<AgentCustomResource>
                         AgentResourcesFactory.GenerateStatefulsetParams.builder()
                                 .agentCustomResource(primary)
                                 .agentResourceUnitConfiguration(configuration.getAgentResources())
-                                .podTemplate(configuration.getPodTemplate())
+                                .podTemplate(configuration.getAgentPodTemplate())
                                 .image(configuration.getRuntimeImage())
                                 .imagePullPolicy(configuration.getRuntimeImagePullPolicy())
                                 .build();

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
@@ -116,7 +116,7 @@ public class AppController extends BaseController<ApplicationCustomResource>
                         .applicationCustomResource(applicationCustomResource)
                         .deleteJob(delete)
                         .clusterRuntimeConfiguration(configuration.getClusterRuntime())
-                        .podTemplate(configuration.getPodTemplate())
+                        .podTemplate(configuration.getAppDeployerPodTemplate())
                         .image(configuration.getRuntimeImage())
                         .imagePullPolicy(configuration.getRuntimeImagePullPolicy())
                         .build();


### PR DESCRIPTION
* Added new option in the deployer configmap under podTemplate.annotations
* Added new options for specifying annotations only for the app deployer vs agent runner. If not configured, they fallback to `podTemplate`.

So you can configure annotations in this way:
```
deployer:
  app:
    config: 
      podTemplate:
        annotations: 
           my-ann: value1
```

or only for the agent runner

```
deployer:
  app:
    config: 
      agentPodTemplate:
        annotations: 
           my-ann: value1
```

or only for the app deployer


```
deployer:
  app:
    config: 
      appDeployerPodTemplate:
        annotations: 
           my-ann: value1
```

