### PR TITLE
Tenants: add create/update methods and maxUnits configuration

### DIFF
--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -30,6 +30,8 @@ public interface ApplicationStore extends GenericStore {
 
     void onTenantCreated(String tenant);
 
+    void onTenantUpdated(String tenant);
+
     void onTenantDeleted(String tenant);
 
     void put(

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/CreateTenantRequest.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/CreateTenantRequest.java
@@ -1,0 +1,15 @@
+package ai.langstream.api.webservice.tenant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateTenantRequest {
+
+    private Integer maxTotalResourceUnits;
+}

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/TenantConfiguration.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/TenantConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.api.model;
+package ai.langstream.api.webservice.tenant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,4 +26,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TenantConfiguration {
     private String name;
+    private int maxTotalResourceUnits;
 }

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/UpdateTenantRequest.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/UpdateTenantRequest.java
@@ -1,0 +1,15 @@
+package ai.langstream.api.webservice.tenant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateTenantRequest {
+
+    private Integer maxTotalResourceUnits;
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -21,6 +21,7 @@ import ai.langstream.admin.client.AdminClientLogger;
 import ai.langstream.cli.LangStreamCLIConfig;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
@@ -52,6 +53,8 @@ public abstract class BaseCmd implements Runnable {
             new ObjectMapper(new YAMLFactory())
                     .enable(SerializationFeature.INDENT_OUTPUT)
                     .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+    protected static final ObjectWriter jsonBodyWriter = new ObjectMapper().writer();
 
     @CommandLine.Spec protected CommandLine.Model.CommandSpec command;
     private AdminClient client;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootTenantCmd.java
@@ -15,10 +15,12 @@
  */
 package ai.langstream.cli.commands;
 
+import ai.langstream.cli.commands.tenants.CreateTenantCmd;
 import ai.langstream.cli.commands.tenants.DeleteTenantCmd;
 import ai.langstream.cli.commands.tenants.GetTenantCmd;
 import ai.langstream.cli.commands.tenants.ListTenantCmd;
 import ai.langstream.cli.commands.tenants.PutTenantCmd;
+import ai.langstream.cli.commands.tenants.UpdateTenantCmd;
 import lombok.Getter;
 import picocli.CommandLine;
 
@@ -30,7 +32,9 @@ import picocli.CommandLine;
             PutTenantCmd.class,
             DeleteTenantCmd.class,
             ListTenantCmd.class,
-            GetTenantCmd.class
+            GetTenantCmd.class,
+            CreateTenantCmd.class,
+            UpdateTenantCmd.class
         })
 @Getter
 public class RootTenantCmd {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/CreateTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/CreateTenantCmd.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.tenants;
+
+import ai.langstream.api.webservice.tenant.CreateTenantRequest;
+import java.net.http.HttpRequest;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "create",
+        mixinStandardHelpOptions = true,
+        description = "Create a new tenant")
+public class CreateTenantCmd extends BaseTenantCmd {
+
+    @CommandLine.Parameters(description = "Name of the tenant")
+    private String name;
+
+    @CommandLine.Option(
+            names = {"--max-total-resource-units"},
+            description = "Max application's units for the tenant.")
+    private Integer maxUnits;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        final CreateTenantRequest request =
+                CreateTenantRequest.builder().maxTotalResourceUnits(maxUnits).build();
+        final String body = jsonBodyWriter.writeValueAsString(request);
+
+        final HttpRequest httpRequest =
+                getClient()
+                        .newPost(
+                                pathForTenant(name),
+                                "application/json",
+                                HttpRequest.BodyPublishers.ofString(body));
+        getClient().http(httpRequest);
+        log("tenant %s created".formatted(name));
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/UpdateTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/UpdateTenantCmd.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.tenants;
+
+import ai.langstream.api.webservice.tenant.UpdateTenantRequest;
+import java.net.http.HttpRequest;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "update",
+        mixinStandardHelpOptions = true,
+        description = "Update an existing tenant")
+public class UpdateTenantCmd extends BaseTenantCmd {
+
+    @CommandLine.Parameters(description = "Name of the tenant")
+    private String name;
+
+    @CommandLine.Option(
+            names = {"--max-total-resource-units"},
+            description = "Max application's units for the tenant.")
+    private Integer maxUnits;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        final UpdateTenantRequest request =
+                UpdateTenantRequest.builder().maxTotalResourceUnits(maxUnits).build();
+        final String body = jsonBodyWriter.writeValueAsString(request);
+
+        final HttpRequest httpRequest =
+                getClient()
+                        .newPatch(
+                                pathForTenant(name),
+                                "application/json",
+                                HttpRequest.BodyPublishers.ofString(body));
+        getClient().http(httpRequest);
+        log("tenant %s updated".formatted(name));
+    }
+}

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/TenantsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/TenantsCmdTest.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.cli.commands.applications;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,42 @@ class TenantsCmdTest extends CommandTestBase {
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
         Assertions.assertEquals("tenant newt created/updated", result.out());
+    }
+
+    @Test
+    public void testCreate() {
+        wireMock.register(
+                WireMock.post("/api/tenants/%s".formatted("newt"))
+                        .withRequestBody(WireMock.equalToJson("{\"maxTotalResourceUnits\":null}"))
+                        .willReturn(WireMock.ok("")));
+        CommandResult result = executeCommand("tenants", "create", "newt");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("tenant newt created", result.out());
+    }
+
+    @Test
+    public void testCreatemaxTotalResourceUnits() {
+        wireMock.register(
+                WireMock.post("/api/tenants/%s".formatted("newt"))
+                        .withRequestBody(WireMock.equalToJson("{\"maxTotalResourceUnits\":10}"))
+                        .willReturn(WireMock.ok("")));
+        CommandResult result = executeCommand("tenants", "create", "newt", "--max-total-resource-units", "10");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("tenant newt created", result.out());
+    }
+
+    @Test
+    public void testUpdatemaxTotalResourceUnits() {
+        wireMock.register(
+                WireMock.patch(urlEqualTo("/api/tenants/%s".formatted("newt")))
+                        .withRequestBody(WireMock.equalToJson("{\"maxTotalResourceUnits\":10}"))
+                        .willReturn(WireMock.ok("")));
+            CommandResult result = executeCommand("tenants", "update", "newt", "--max-total-resource-units", "10");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("tenant newt updated", result.out());
     }
 
     @Test

--- a/langstream-core/src/main/java/ai/langstream/impl/storage/GlobalMetadataStoreManager.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/storage/GlobalMetadataStoreManager.java
@@ -15,19 +15,26 @@
  */
 package ai.langstream.impl.storage;
 
-import ai.langstream.api.model.TenantConfiguration;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.api.storage.GlobalMetadataStore;
+import ai.langstream.api.webservice.tenant.CreateTenantRequest;
+import ai.langstream.api.webservice.tenant.TenantConfiguration;
+import ai.langstream.api.webservice.tenant.UpdateTenantRequest;
+import ai.langstream.impl.storage.tenants.TenantException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
+@Slf4j
 public class GlobalMetadataStoreManager {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     protected static final String TENANT_KEY_PREFIX = "t-";
     private final GlobalMetadataStore globalMetadataStore;
     private final ApplicationStore applicationStore;
@@ -41,10 +48,67 @@ public class GlobalMetadataStoreManager {
     }
 
     @SneakyThrows
+    public void createTenant(String tenant, CreateTenantRequest request) throws TenantException {
+        final String key = keyedTenantName(tenant);
+        if (globalMetadataStore.get(key) != null) {
+            throw new TenantException(
+                    "Tenant " + tenant + " already exists", TenantException.Type.AlreadyExists);
+        }
+        final TenantConfiguration configuration = createConfiguration(tenant, request);
+        log.info("Creating tenant {} with configuration {}", tenant, configuration);
+
+        globalMetadataStore.put(key, mapper.writeValueAsString(configuration));
+        applicationStore.onTenantCreated(tenant);
+    }
+
+    private TenantConfiguration createConfiguration(String tenant, CreateTenantRequest request) {
+        final TenantConfiguration.TenantConfigurationBuilder builder =
+                TenantConfiguration.builder().name(tenant);
+        final Integer maxTotalResourceUnits = request.getMaxTotalResourceUnits();
+        if (maxTotalResourceUnits != null && maxTotalResourceUnits < 0) {
+            throw new IllegalArgumentException("maxTotalResourceUnits must be positive");
+        }
+        builder.maxTotalResourceUnits(maxTotalResourceUnits == null ? 0 : maxTotalResourceUnits.intValue());
+
+        final TenantConfiguration configuration = builder.build();
+        return configuration;
+    }
+
+    @SneakyThrows
+    public void updateTenant(String tenant, UpdateTenantRequest request) throws TenantException {
+        final String key = keyedTenantName(tenant);
+        final String before = globalMetadataStore.get(key);
+        if (before == null) {
+            throw new TenantException(
+                    "Tenant " + tenant + " not found", TenantException.Type.NotFound);
+        }
+        final TenantConfiguration mergeConfig = mapper.readValue(before, TenantConfiguration.class);
+        mergeConfiguration(request, mergeConfig);
+
+        log.info("Updating tenant {} with configuration {}", tenant, mergeConfig);
+
+        globalMetadataStore.put(key, mapper.writeValueAsString(mergeConfig));
+        applicationStore.onTenantUpdated(tenant);
+    }
+
+    private void mergeConfiguration(UpdateTenantRequest request, TenantConfiguration mergeConfig) {
+        final Integer maxTotalResourceUnits = request.getMaxTotalResourceUnits();
+        if (maxTotalResourceUnits != null && maxTotalResourceUnits < 0) {
+            throw new IllegalArgumentException("maxTotalResourceUnits must be positive");
+        }
+        mergeConfig.setMaxTotalResourceUnits(maxTotalResourceUnits != null ? maxTotalResourceUnits : 0);
+    }
+
+    @SneakyThrows
     public void putTenant(String tenant, TenantConfiguration tenantConfiguration) {
         final String key = keyedTenantName(tenant);
+        final String before = globalMetadataStore.get(key);
         globalMetadataStore.put(key, mapper.writeValueAsString(tenantConfiguration));
-        applicationStore.onTenantCreated(tenant);
+        if (before != null) {
+            applicationStore.onTenantUpdated(tenant);
+        } else {
+            applicationStore.onTenantCreated(tenant);
+        }
     }
 
     public TenantConfiguration getTenant(String tenant) {

--- a/langstream-core/src/main/java/ai/langstream/impl/storage/tenants/TenantException.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/storage/tenants/TenantException.java
@@ -1,0 +1,18 @@
+package ai.langstream.impl.storage.tenants;
+
+import lombok.Getter;
+
+public class TenantException extends Exception {
+
+    public enum Type {
+        NotFound,
+        AlreadyExists;
+    }
+
+    @Getter private final Type type;
+
+    public TenantException(String message, Type type) {
+        super(message);
+        this.type = type;
+    }
+}

--- a/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
+++ b/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
@@ -90,6 +90,9 @@ public class KubernetesApplicationStore implements ApplicationStore {
     }
 
     @Override
+    public void onTenantUpdated(String tenant) {}
+
+    @Override
     public void onTenantDeleted(String tenant) {
         final String namespace = tenantToNamespace(tenant);
         if (client.namespaces().withName(namespace).get() != null) {

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/LangStreamEventListener.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/LangStreamEventListener.java
@@ -15,7 +15,7 @@
  */
 package ai.langstream.webservice;
 
-import ai.langstream.api.model.TenantConfiguration;
+import ai.langstream.api.webservice.tenant.TenantConfiguration;
 import ai.langstream.webservice.common.GlobalMetadataService;
 import ai.langstream.webservice.config.TenantProperties;
 import lombok.AllArgsConstructor;

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/common/GlobalMetadataService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/common/GlobalMetadataService.java
@@ -15,12 +15,16 @@
  */
 package ai.langstream.webservice.common;
 
-import ai.langstream.api.model.TenantConfiguration;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.api.storage.GlobalMetadataStore;
 import ai.langstream.api.storage.GlobalMetadataStoreRegistry;
+import ai.langstream.api.webservice.tenant.CreateTenantRequest;
+import ai.langstream.api.webservice.tenant.TenantConfiguration;
+import ai.langstream.api.webservice.tenant.UpdateTenantRequest;
 import ai.langstream.impl.storage.GlobalMetadataStoreManager;
+import ai.langstream.impl.storage.tenants.TenantException;
 import ai.langstream.webservice.config.StorageProperties;
+import ai.langstream.webservice.config.TenantProperties;
 import java.util.Map;
 import lombok.SneakyThrows;
 import org.springframework.stereotype.Service;
@@ -29,17 +33,45 @@ import org.springframework.stereotype.Service;
 public class GlobalMetadataService {
 
     private final GlobalMetadataStoreManager store;
+    private final TenantProperties tenantProperties;
 
     public GlobalMetadataService(
-            StorageProperties storageProperties, ApplicationStore applicationStore) {
+            StorageProperties storageProperties, ApplicationStore applicationStore, TenantProperties tenantProperties) {
         final GlobalMetadataStore globalMetadataStore =
                 GlobalMetadataStoreRegistry.loadStore(
                         storageProperties.getGlobal().getType(),
                         storageProperties.getGlobal().getConfiguration());
         store = new GlobalMetadataStoreManager(globalMetadataStore, applicationStore);
+        this.tenantProperties = tenantProperties;
     }
 
-    @SneakyThrows
+    public void createTenant(String tenant, CreateTenantRequest request) throws TenantException {
+        validateCreateTenantRequest(request);
+        store.createTenant(tenant, request);
+    }
+
+    private void validateCreateTenantRequest(CreateTenantRequest request) {
+        validateMaxTotalResourceUnits(request.getMaxTotalResourceUnits());
+    }
+
+    private void validateUpdateTenantRequest(UpdateTenantRequest request) {
+        validateMaxTotalResourceUnits(request.getMaxTotalResourceUnits());
+    }
+
+    private void validateMaxTotalResourceUnits(Integer maxTotalResourceUnits) {
+        if (maxTotalResourceUnits != null
+                && maxTotalResourceUnits > 0
+                && maxTotalResourceUnits > tenantProperties.getMaxTotalResourceUnitsLimit()) {
+            throw new IllegalArgumentException(
+                    "Max total resource units limit is " + tenantProperties.getMaxTotalResourceUnitsLimit());
+        }
+    }
+
+    public void updateTenant(String tenant, UpdateTenantRequest request) throws TenantException {
+        validateUpdateTenantRequest(request);
+        store.updateTenant(tenant, request);
+    }
+
     public void putTenant(String tenant, TenantConfiguration tenantConfiguration) {
         store.putTenant(tenant, tenantConfiguration);
     }

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/common/ResourceErrorsHandler.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/common/ResourceErrorsHandler.java
@@ -38,7 +38,6 @@ public class ResourceErrorsHandler {
             log.error("Bad request", exception);
             return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.getMessage());
         }
-
         log.error("Internal error", exception);
         return ProblemDetail.forStatusAndDetail(
                 HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/config/TenantProperties.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/config/TenantProperties.java
@@ -37,4 +37,5 @@ public class TenantProperties {
 
     private DefaultTenantProperties defaultTenant;
     private int defaultMaxUnitsPerTenant;
+    private int maxTotalResourceUnitsLimit;
 }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
@@ -157,6 +157,11 @@ class ApplicationServiceResourceLimitTest {
         }
 
         @Override
+        public void onTenantUpdated(String tenant) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void onTenantDeleted(String tenant) {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
* Added new endpoint for creating (POST) and updating a tenant (PATCH), similar to the application ones
* The PUT tenant is still there

The new commands can pass a new optional param `--max-units` (integer) (part of https://github.com/LangStream/langstream/issues/304)

The PUT endpoint doesn't accept any body. To create or update the tenant is recommended to use create/update from now on.  