### PR TITLE
Fix tenants creation while deleting is in progress

### DIFF
--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 
 public interface ApplicationStore extends GenericStore {
 
+    void validateTenant(String tenant, boolean failIfNotExists) throws IllegalStateException;
+
     void onTenantCreated(String tenant);
 
     void onTenantUpdated(String tenant);

--- a/langstream-core/src/main/java/ai/langstream/impl/storage/GlobalMetadataStoreManager.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/storage/GlobalMetadataStoreManager.java
@@ -36,6 +36,14 @@ public class GlobalMetadataStoreManager {
     private static final ObjectMapper mapper =
             new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
+    public static class TenantNotFoundException extends Exception {
+
+        public TenantNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+    protected static final String TENANT_KEY_PREFIX = "t-";
     private final GlobalMetadataStore globalMetadataStore;
     private final ApplicationStore applicationStore;
 
@@ -45,6 +53,15 @@ public class GlobalMetadataStoreManager {
 
     public void syncTenantConfiguration(String tenant) {
         applicationStore.onTenantCreated(tenant);
+    }
+
+    public void validateTenant(String tenant, boolean failIfNotExists)
+            throws TenantNotFoundException {
+        final TenantConfiguration config = getTenant(tenant);
+        if (config == null && failIfNotExists) {
+            throw new TenantNotFoundException("Tenant " + tenant + " not found");
+        }
+        applicationStore.validateTenant(tenant, failIfNotExists);
     }
 
     @SneakyThrows

--- a/langstream-k8s-common/src/test/java/ai/langstream/impl/k8s/tests/KubeTestServer.java
+++ b/langstream-k8s-common/src/test/java/ai/langstream/impl/k8s/tests/KubeTestServer.java
@@ -222,7 +222,14 @@ public class KubeTestServer
         server.expect()
                 .get()
                 .withPath("/api/v1/namespaces/%s".formatted(namespace))
-                .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> new NamespaceBuilder().withNewMetadata().withName(namespace).endMetadata().build())
+                .andReply(
+                        HttpURLConnection.HTTP_OK,
+                        recordedRequest ->
+                                new NamespaceBuilder()
+                                        .withNewMetadata()
+                                        .withName(namespace)
+                                        .endMetadata()
+                                        .build())
                 .always();
 
         server.expect()

--- a/langstream-k8s-common/src/test/java/ai/langstream/impl/k8s/tests/KubeTestServer.java
+++ b/langstream-k8s-common/src/test/java/ai/langstream/impl/k8s/tests/KubeTestServer.java
@@ -22,6 +22,7 @@ import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
 import ai.langstream.impl.k8s.KubernetesClientFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -217,6 +218,13 @@ public class KubeTestServer
                 .withPath("/api/v1/namespaces/%s?fieldManager=fabric8".formatted(namespace))
                 .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> null)
                 .always();
+
+        server.expect()
+                .get()
+                .withPath("/api/v1/namespaces/%s".formatted(namespace))
+                .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> new NamespaceBuilder().withNewMetadata().withName(namespace).endMetadata().build())
+                .always();
+
         server.expect()
                 .patch()
                 .withPath(

--- a/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
+++ b/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
@@ -88,6 +88,7 @@ public class KubernetesApplicationStore implements ApplicationStore {
         final Namespace ns = client.namespaces().withName(namespace).get();
         if (ns == null) {
             if (failIfNotExists) {
+                log.warn("Namespace {} not found for tenant {}", namespace, tenant);
                 throw new IllegalStateException("Tenant " + tenant + " does not exist");
             }
         } else if (ns.isMarkedForDeletion()) {

--- a/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
+++ b/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
@@ -32,6 +32,7 @@ import ai.langstream.deployer.k8s.util.KubeUtil;
 import ai.langstream.impl.k8s.KubernetesClientFactory;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
@@ -82,6 +83,19 @@ public class KubernetesApplicationStore implements ApplicationStore {
     }
 
     @Override
+    public void validateTenant(String tenant, boolean failIfNotExists) {
+        final String namespace = tenantToNamespace(tenant);
+        final Namespace ns = client.namespaces().withName(namespace).get();
+        if (ns == null) {
+            if (failIfNotExists) {
+                throw new IllegalStateException("Tenant " + tenant + " does not exist");
+            }
+        } else if (ns.isMarkedForDeletion()) {
+            throw new IllegalStateException("Tenant " + tenant + " is marked for deletion.");
+        }
+    }
+
+    @Override
     @SneakyThrows
     public void onTenantCreated(String tenant) {
         final String namespace = tenantToNamespace(tenant);
@@ -112,9 +126,7 @@ public class KubernetesApplicationStore implements ApplicationStore {
         if (existing != null) {
             if (existing.isMarkedForDeletion()) {
                 throw new IllegalArgumentException(
-                        "Application "
-                                + applicationId
-                                + " is marked for deletion. Please retry once the application is deleted.");
+                        "Application " + applicationId + " is marked for deletion.");
             }
         }
 

--- a/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
+++ b/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
@@ -147,9 +147,7 @@ class KubernetesApplicationStoreTest {
             store.put(tenant, "myapp", app, "code-1", null);
             fail();
         } catch (IllegalArgumentException aie) {
-            assertEquals(
-                    "Application myapp is marked for deletion. Please retry once the application is deleted.",
-                    aie.getMessage());
+            assertEquals("Application myapp is marked for deletion.", aie.getMessage());
         }
         createdCr = k3s.getClient().resource(createdCr).get();
         createdCr.getMetadata().setFinalizers(List.of());

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
@@ -32,6 +32,7 @@ import ai.langstream.api.webservice.tenant.TenantConfiguration;
 import ai.langstream.impl.common.DefaultAgentNode;
 import ai.langstream.impl.deploy.ApplicationDeployer;
 import ai.langstream.impl.parser.ModelBuilder;
+import ai.langstream.impl.storage.GlobalMetadataStoreManager;
 import ai.langstream.webservice.common.GlobalMetadataService;
 import ai.langstream.webservice.config.ApplicationDeployProperties;
 import ai.langstream.webservice.config.TenantProperties;
@@ -350,8 +351,10 @@ public class ApplicationService {
     }
 
     private void checkTenant(String tenant) {
-        if (globalMetadataService.getTenant(tenant) == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "tenant not found");
+        try {
+            globalMetadataService.validateTenant(tenant, true);
+        } catch (GlobalMetadataStoreManager.TenantNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }
 

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/common/GlobalMetadataService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/common/GlobalMetadataService.java
@@ -27,7 +27,9 @@ import ai.langstream.webservice.config.StorageProperties;
 import ai.langstream.webservice.config.TenantProperties;
 import java.util.Map;
 import lombok.SneakyThrows;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class GlobalMetadataService {
@@ -48,6 +50,7 @@ public class GlobalMetadataService {
     }
 
     public void createTenant(String tenant, CreateTenantRequest request) throws TenantException {
+        checkTenant(tenant);
         validateCreateTenantRequest(request);
         store.createTenant(tenant, request);
     }
@@ -72,20 +75,38 @@ public class GlobalMetadataService {
     }
 
     public void updateTenant(String tenant, UpdateTenantRequest request) throws TenantException {
+        checkTenant(tenant);
         validateUpdateTenantRequest(request);
         store.updateTenant(tenant, request);
     }
 
+    public void validateTenant(String tenant, boolean failIfNotExists)
+            throws GlobalMetadataStoreManager.TenantNotFoundException {
+        store.validateTenant(tenant, failIfNotExists);
+    }
+
+    @SneakyThrows
     public void putTenant(String tenant, TenantConfiguration tenantConfiguration) {
+        checkTenant(tenant);
         store.putTenant(tenant, tenantConfiguration);
     }
 
+    private void checkTenant(String tenant) {
+        try {
+            validateTenant(tenant, false);
+        } catch (GlobalMetadataStoreManager.TenantNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
     public TenantConfiguration getTenant(String tenant) {
+        checkTenant(tenant);
         return store.getTenant(tenant);
     }
 
     @SneakyThrows
     public void deleteTenant(String tenant) {
+        checkTenant(tenant);
         store.deleteTenant(tenant);
     }
 

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/AppTestHelper.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/AppTestHelper.java
@@ -72,7 +72,28 @@ public class AppTestHelper {
                 applicationId,
                 appFileContent,
                 instanceContent,
-                secretsContent);
+                secretsContent,
+                true);
+    }
+
+    public static ResultActions deployApp(
+            MockMvc mockMvc,
+            String tenant,
+            String applicationId,
+            String appFileContent,
+            String instanceContent,
+            String secretsContent,
+            boolean checkOk)
+            throws Exception {
+        return updateApp(
+                mockMvc,
+                false,
+                tenant,
+                applicationId,
+                appFileContent,
+                instanceContent,
+                secretsContent,
+                checkOk);
     }
 
     public static ResultActions updateApp(
@@ -90,7 +111,8 @@ public class AppTestHelper {
                 applicationId,
                 appFileContent,
                 instanceContent,
-                secretsContent);
+                secretsContent,
+                true);
     }
 
     public static ResultActions updateApp(
@@ -100,7 +122,8 @@ public class AppTestHelper {
             String applicationId,
             String appFileContent,
             String instanceContent,
-            String secretsContent)
+            String secretsContent,
+            boolean checkOk)
             throws Exception {
         final MockMultipartHttpServletRequestBuilder multipart =
                 multipart(
@@ -117,6 +140,10 @@ public class AppTestHelper {
             multipart.part(
                     new MockPart("secrets", secretsContent.getBytes(StandardCharsets.UTF_8)));
         }
-        return mockMvc.perform(multipart).andExpect(status().isOk());
+        final ResultActions perform = mockMvc.perform(multipart);
+        if (checkOk) {
+            return perform.andExpect(status().isOk());
+        }
+        return perform;
     }
 }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
@@ -181,6 +181,10 @@ class ApplicationServiceResourceLimitTest {
         private final Map<String, Integer> currentUsage;
 
         @Override
+        public void validateTenant(String tenant, boolean failIfNotExists)
+                throws IllegalStateException {}
+
+        @Override
         public void onTenantCreated(String tenant) {}
 
         @Override

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/TenantResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/TenantResourceTest.java
@@ -26,6 +26,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ai.langstream.impl.k8s.tests.KubeK3sServer;
 import ai.langstream.webservice.WebAppTestConfig;
 import lombok.extern.slf4j.Slf4j;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -117,7 +119,20 @@ class TenantResourceTest {
                 .andExpect(jsonPath("$.test.maxTotalResourceUnits").value(8));
 
         mockMvc.perform(delete("/api/tenants/test")).andExpect(status().isOk());
+        mockMvc.perform(put("/api/tenants/test")).andExpect(status().isInternalServerError());
 
-        mockMvc.perform(get("/api/tenants/test")).andExpect(status().isNotFound());
+        mockMvc.perform(get("/api/tenants/test"))
+                .andExpect(
+                        status().is(
+                                        new BaseMatcher<Integer>() {
+                                            @Override
+                                            public boolean matches(Object o) {
+
+                                                return (int) o == 500 || (int) o == 404;
+                                            }
+
+                                            @Override
+                                            public void describeTo(Description description) {}
+                                        }));
     }
 }


### PR DESCRIPTION
When a tenant is deleted, the namespace is deleted. However the namespace could take time since all the apps have to undeploy successfully.

All the operations on a in-progress tenant should be blocked

Fixes https://github.com/LangStream/langstream/issues/271