### PR TITLE
Deployer: add application resource limits per tenant

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -37,7 +37,7 @@ build_docker_image() {
 
 if [ "$only_image" == "control-plane" ]; then
   build_docker_image langstream-webservice
-elif [ "$only_image" == "operator" ]; then
+elif [ "$only_image" == "operator" ] || [ "$only_image" == "deployer" ]; then
   build_docker_image langstream-k8s-deployer/langstream-k8s-deployer-operator
 elif [ "$only_image" == "runtime" ]; then
   build_docker_image langstream-runtime/langstream-runtime-impl
@@ -50,7 +50,7 @@ else
   ./mvnw install -DskipTests -T 1C -Ddocker.platforms="$(docker_platforms)" -PskipPython
   # Build docker images
   ./mvnw package -DskipTests -Pdocker -T 1C -Ddocker.platforms="$(docker_platforms)" -PskipPython
-  docker images | head -n 5
+  docker images | head -n 6
 fi
 
 

--- a/helm/crds/applications.langstream.ai-v1.yml
+++ b/helm/crds/applications.langstream.ai-v1.yml
@@ -48,6 +48,11 @@ spec:
                   reason:
                     type: string
                 type: object
+              resourceLimitStatus:
+                enum:
+                - ACCEPTED
+                - REJECTED
+                type: string
               lastApplied:
                 description: Last spec applied.
                 type: string

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/AgentNode.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/AgentNode.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.api.runtime;
 
+import ai.langstream.api.model.ResourcesSpec;
 import java.util.Map;
 
 public interface AgentNode extends ConnectionImplementation {
@@ -35,4 +36,6 @@ public interface AgentNode extends ConnectionImplementation {
     ConnectionImplementation getInputConnectionImplementation();
 
     ConnectionImplementation getOutputConnectionImplementation();
+
+    ResourcesSpec getResources();
 }

--- a/langstream-api/src/main/java/ai/langstream/api/storage/MetadataOwnerLock.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/MetadataOwnerLock.java
@@ -13,20 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.deployer.k8s.api.crds.apps;
+package ai.langstream.api.storage;
 
-import ai.langstream.api.model.ApplicationLifecycleStatus;
-import ai.langstream.deployer.k8s.api.crds.BaseStatus;
-import lombok.Data;
-
-@Data
-public class ApplicationStatus extends BaseStatus {
-
-    public enum ResourceLimitStatus {
-        ACCEPTED,
-        REJECTED
-    }
-
-    ApplicationLifecycleStatus status;
-    ResourceLimitStatus resourceLimitStatus;
-}
+public interface MetadataOwnerLock {}

--- a/langstream-core/src/main/java/ai/langstream/impl/common/DefaultAgentNode.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/DefaultAgentNode.java
@@ -86,4 +86,9 @@ public class DefaultAgentNode implements AgentNode {
     public ConnectionImplementation getOutputConnectionImplementation() {
         return outputConnectionImplementation;
     }
+
+    @Override
+    public ResourcesSpec getResources() {
+        return resourcesSpec;
+    }
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpec.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpec.java
@@ -16,15 +16,39 @@
 package ai.langstream.deployer.k8s.api.crds.apps;
 
 import ai.langstream.deployer.k8s.api.crds.NamespacedSpec;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 
 @Data
 @NoArgsConstructor
 public class ApplicationSpec extends NamespacedSpec {
+
+    private static final ObjectMapper mapper =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @SneakyThrows
+    public static String serializeApplication(
+            SerializedApplicationInstance serializedApplicationInstance) {
+        return mapper.writeValueAsString(serializedApplicationInstance);
+    }
+
+    @SneakyThrows
+    public static SerializedApplicationInstance deserializeApplication(
+            String serializedApplicationInstance) {
+        return mapper.readValue(serializedApplicationInstance, SerializedApplicationInstance.class);
+    }
+
     @Deprecated private String image;
     @Deprecated private String imagePullPolicy;
+
+    /**
+     * {@link SerializedApplicationInstance} serialized as json. Field as string to simplify future
+     * changes to the SerializedApplicationInstance schema.
+     */
     private String application;
 
     private String codeArchiveId;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/SerializedApplicationInstance.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/SerializedApplicationInstance.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.deployer.k8s.api.crds.apps;
+
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.Gateways;
+import ai.langstream.api.model.Instance;
+import ai.langstream.api.model.Module;
+import ai.langstream.api.model.Resource;
+import ai.langstream.api.model.ResourcesSpec;
+import ai.langstream.api.runtime.AgentNode;
+import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.Topic;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@NoArgsConstructor
+@Slf4j
+public class SerializedApplicationInstance {
+
+    public SerializedApplicationInstance(
+            Application applicationInstance, ExecutionPlan executionPlan) {
+        this.resources = applicationInstance.getResources();
+        this.modules = applicationInstance.getModules();
+        this.instance = applicationInstance.getInstance();
+        this.gateways = applicationInstance.getGateways();
+        this.agentRunners = new HashMap<>();
+        log.info(
+                "Serializing application instance {} executionPlan {}",
+                applicationInstance,
+                executionPlan);
+        if (executionPlan != null && executionPlan.getAgents() != null) {
+            for (Map.Entry<String, AgentNode> entry : executionPlan.getAgents().entrySet()) {
+                AgentNode agentNode = entry.getValue();
+                AgentRunnerDefinition agentRunnerDefinition = new AgentRunnerDefinition();
+                agentRunnerDefinition.setAgentId(agentNode.getId());
+                agentRunnerDefinition.setAgentType(agentNode.getAgentType());
+                agentRunnerDefinition.setComponentType(agentNode.getComponentType() + "");
+                agentRunnerDefinition.setConfiguration(
+                        agentNode.getConfiguration() != null
+                                ? agentNode.getConfiguration()
+                                : Map.of());
+                agentRunnerDefinition.setResources(agentNode.getResources());
+
+                agentRunners.put(entry.getKey(), agentRunnerDefinition);
+
+                if (agentNode.getInputConnectionImplementation() instanceof Topic topic) {
+                    agentRunnerDefinition.setInputTopic(topic.topicName());
+                }
+
+                if (agentNode.getOutputConnectionImplementation() instanceof Topic topic) {
+                    agentRunnerDefinition.setOutputTopic(topic.topicName());
+                }
+            }
+        }
+    }
+
+    private Map<String, Resource> resources = new HashMap<>();
+    private Map<String, Module> modules = new HashMap<>();
+    private Instance instance;
+    private Gateways gateways;
+    private Map<String, AgentRunnerDefinition> agentRunners;
+
+    public Application toApplicationInstance() {
+        final Application app = new Application();
+        app.setInstance(instance);
+        app.setModules(modules);
+        app.setResources(resources);
+        app.setGateways(gateways);
+        return app;
+    }
+
+    public Map<String, AgentRunnerDefinition> getAgentRunners() {
+        return agentRunners;
+    }
+
+    @Data
+    public static class AgentRunnerDefinition {
+        private String agentId;
+        private String agentType;
+        private String componentType;
+        private Map<String, Object> configuration;
+        private String inputTopic;
+        private String outputTopic;
+        private ResourcesSpec resources;
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
@@ -30,4 +30,6 @@ public class AgentResourceUnitConfiguration {
 
     private int maxCpuMemUnits = 8;
     private int maxInstanceUnits = 8;
+
+    private int defaultMaxUnitsPerTenant = 0;
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsChecker.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsChecker.java
@@ -152,9 +152,9 @@ public class ApplicationResourceLimitsChecker {
         final SerializedApplicationInstance serializedApplicationInstance =
                 ApplicationSpec.deserializeApplication(
                         applicationCustomResource.getSpec().getApplication());
-        final Collection<SerializedApplicationInstance.AgentRunnerDefinition> agents =
-                serializedApplicationInstance.getAgentRunners().values();
-        if (agents.isEmpty()) {
+        final Map<String, SerializedApplicationInstance.AgentRunnerDefinition> runners =
+                serializedApplicationInstance.getAgentRunners();
+        if (runners == null || runners.isEmpty()) {
             log.warn(
                     "Application {} has no agents configured, this might be a old format of the agent definition.",
                     applicationCustomResource.getMetadata().getName());
@@ -162,7 +162,7 @@ public class ApplicationResourceLimitsChecker {
         }
 
         int totalUnits = 0;
-        for (SerializedApplicationInstance.AgentRunnerDefinition agent : agents) {
+        for (SerializedApplicationInstance.AgentRunnerDefinition agent : runners.values()) {
             if (agent.getResources() == null) {
                 // mantain backward-compatibility
                 log.warn(

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsChecker.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsChecker.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.deployer.k8s.limits;
+
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationSpec;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationStatus;
+import ai.langstream.deployer.k8s.api.crds.apps.SerializedApplicationInstance;
+import ai.langstream.deployer.k8s.util.KeyedLockHandler;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class ApplicationResourceLimitsChecker {
+
+    private final KubernetesClient client;
+    private final KeyedLockHandler lockHandler;
+    private final Function<String, Integer> limitSupplier;
+    private final Map<String, Map<String, Integer>> tenantUsage = new ConcurrentHashMap<>();
+
+    public boolean checkLimitsForTenant(ApplicationCustomResource applicationCustomResource) {
+
+        final String tenant = applicationCustomResource.getSpec().getTenant();
+        final String namespace = applicationCustomResource.getMetadata().getNamespace();
+        final String applicationId = applicationCustomResource.getMetadata().getName();
+        final int requestedUnits = computeRequestedUnits(applicationCustomResource);
+        if (requestedUnits <= 0) {
+            log.warn(
+                    "Unknown resource requests for application {}/{}, will deploy anyway.",
+                    tenant,
+                    applicationId);
+            return true;
+        }
+        log.info("Application {}/{} requires {} units", tenant, applicationId, requestedUnits);
+
+        try (KeyedLockHandler.LockHolder lock = lockHandler.lock(tenant)) {
+            log.info("Checking limits for application {}/{}", tenant, applicationId);
+            final Integer max = limitSupplier.apply(tenant);
+            if (max == null || max <= 0) {
+                log.info("No limit for tenant {}", tenant);
+                return true;
+            }
+
+            final Map<String, Integer> actualTenantUsageByApp =
+                    tenantUsage.computeIfAbsent(tenant, loadUsage(namespace));
+
+            final Integer currentUsage =
+                    actualTenantUsageByApp.entrySet().stream()
+                            .filter(e -> !e.getKey().equals(applicationId))
+                            .collect(Collectors.summingInt(e -> e.getValue()));
+
+            log.info(
+                    "Current usage for tenant {} is {}/{} units (excluding application {}), distribution: {}",
+                    tenant,
+                    currentUsage,
+                    max,
+                    applicationId,
+                    actualTenantUsageByApp);
+
+            final int totalUnits = currentUsage + requestedUnits;
+
+            if (max >= totalUnits) {
+                log.info(
+                        "Accept to deploy application {} with {} units",
+                        applicationId,
+                        requestedUnits);
+                actualTenantUsageByApp.put(applicationId, requestedUnits);
+                return true;
+            } else {
+                log.info(
+                        "Reject to deploy application {} with {} units",
+                        applicationId,
+                        requestedUnits);
+                return false;
+            }
+        }
+    }
+
+    public void onAppBeingDeleted(ApplicationCustomResource applicationCustomResource) {
+        final String tenant = applicationCustomResource.getSpec().getTenant();
+        final String namespace = applicationCustomResource.getMetadata().getNamespace();
+        final String applicationId = applicationCustomResource.getMetadata().getName();
+
+        try (KeyedLockHandler.LockHolder lock = lockHandler.lock(tenant)) {
+            final Map<String, Integer> actualTenantUsageByApp =
+                    tenantUsage.computeIfAbsent(tenant, loadUsage(namespace));
+            if (actualTenantUsageByApp != null) {
+                actualTenantUsageByApp.remove(applicationId);
+            }
+        }
+    }
+
+    private Function<String, Map<String, Integer>> loadUsage(String namespace) {
+        return t -> {
+            final List<ApplicationCustomResource> applications =
+                    client.resources(ApplicationCustomResource.class)
+                            .inNamespace(namespace)
+                            .list()
+                            .getItems();
+            if (applications.isEmpty()) {
+                return new HashMap<>();
+            }
+            Map<String, Integer> appUsage = new HashMap<>();
+            for (ApplicationCustomResource application : applications) {
+                if (application.getStatus() != null) {
+                    final ApplicationStatus.ResourceLimitStatus resourceLimitStatus =
+                            application.getStatus().getResourceLimitStatus();
+                    if (resourceLimitStatus != null
+                            && resourceLimitStatus
+                                    == ApplicationStatus.ResourceLimitStatus.REJECTED) {
+                        continue;
+                    }
+                }
+                final int usage = computeRequestedUnits(application);
+                if (usage <= 0) {
+                    log.warn(
+                            "Unknown resource requests for application {}/{}. This app won't be counted for tenant resource usage.",
+                            application.getSpec().getTenant(),
+                            application.getMetadata().getName());
+                    continue;
+                }
+                appUsage.put(application.getMetadata().getName(), usage);
+            }
+            return appUsage;
+        };
+    }
+
+    private static int computeRequestedUnits(ApplicationCustomResource applicationCustomResource) {
+
+        final SerializedApplicationInstance serializedApplicationInstance =
+                ApplicationSpec.deserializeApplication(
+                        applicationCustomResource.getSpec().getApplication());
+        final Collection<SerializedApplicationInstance.AgentRunnerDefinition> agents =
+                serializedApplicationInstance.getAgentRunners().values();
+        if (agents.isEmpty()) {
+            log.warn(
+                    "Application {} has no agents configured, this might be a old format of the agent definition.",
+                    applicationCustomResource.getMetadata().getName());
+            return -1;
+        }
+
+        int totalUnits = 0;
+        for (SerializedApplicationInstance.AgentRunnerDefinition agent : agents) {
+            if (agent.getResources() == null) {
+                // mantain backward-compatibility
+                log.warn(
+                        "Found agent {} with null resources, this might be a old format of the agent definition.",
+                        agent.getAgentId(),
+                        agent.getResources());
+                return -1;
+            }
+            totalUnits += agent.getResources().parallelism() * agent.getResources().size();
+        }
+        return totalUnits;
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsChecker.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsChecker.java
@@ -21,7 +21,6 @@ import ai.langstream.deployer.k8s.api.crds.apps.ApplicationStatus;
 import ai.langstream.deployer.k8s.api.crds.apps.SerializedApplicationInstance;
 import ai.langstream.deployer.k8s.util.KeyedLockHandler;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KeyedLockHandler.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KeyedLockHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.deployer.k8s.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class KeyedLockHandler {
+
+    public interface LockHolder extends AutoCloseable {
+        void release();
+
+        default void close() {
+            release();
+        }
+    }
+
+    private final Map<String, Lock> mapStringLock = new ConcurrentHashMap<>();
+
+    public LockHolder lock(String key) {
+        Lock lock = mapStringLock.computeIfAbsent(key, k -> new ReentrantLock());
+        lock.lock();
+        return new LockHolder() {
+            @Override
+            public void release() {
+                lock.unlock();
+            }
+        };
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsCheckerTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/limits/ApplicationResourceLimitsCheckerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.deployer.k8s.limits;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import ai.langstream.deployer.k8s.util.KeyedLockHandler;
+import ai.langstream.deployer.k8s.util.SerializationUtil;
+import ai.langstream.impl.k8s.tests.KubeK3sServer;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class ApplicationResourceLimitsCheckerTest {
+    @RegisterExtension static final KubeK3sServer k3s = new KubeK3sServer(true);
+
+    @Test
+    void testLimits() {
+        final ApplicationResourceLimitsChecker checker =
+                new ApplicationResourceLimitsChecker(
+                        k3s.getClient(), new KeyedLockHandler(), tenant -> 10);
+
+        final String tenant1 = genTenant();
+        final String tenant2 = genTenant();
+        setupTenant(tenant1);
+        setupTenant(tenant2);
+        // must not be kept in consideration
+        createApp(tenant2, 10, 1);
+
+        ApplicationCustomResource app1 = createApp(tenant1, 10, 1);
+        assertTrue(checker.checkLimitsForTenant(app1));
+        deleteApp(app1, checker);
+
+        app1 = createApp(tenant1, 1, 10);
+        assertTrue(checker.checkLimitsForTenant(app1));
+
+        ApplicationCustomResource app2 = createApp(tenant1, 1, 1);
+        assertFalse(checker.checkLimitsForTenant(app2));
+
+        deleteApp(app1, checker);
+        assertTrue(checker.checkLimitsForTenant(app2));
+    }
+
+    @Test
+    void testConcurrency() {
+        final ApplicationResourceLimitsChecker checker =
+                new ApplicationResourceLimitsChecker(
+                        k3s.getClient(), new KeyedLockHandler(), tenant -> 10);
+
+        final String tenant1 = genTenant();
+        final String tenant2 = genTenant();
+        setupTenant(tenant1);
+        setupTenant(tenant2);
+
+        final int nThreads = 50;
+        final ExecutorService executorService = Executors.newFixedThreadPool(nThreads);
+
+        AtomicInteger countDone = new AtomicInteger();
+        AtomicReference<String> successfullApp = new AtomicReference();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < nThreads; i++) {
+            final CompletableFuture<Void> future =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                ApplicationCustomResource app1 = createApp(tenant1, 10, 1);
+                                final boolean done = checker.checkLimitsForTenant(app1);
+                                if (done) {
+                                    countDone.incrementAndGet();
+                                    successfullApp.set(app1.getMetadata().getName());
+                                }
+                            },
+                            executorService);
+            futures.add(future);
+        }
+        futures.forEach(CompletableFuture::join);
+        assertEquals(1, countDone.get());
+        ApplicationCustomResource anotherApp = createApp(tenant1, 1, 1);
+
+        ApplicationCustomResource successfullAppUpgrade = createApp(tenant1, 1, 9);
+        successfullAppUpgrade.getMetadata().setName(successfullApp.get());
+        assertTrue(checker.checkLimitsForTenant(successfullAppUpgrade));
+        assertTrue(checker.checkLimitsForTenant(anotherApp));
+        assertFalse(checker.checkLimitsForTenant(createApp(tenant1, 1, 1)));
+
+        checker.onAppBeingDeleted(successfullAppUpgrade);
+        assertTrue(checker.checkLimitsForTenant(createApp(tenant1, 9, 1)));
+    }
+
+    private void deleteApp(
+            ApplicationCustomResource resource, ApplicationResourceLimitsChecker checker) {
+        k3s.getClient().resource(resource).delete();
+        checker.onAppBeingDeleted(resource);
+    }
+
+    private ApplicationCustomResource createApp(String tenant, int size, int parallelism) {
+        final String appId = genAppId();
+        ApplicationCustomResource resource =
+                getCr(
+                        """
+                                apiVersion: langstream.ai/v1alpha1
+                                kind: Application
+                                metadata:
+                                  name: %s
+                                  namespace: %s
+                                spec:
+                                    application: '{"agentRunners": {"agent1": {"resources": {"size": %d, "parallelism": %d}}}}'
+                                    tenant: %s
+                                """
+                                .formatted(appId, tenant, size, parallelism, tenant));
+        return resource;
+    }
+
+    static AtomicInteger counter = new AtomicInteger(0);
+
+    private String genAppId() {
+        return "app-%s".formatted(counter.incrementAndGet());
+    }
+
+    private String genTenant() {
+        return "tenant-%s".formatted(counter.incrementAndGet());
+    }
+
+    private ApplicationCustomResource getCr(String yaml) {
+        return SerializationUtil.readYaml(yaml, ApplicationCustomResource.class);
+    }
+
+    private void setupTenant(String tenant) {
+        k3s.getClient()
+                .resource(
+                        new NamespaceBuilder()
+                                .withNewMetadata()
+                                .withName(tenant)
+                                .endMetadata()
+                                .build())
+                .create();
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantLimitsChecker.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantLimitsChecker.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.deployer.k8s;
+
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import ai.langstream.deployer.k8s.limits.ApplicationResourceLimitsChecker;
+import ai.langstream.deployer.k8s.util.KeyedLockHandler;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.function.Function;
+import lombok.AllArgsConstructor;
+
+@ApplicationScoped
+public class TenantLimitsChecker {
+
+    private final ApplicationResourceLimitsChecker resourceLimitsEnforcer;
+
+    public TenantLimitsChecker(
+            ResolvedDeployerConfiguration resolvedDeployerConfiguration,
+            KubernetesClient kubernetesClient) {
+        this.resourceLimitsEnforcer =
+                new ApplicationResourceLimitsChecker(
+                        kubernetesClient,
+                        new KeyedLockHandler(),
+                        new LimitsSupplier(
+                                resolvedDeployerConfiguration
+                                        .getAgentResources()
+                                        .getDefaultMaxUnitsPerTenant()));
+    }
+
+    @AllArgsConstructor
+    static class LimitsSupplier implements Function<String, Integer> {
+        private final int defaultLimit;
+
+        @Override
+        public Integer apply(String s) {
+            return defaultLimit;
+        }
+    }
+
+    public boolean checkLimitsForTenant(ApplicationCustomResource applicationCustomResource) {
+        return resourceLimitsEnforcer.checkLimitsForTenant(applicationCustomResource);
+    }
+
+    public void onAppBeingDeleted(ApplicationCustomResource applicationCustomResource) {
+        resourceLimitsEnforcer.onAppBeingDeleted(applicationCustomResource);
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/BaseController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/BaseController.java
@@ -16,6 +16,7 @@
 package ai.langstream.deployer.k8s.controllers;
 
 import ai.langstream.deployer.k8s.ResolvedDeployerConfiguration;
+import ai.langstream.deployer.k8s.TenantLimitsChecker;
 import ai.langstream.deployer.k8s.api.crds.BaseStatus;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -36,6 +37,8 @@ public abstract class BaseController<T extends CustomResource<?, ? extends BaseS
     @Inject protected KubernetesClient client;
 
     @Inject protected ResolvedDeployerConfiguration configuration;
+
+    @Inject protected TenantLimitsChecker appResourcesLimiter;
 
     protected abstract UpdateControl<T> patchResources(T resource, Context<T> context);
 

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -47,6 +47,12 @@ public class AppControllerIT {
                             "DEPLOYER_RUNTIME_IMAGE", "busybox",
                             "DEPLOYER_RUNTIME_IMAGE_PULL_POLICY", "IfNotPresent"));
 
+
+    static AtomicInteger counter = new AtomicInteger(0);
+    static String genTenant() {
+        return "tenant-" + counter.incrementAndGet();
+    }
+
     @Test
     void testAppController() {
 
@@ -134,7 +140,7 @@ public class AppControllerIT {
     @Test
     void testAppResources() {
 
-        final String tenant = "my-tenant";
+        final String tenant = genTenant();
         setupTenant(tenant);
         final ApplicationCustomResource app1 = createAppWithResources(tenant, 1, 1);
         awaitApplicationDeployingStatus(app1);

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -270,8 +270,9 @@ public class AppControllerIT {
         assertEquals("bash", initContainer.getCommand().get(0));
         assertEquals("-c", initContainer.getCommand().get(1));
         assertEquals(
-                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{app: true}\","
-                        + "\"codeStorageArchiveId\":null}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
+                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": "
+                        + "{}}\",\"codeStorageArchiveId\":null}' > /app-config/config && echo '{}' > "
+                        + "/cluster-runtime-config/config",
                 initContainer.getArgs().get(0));
     }
 

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -313,8 +313,6 @@ public class AppControllerIT {
                 .create();
     }
 
-    AtomicInteger counter = new AtomicInteger(0);
-
     private String genAppId() {
         return "app-%s".formatted(counter.incrementAndGet());
     }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import ai.langstream.api.model.ApplicationLifecycleStatus;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationStatus;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
@@ -28,6 +29,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -36,7 +39,13 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 @Testcontainers
 public class AppControllerIT {
 
-    @RegisterExtension static final OperatorExtension deployment = new OperatorExtension();
+    @RegisterExtension
+    static final OperatorExtension deployment =
+            new OperatorExtension(
+                    Map.of(
+                            "DEPLOYER_AGENT_RESOURCES", "{defaultMaxUnitsPerTenant: 3}",
+                            "DEPLOYER_RUNTIME_IMAGE", "busybox",
+                            "DEPLOYER_RUNTIME_IMAGE_PULL_POLICY", "IfNotPresent"));
 
     @Test
     void testAppController() {
@@ -122,6 +131,70 @@ public class AppControllerIT {
         assertNotNull(client.resource(resource).inNamespace(namespace).get());
     }
 
+    @Test
+    void testAppResources() {
+
+        final String tenant = "my-tenant";
+        setupTenant(tenant);
+        final ApplicationCustomResource app1 = createAppWithResources(tenant, 1, 1);
+        awaitApplicationDeployingStatus(app1);
+
+        final ApplicationCustomResource app2 = createAppWithResources(tenant, 1, 1);
+        awaitApplicationDeployingStatus(app2);
+
+        final ApplicationCustomResource app3 = createAppWithResources(tenant, 2, 1);
+        awaitApplicationErrorForResources(app3);
+
+        deployment.getClient().resource(app2).delete();
+        awaitApplicationDeployingStatus(app3);
+
+        final ApplicationCustomResource app4 = createAppWithResources(tenant, 2, 1);
+        awaitApplicationErrorForResources(app4);
+
+        deployment.restartDeployerOperator();
+        deployment.getClient().resource(app3).delete();
+        awaitApplicationDeployingStatus(app4);
+    }
+
+    private void awaitApplicationErrorForResources(ApplicationCustomResource original) {
+        org.awaitility.Awaitility.await()
+                .untilAsserted(
+                        () -> {
+                            final ApplicationCustomResource resource =
+                                    deployment.getClient().resource(original).get();
+                            assertEquals(
+                                    ApplicationLifecycleStatus.Status.ERROR_DEPLOYING,
+                                    resource.getStatus().getStatus().getStatus());
+                            assertEquals(
+                                    "Not enough resources to deploy application",
+                                    resource.getStatus().getStatus().getReason());
+                            assertEquals(
+                                    ApplicationStatus.ResourceLimitStatus.REJECTED,
+                                    resource.getStatus().getResourceLimitStatus());
+                        });
+    }
+
+    private void awaitApplicationDeployingStatus(ApplicationCustomResource resource) {
+        Awaitility.await()
+                .atMost(1, java.util.concurrent.TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            final ApplicationCustomResource applicationCustomResource =
+                                    deployment
+                                            .getClient()
+                                            .resource(resource)
+                                            .inNamespace(resource.getMetadata().getNamespace())
+                                            .get();
+                            assertNotNull(applicationCustomResource);
+                            assertEquals(
+                                    ApplicationLifecycleStatus.Status.DEPLOYING,
+                                    applicationCustomResource.getStatus().getStatus().getStatus());
+                            assertEquals(
+                                    ApplicationStatus.ResourceLimitStatus.ACCEPTED,
+                                    applicationCustomResource.getStatus().getResourceLimitStatus());
+                        });
+    }
+
     private void checkJob(Job job, boolean cleanup) {
         final JobSpec spec = job.getSpec();
         final PodSpec templateSpec = spec.getTemplate().getSpec();
@@ -198,5 +271,45 @@ public class AppControllerIT {
 
     private ApplicationCustomResource getCr(String yaml) {
         return SerializationUtil.readYaml(yaml, ApplicationCustomResource.class);
+    }
+
+    private void setupTenant(String tenant) {
+        deployment
+                .getClient()
+                .resource(
+                        new NamespaceBuilder()
+                                .withNewMetadata()
+                                .withName("langstream-" + tenant)
+                                .endMetadata()
+                                .build())
+                .create();
+    }
+
+    private ApplicationCustomResource createAppWithResources(
+            String tenant, int size, int parallelism) {
+        final String appId = genAppId();
+        ApplicationCustomResource resource =
+                getCr(
+                        """
+                                apiVersion: langstream.ai/v1alpha1
+                                kind: Application
+                                metadata:
+                                  name: %s
+                                spec:
+                                    application: '{"agentRunners": {"agent1": {"resources": {"size": %d, "parallelism": %d}}}}'
+                                    tenant: %s
+                                """
+                                .formatted(appId, size, parallelism, tenant));
+        return deployment
+                .getClient()
+                .resource(resource)
+                .inNamespace("langstream-" + tenant)
+                .create();
+    }
+
+    AtomicInteger counter = new AtomicInteger(0);
+
+    private String genAppId() {
+        return "app-%s".formatted(counter.incrementAndGet());
     }
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -47,8 +47,8 @@ public class AppControllerIT {
                             "DEPLOYER_RUNTIME_IMAGE", "busybox",
                             "DEPLOYER_RUNTIME_IMAGE_PULL_POLICY", "IfNotPresent"));
 
-
     static AtomicInteger counter = new AtomicInteger(0);
+
     static String genTenant() {
         return "tenant-" + counter.incrementAndGet();
     }
@@ -70,7 +70,7 @@ public class AppControllerIT {
                 spec:
                     image: busybox
                     imagePullPolicy: IfNotPresent
-                    application: "{app: true}"
+                    application: '{"modules": {}}'
                     tenant: %s
                 """
                                 .formatted(applicationId, namespace, tenant));

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntime.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntime.java
@@ -199,8 +199,7 @@ public class KubernetesClusterRuntime extends BasicClusterRuntime {
         agentSpec.setApplicationId(applicationInstance.getApplicationId());
         agentSpec.setResources(
                 new AgentSpec.Resources(
-                        ((DefaultAgentNode) agent).getResourcesSpec().parallelism(),
-                        ((DefaultAgentNode) agent).getResourcesSpec().size()));
+                        agent.getResources().parallelism(), agent.getResources().size()));
         agentSpec.setAgentConfigSecretRef(secretName);
         agentSpec.setCodeArchiveId(codeStorageArchiveId);
         MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
@@ -19,27 +19,27 @@ FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install some utilities
+# Setup apt
 RUN echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
+     && mkdir -p /etc/apt/keyrings \
+     && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
      && apt-get update \
-     && apt-get -y dist-upgrade \
-     && apt-get -y install --no-install-recommends vim netcat dnsutils less procps net-tools iputils-ping \
+     && apt-get -y dist-upgrade
+
+# Install some utilities
+RUN apt-get -y install --no-install-recommends vim netcat dnsutils less procps net-tools iputils-ping \
                  curl ca-certificates wget apt-transport-https software-properties-common gpg-agent
 
 # Install Python3.11
-RUN apt-get update && add-apt-repository ppa:deadsnakes/ppa \
+RUN add-apt-repository ppa:deadsnakes/ppa \
      && apt-get -y install --no-install-recommends python3.11-full \
      && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
      && python3 -m ensurepip && python3 -m pip install pipenv
 
 
 # Install Eclipse Temurin Package
-RUN mkdir -p /etc/apt/keyrings \
-     && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
-     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
-     && apt-get update \
-     && apt-get -y dist-upgrade \
-     && apt-get -y install temurin-17-jdk \
+RUN apt-get -y install temurin-17-jdk \
      && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
      && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
@@ -19,29 +19,29 @@ FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Setup apt
-RUN echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
-     && mkdir -p /etc/apt/keyrings \
-     && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
-     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
-     && apt-get update \
-     && apt-get -y dist-upgrade
-
 # Install some utilities
-RUN apt-get -y install --no-install-recommends vim netcat dnsutils less procps net-tools iputils-ping \
+RUN echo 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "3";' > /etc/apt/apt.conf.d/99timeout_and_retries \
+     && apt-get update \
+     && apt-get -y dist-upgrade \
+     && apt-get -y install --no-install-recommends vim netcat dnsutils less procps net-tools iputils-ping \
                  curl ca-certificates wget apt-transport-https software-properties-common gpg-agent
 
 # Install Python3.11
-RUN add-apt-repository ppa:deadsnakes/ppa \
+RUN apt-get update && add-apt-repository ppa:deadsnakes/ppa \
      && apt-get -y install --no-install-recommends python3.11-full \
      && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
      && python3 -m ensurepip && python3 -m pip install pipenv
 
 
 # Install Eclipse Temurin Package
-RUN apt-get -y install temurin-17-jdk \
+RUN mkdir -p /etc/apt/keyrings \
+     && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list \
+     && apt-get update \
+     && apt-get -y dist-upgrade \
+     && apt-get -y install temurin-17-jdk \
      && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
 
 # Cleanup apt
 RUN apt-get -y --purge autoremove \

--- a/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-impl/src/main/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa \
 # Install Eclipse Temurin Package
 RUN apt-get -y install temurin-17-jdk \
      && export ARCH=$(uname -m | sed -r 's/aarch64/arm64/g' |  awk '!/arm64/{$0="amd64"}1') \
-     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security \
+     && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security
 
 # Cleanup apt
 RUN apt-get -y --purge autoremove \


### PR DESCRIPTION
Implementation of the deployer check of https://github.com/LangStream/langstream/issues/304

* The deployer keeps a local map, counting all the resources used by every application (per tenant)
* The application info are retrieved from the application specs (generated by the execution plan) - this is a new field that will be empty for existing applications
* There's a local lock (per tenant) and only one application can be deployed (meaning both new and updates) at the same time
* When the deployer restarts, once a new application is created/updated/deleted, it recovers the current status by looking at the Application CR. We use the application CR because we want to also count applications that are in error state (before deploying)
* Added new status field in the app custom resource about the resource limits status to ensure to not include rejected applications in the grand total of the tenant usage
* New option in the deployer `defaultMaxUnitsPerTenant`, default 0 (0 means no limits)

Notes:
* Any change to the limit threshold, is not retroactive.
* Existing applications are NOT counted in the limit because they're missing the resource field in the custom resource. Any update to them, will make them to be included in the count




