### PR TITLE
Add integration tests and harden failure handling in Java code

### DIFF
--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
@@ -84,6 +84,9 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
 
     @Override
     public void process(List<Record> records, RecordSink recordSink) {
+        if (records == null || records.isEmpty()) {
+            throw new IllegalStateException("Records cannot be null or empty");
+        }
         for (Record record : records) {
             processed(1, 0);
             CompletableFuture<List<Record>> process = processRecord(record);

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentProcessor.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentProcessor.java
@@ -25,9 +25,10 @@ public interface AgentProcessor extends AgentCode {
     /**
      * The agent processes records and returns a list of records. The transactionality of the
      * function is guaranteed by the runtime. This method should not throw any exceptions, but
-     * report errors to the RecordSink.
+     * report errors to the RecordSink. It is expected that the agent will emit the same number of
+     * records as it received.
      *
-     * @param records the list of input records
+     * @param records the list of input records, this is never empty
      * @return the list of output records
      */
     void process(List<Record> records, RecordSink recordSink);

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/SingleRecordAgentProcessor.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/SingleRecordAgentProcessor.java
@@ -30,6 +30,9 @@ public abstract class SingleRecordAgentProcessor extends AbstractAgentCode
 
     @Override
     public final void process(List<Record> records, RecordSink recordSink) {
+        if (records == null || records.isEmpty()) {
+            throw new IllegalStateException("Records cannot be null or empty");
+        }
         for (Record record : records) {
             try {
                 List<Record> process = processRecord(record);

--- a/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
@@ -89,6 +89,18 @@ public class ConfigurationUtils {
         }
     }
 
+    public static Long getLong(String key, Long defaultValue, Map<String, Object> configuration) {
+        Object value = configuration.getOrDefault(key, defaultValue);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Number n) {
+            return n.longValue();
+        } else {
+            return Long.parseLong(value.toString());
+        }
+    }
+
     public static Double getDouble(
             String key, Double defaultValue, Map<String, Object> configuration) {
         Object value = configuration.getOrDefault(key, defaultValue);

--- a/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
@@ -154,6 +154,13 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
 
                 ConnectionImplementation agent1OutputConnectionImplementation =
                         agent1.getOutputConnectionImplementation();
+                if (agent1OutputConnectionImplementation == null) {
+                    throw new IllegalStateException(
+                            "Invalid agent configuration for ("
+                                    + agent1.getId()
+                                    + "), missing output");
+                }
+                ;
                 if (agent1OutputConnectionImplementation.equals(
                                 agent2.getInputConnectionImplementation())
                         && agent1OutputConnectionImplementation instanceof Topic topic

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -334,7 +334,20 @@ public class ModelBuilder {
                 AgentConfiguration agentConfiguration = agent.toAgentConfiguration(pipeline);
                 if (agentConfiguration.getType() == null
                         || agentConfiguration.getType().isBlank()) {
-                    throw new IllegalArgumentException("Agent type is always required");
+                    if (agentConfiguration.getId() != null) {
+                        throw new IllegalArgumentException(
+                                "Agent type is always required (check agent id "
+                                        + agentConfiguration.getId()
+                                        + ")");
+                    } else if (agentConfiguration.getName() != null) {
+                        throw new IllegalArgumentException(
+                                "Agent type is always required (check agent name "
+                                        + agentConfiguration.getName()
+                                        + ")");
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Agent type is always required (there is an agent without type, id or name)");
+                    }
                 }
                 ErrorsSpec errorsSpec = validateErrorsSpec(agentConfiguration.getErrors());
                 if (agentConfiguration.getId() == null) {

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
@@ -162,10 +162,11 @@ public class KafkaConsumerWrapper implements TopicConsumer, ConsumerRebalanceLis
             }
             int sum = uncommittedOffsets.values().stream().mapToInt(Set::size).sum();
             log.info(
-                    "Closing consumer to {} with {} pending commits and {} uncommitted offsets",
+                    "Closing consumer to {} with {} pending commits and {} uncommitted offsets: {} ",
                     topicName,
                     pendingCommits.get(),
-                    sum);
+                    sum,
+                    uncommittedOffsets);
             consumer.close();
         }
     }

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runtime/KafkaTopic.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runtime/KafkaTopic.java
@@ -23,6 +23,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_
 import ai.langstream.api.model.SchemaDefinition;
 import ai.langstream.api.runtime.ConnectionImplementation;
 import ai.langstream.api.runtime.Topic;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,22 @@ public record KafkaTopic(
         Map<String, Object> config,
         Map<String, Object> options)
         implements ConnectionImplementation, Topic {
+
+    public KafkaTopic {
+        // options must be a mutable map, because we can dynamically add options
+        // for instance the deadLetter configuration
+        if (options == null) {
+            options = new HashMap<>();
+        } else {
+            options = new HashMap<>();
+        }
+    }
+
+    @Override
+    public Map<String, Object> options() {
+        return Collections.unmodifiableMap(options);
+    }
+
     public Map<String, Object> createConsumerConfiguration() {
         Map<String, Object> configuration = new HashMap<>();
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -579,7 +579,6 @@ public class AgentRunner {
                 (AgentProcessor.SourceRecordAndResult result) -> {
                     Record sourceRecord = result.sourceRecord();
                     try {
-                        log.info("Result for record {}: {}", sourceRecord, result);
                         if (result.error() != null) {
                             Throwable error = result.error();
                             // handle error

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
@@ -104,6 +104,7 @@ public class AgentRunnerStarter extends RuntimeStarter {
                 codeDirectory,
                 agentsDirectory,
                 new AgentInfo(),
-                -1);
+                -1,
+                null);
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
@@ -155,7 +155,7 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
                                     new SourceRecordAndResult(
                                             initialSourceRecord,
                                             recordAndResult.resultRecords(),
-                                            null));
+                                            recordAndResult.error()));
                             processed(0, recordAndResult.resultRecords().size());
                             return;
                         }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/TopicConsumerSource.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/TopicConsumerSource.java
@@ -50,6 +50,7 @@ public class TopicConsumerSource extends AbstractAgentCode implements AgentSourc
     @Override
     public void permanentFailure(Record record, Exception error) {
         // DLQ
+        log.error("Permanent failure on record {}", record, error);
         deadLetterQueueProducer.write(List.of(record));
     }
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -336,7 +336,20 @@ public abstract class AbstractApplicationRunner {
         return new AgentRunResult(allAgentsInfo);
     }
 
+    private volatile boolean validateConsumerOffsets = true;
+
+    public boolean isValidateConsumerOffsets() {
+        return validateConsumerOffsets;
+    }
+
+    public void setValidateConsumerOffsets(boolean validateConsumerOffsets) {
+        this.validateConsumerOffsets = validateConsumerOffsets;
+    }
+
     private void validateAgentInfoBeforeStop(AgentInfo agentInfo) {
+        if (!validateConsumerOffsets) {
+            return;
+        }
         agentInfo
                 .serveWorkerStatus()
                 .forEach(

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -18,6 +18,7 @@ package ai.langstream;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.langstream.api.model.Application;
@@ -36,12 +37,12 @@ import io.fabric8.kubernetes.api.model.Secret;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -244,7 +245,7 @@ public abstract class AbstractApplicationRunner {
                 "{} Starting Agent Runners. Running {} pods",
                 runnerExecutionId,
                 runtime.secrets.size());
-        Map<String, AgentInfo> allAgentsInfo = new HashMap<>();
+        Map<String, AgentInfo> allAgentsInfo = new ConcurrentHashMap<>();
         try {
             List<RuntimePodConfiguration> pods = new ArrayList<>();
             runtime.secrets()
@@ -287,7 +288,8 @@ public abstract class AbstractApplicationRunner {
                                         null,
                                         agentsDirectory,
                                         agentInfo,
-                                        10);
+                                        10,
+                                        () -> validateAgentInfoBeforeStop(agentInfo));
                                 List<?> infos = agentInfo.serveWorkerStatus();
                                 log.info(
                                         "{} AgentPod {} AgentInfo {}",
@@ -314,8 +316,11 @@ public abstract class AbstractApplicationRunner {
             try {
                 CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
             } catch (ExecutionException executionException) {
+                log.error(
+                        "Some error occurred while executing the agent",
+                        executionException.getCause());
                 // unwrap the exception in order to easily perform assertions
-                if (executionException instanceof Exception) {
+                if (executionException.getCause() instanceof Exception) {
                     throw (Exception) executionException.getCause();
                 } else {
                     throw executionException;
@@ -329,6 +334,50 @@ public abstract class AbstractApplicationRunner {
             log.info("{} Agent Runners Stopped", runnerExecutionId);
         }
         return new AgentRunResult(allAgentsInfo);
+    }
+
+    private void validateAgentInfoBeforeStop(AgentInfo agentInfo) {
+        agentInfo
+                .serveWorkerStatus()
+                .forEach(
+                        workerStatus -> {
+                            String agentType = workerStatus.getAgentType();
+                            log.info("Checking Agent type {}", agentType);
+                            switch (agentType) {
+                                case "topic-source":
+                                    Map<String, Object> info = workerStatus.getInfo();
+                                    log.info("Topic source info {}", info);
+                                    Map<String, Object> consumerInfo =
+                                            (Map<String, Object>) info.get("consumer");
+                                    if (consumerInfo != null) {
+                                        Map<String, Object> committedOffsets =
+                                                (Map<String, Object>)
+                                                        consumerInfo.get("committedOffsets");
+                                        log.info("Committed offsets {}", committedOffsets);
+                                        committedOffsets.forEach(
+                                                (topic, offset) -> {
+                                                    assertNotNull(offset);
+                                                    assertTrue(((Number) offset).intValue() >= 0);
+                                                });
+                                        Map<String, Object> uncommittedOffsets =
+                                                (Map<String, Object>)
+                                                        consumerInfo.get("uncommittedOffsets");
+                                        log.info("Uncommitted offsets {}", uncommittedOffsets);
+                                        uncommittedOffsets.forEach(
+                                                (topic, number) -> {
+                                                    assertNotNull(number);
+                                                    assertTrue(
+                                                            ((Number) number).intValue() <= 0,
+                                                            "for topic "
+                                                                    + topic
+                                                                    + " we have some uncommitted offsets: "
+                                                                    + number);
+                                                });
+                                    }
+                                default:
+                                    // ignore
+                            }
+                        });
     }
 
     protected KafkaConsumer<String, String> createConsumer(String topic) {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AsyncProcessingIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AsyncProcessingIT.java
@@ -15,14 +15,24 @@
  */
 package ai.langstream.kafka;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import ai.langstream.AbstractApplicationRunner;
+import ai.langstream.mockagents.MockProcessorAgentsCodeProvider;
+import ai.langstream.runtime.agent.AgentRunner;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Slf4j
 class AsyncProcessingIT extends AbstractApplicationRunner {
@@ -31,6 +41,8 @@ class AsyncProcessingIT extends AbstractApplicationRunner {
     public void testProcessMultiThreadOutOfOrder() throws Exception {
         String tenant = "tenant";
         String[] expectedAgents = {"app-step1"};
+        String inputTopic = "input-topic-" + UUID.randomUUID();
+        String outputTopic = "output-topic-" + UUID.randomUUID();
 
         Map<String, String> application =
                 Map.of(
@@ -39,37 +51,367 @@ class AsyncProcessingIT extends AbstractApplicationRunner {
                                 module: "module-1"
                                 id: "pipeline-1"
                                 topics:
-                                  - name: "input-topic"
+                                  - name: "%s"
                                     creation-mode: create-if-not-exists
                                     partitions: 4
-                                  - name: "output-topic"
+                                  - name: "%s"
                                     creation-mode: create-if-not-exists
                                     partitions: 2
                                 pipeline:
                                   - name: "async-process-records"
                                     id: "step1"
                                     type: "mock-async-processor"
-                                    input: "input-topic"
-                                    output: "output-topic"
-                                """);
+                                    input: "%s"
+                                    output: "%s"
+                                """
+                                .formatted(inputTopic, outputTopic, inputTopic, outputTopic));
 
         try (ApplicationRuntime applicationRuntime =
                 deployApplication(
                         tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
             try (KafkaProducer<String, String> producer = createProducer();
-                    KafkaConsumer<String, String> consumer = createConsumer("output-topic")) {
+                    KafkaConsumer<String, String> consumer = createConsumer(outputTopic)) {
 
                 Set<String> expected = new HashSet<>();
                 int numMessages = 100;
                 for (int i = 0; i < numMessages; i++) {
                     String content = "test message " + i;
                     expected.add(content);
-                    sendMessage("input-topic", content, producer);
+                    sendMessage(inputTopic, content, producer);
                 }
 
                 executeAgentRunners(applicationRuntime);
 
                 waitForMessagesInAnyOrder(consumer, expected);
+            }
+        }
+    }
+
+    @Test
+    public void testCompositeMultiStepProcessMultiThreadOutOfOrder() throws Exception {
+        String tenant = "tenant";
+        String[] expectedAgents = {"app-step1"};
+        String inputTopic = "input-topic-" + UUID.randomUUID();
+        String outputTopic = "output-topic-" + UUID.randomUUID();
+
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 4
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 2
+                                pipeline:
+                                  - name: "async-process-records"
+                                    id: "step1"
+                                    type: "mock-async-processor"
+                                    input: "%s"
+                                  - name: "mock-failing-processor"
+                                    id: "step2"
+                                    type: "mock-failing-processor"
+                                  - name: "async-process-records"
+                                    id: "step3"
+                                    type: "mock-async-processor"
+                                  - name: "mock-failing-processor"
+                                    id: "step4"
+                                    type: "mock-failing-processor"
+                                    output: "%s"
+                                """
+                                .formatted(inputTopic, outputTopic, inputTopic, outputTopic));
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer();
+                    KafkaConsumer<String, String> consumer = createConsumer(outputTopic)) {
+
+                Set<String> expected = new HashSet<>();
+                int numMessages = 100;
+                for (int i = 0; i < numMessages; i++) {
+                    String content = "test message " + i;
+                    expected.add(content);
+                    sendMessage(inputTopic, content, producer);
+                }
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessagesInAnyOrder(consumer, expected);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    public void testCompositeMultiStepProcessMultiThreadOutOfOrderWithFailureAndSkip(int retries)
+            throws Exception {
+        String tenant = "tenant";
+        String[] expectedAgents = {"app-step1"};
+        String inputTopic = "input-topic-" + UUID.randomUUID();
+        String outputTopic = "output-topic-" + UUID.randomUUID();
+
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                errors:
+                                   on-failure: skip
+                                   retries: %d
+                                topics:
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 4
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 2
+                                pipeline:
+                                  - name: "mock-failing-processor"
+                                    type: "mock-failing-processor"
+                                    id: "step1"
+                                    input: "%s"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-beginning"
+                                  - name: "async-process-records"
+                                    id: "step2"
+                                    type: "mock-async-processor"
+                                  - name: "mock-failing-processor"
+                                    id: "step3"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-middle"
+                                    type: "mock-failing-processor"
+                                  - name: "async-process-records"
+                                    id: "step4"
+                                    type: "mock-async-processor"
+                                  - name: "mock-failing-processor"
+                                    id: "step5"
+                                    type: "mock-failing-processor"
+                                    output: "%s"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-end"
+                                """
+                                .formatted(
+                                        retries, inputTopic, outputTopic, inputTopic, outputTopic));
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer();
+                    KafkaConsumer<String, String> consumer = createConsumer(outputTopic)) {
+
+                Set<String> expected = new HashSet<>();
+                int numMessages = 100;
+                Random random = new Random();
+                for (int i = 0; i < numMessages; i++) {
+                    String content;
+                    int num = random.nextInt(5);
+                    switch (num) {
+                        case 0:
+                            content = "fail-this-message-in-the-beginning";
+                            break;
+                        case 1:
+                            content = "fail-this-message-in-the-middle";
+                            break;
+                        case 2:
+                            content = "fail-this-message-in-the-end";
+                            break;
+                        default:
+                            content = "test message " + i;
+                            expected.add(content);
+                            break;
+                    }
+                    sendMessage(inputTopic, content, producer);
+                }
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessagesInAnyOrder(consumer, expected);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    public void testCompositeMultiStepProcessMultiThreadOutOfOrderWithFailureAndDeadletter(
+            int retries) throws Exception {
+        String tenant = "tenant";
+        String[] expectedAgents = {"app-step1"};
+        String inputTopic = "input-topic-" + UUID.randomUUID();
+        String outputTopic = "output-topic-" + UUID.randomUUID();
+
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                errors:
+                                   on-failure: dead-letter
+                                   retries: %d
+                                topics:
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 4
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 2
+                                pipeline:
+                                  - name: "mock-failing-processor"
+                                    type: "mock-failing-processor"
+                                    id: "step1"
+                                    input: "%s"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-beginning"
+                                  - name: "async-process-records"
+                                    id: "step2"
+                                    type: "mock-async-processor"
+                                  - name: "mock-failing-processor"
+                                    id: "step3"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-middle"
+                                    type: "mock-failing-processor"
+                                  - name: "async-process-records"
+                                    id: "step4"
+                                    type: "mock-async-processor"
+                                  - name: "mock-failing-processor"
+                                    id: "step5"
+                                    type: "mock-failing-processor"
+                                    output: "%s"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-end"
+                                """
+                                .formatted(
+                                        retries, inputTopic, outputTopic, inputTopic, outputTopic));
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer();
+                    KafkaConsumer<String, String> consumer = createConsumer(outputTopic);
+                    KafkaConsumer<String, String> consumerDeadletter =
+                            createConsumer(inputTopic + "-deadletter")) {
+
+                Set<String> expected = new HashSet<>();
+                Set<String> expectedOnDeadletter = new HashSet<>();
+                int numMessages = 100;
+                Random random = new Random();
+                for (int i = 0; i < numMessages; i++) {
+                    String content;
+                    int num = random.nextInt(5);
+                    switch (num) {
+                        case 0:
+                            content = "fail-this-message-in-the-beginning-" + i;
+                            expectedOnDeadletter.add(content);
+                            break;
+                        case 1:
+                            content = "fail-this-message-in-the-middle-" + i;
+                            expectedOnDeadletter.add(content);
+                            break;
+                        case 2:
+                            content = "fail-this-message-in-the-end-" + i;
+                            expectedOnDeadletter.add(content);
+                            break;
+                        default:
+                            content = "test message " + i;
+                            expected.add(content);
+                            break;
+                    }
+                    sendMessage(inputTopic, content, producer);
+                }
+
+                executeAgentRunners(applicationRuntime);
+
+                waitForMessagesInAnyOrder(consumer, expected);
+                waitForMessagesInAnyOrder(consumerDeadletter, expectedOnDeadletter);
+            }
+        }
+    }
+
+    static Object[][] failuresAndRetries() {
+        return new Object[][] {
+            new Object[] {"fail-this-message-in-the-beginning", 0},
+            new Object[] {"fail-this-message-in-the-beginning", 1},
+            new Object[] {"fail-this-message-in-the-beginning", 2},
+            new Object[] {"fail-this-message-in-the-middle", 0},
+            new Object[] {"fail-this-message-in-the-middle", 1},
+            new Object[] {"fail-this-message-in-the-middle", 2},
+            new Object[] {"fail-this-message-in-the-end", 0},
+            new Object[] {"fail-this-message-in-the-end", 1},
+            new Object[] {"fail-this-message-in-the-end", 2}
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("failuresAndRetries")
+    public void testCompositeMultiStepProcessMultiThreadOutOfOrderWithFail(
+            String content, int retries) throws Exception {
+        String tenant = "tenant";
+        String[] expectedAgents = {"app-step1"};
+        String inputTopic = "input-topic-" + UUID.randomUUID();
+        String outputTopic = "output-topic-" + UUID.randomUUID();
+
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                errors:
+                                   on-failure: fail
+                                   retries: %d
+                                topics:
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 4
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                    partitions: 2
+                                pipeline:
+                                  - name: "mock-failing-processor"
+                                    type: "mock-failing-processor"
+                                    id: "step1"
+                                    input: "%s"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-beginning"
+                                  - name: "async-process-records"
+                                    id: "step2"
+                                    type: "mock-async-processor"
+                                  - name: "mock-failing-processor"
+                                    id: "step3"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-middle"
+                                    type: "mock-failing-processor"
+                                  - name: "async-process-records"
+                                    id: "step4"
+                                    type: "mock-async-processor"
+                                  - name: "mock-failing-processor"
+                                    id: "step5"
+                                    type: "mock-failing-processor"
+                                    output: "%s"
+                                    configuration:
+                                       fail-on-content: "fail-this-message-in-the-end"
+                                """
+                                .formatted(
+                                        retries, inputTopic, outputTopic, inputTopic, outputTopic));
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer(); ) {
+                sendMessage(inputTopic, content, producer);
+                AgentRunner.PermanentFailureException permanentFailureException =
+                        assertThrows(
+                                AgentRunner.PermanentFailureException.class,
+                                () -> executeAgentRunners(applicationRuntime));
+                assertInstanceOf(
+                        MockProcessorAgentsCodeProvider.InjectedFailure.class,
+                        permanentFailureException.getCause());
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockProcessorAgentsProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockProcessorAgentsProvider.java
@@ -18,14 +18,14 @@ package ai.langstream.mockagents;
 import ai.langstream.api.model.AgentConfiguration;
 import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.runtime.ComputeClusterRuntime;
-import ai.langstream.impl.common.AbstractAgentProvider;
+import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class MockProcessorAgentsProvider extends AbstractAgentProvider {
+public class MockProcessorAgentsProvider extends AbstractComposableAgentProvider {
     public MockProcessorAgentsProvider() {
         super(
                 Set.of("mock-failing-processor", "mock-failing-sink", "mock-async-processor"),

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
@@ -142,7 +142,8 @@ class PulsarRunnerDockerTest {
                     null,
                     AbstractApplicationRunner.agentsDirectory,
                     new AgentInfo(),
-                    5);
+                    5,
+                    null);
 
             // receive one message from the output-topic (written by the PodJavaRuntime)
             Message<byte[]> record = consumer.receive();

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
@@ -86,7 +86,8 @@ class AgentRunnerStarterTest {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.any(),
-                        Mockito.anyInt());
+                        Mockito.anyInt(),
+                        Mockito.any());
     }
 
     static class TestDeployer extends AgentRunnerStarter {


### PR DESCRIPTION
Summary:
- ensure that we are properly committing the offsets in case of all the types of failure handling
- add tests with async processors
- add some validations in the model parser in order to have better errors in some cases
- reports on the TopicSource the status of the consumer: current committed offsets and current uncommitted offsets (due to out of order processing)
- fix a bug in CompositeAgent in presence of agents that generate more messages from a single message (like the TextSplitterAgent)