### PR TITLE
Agents: document-to-json: handle copy-properties while reading directly from a topic

### DIFF
--- a/langstream-agents/langstream-agents-text-processing/src/main/java/ai/langstream/agents/text/DocumentToJsonAgent.java
+++ b/langstream-agents/langstream-agents-text-processing/src/main/java/ai/langstream/agents/text/DocumentToJsonAgent.java
@@ -19,6 +19,8 @@ import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.runner.code.SingleRecordAgentProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +52,14 @@ public class DocumentToJsonAgent extends SingleRecordAgentProcessor {
         Map<String, Object> asJson = new HashMap<>();
         asJson.put(textField, stream);
         if (copyProperties) {
-            record.headers().forEach(h -> asJson.put(h.key(), h.value()));
+            record.headers().forEach(h -> {
+                Object headerValue = h.value();
+                // JSON doesn't deal well with byte arrays
+                if (headerValue instanceof byte[]) {
+                    headerValue = new String((byte[]) headerValue, StandardCharsets.UTF_8);
+                }
+                asJson.put(h.key(), headerValue);
+            });
         }
 
         return List.of(

--- a/langstream-agents/langstream-agents-text-processing/src/main/java/ai/langstream/agents/text/DocumentToJsonAgent.java
+++ b/langstream-agents/langstream-agents-text-processing/src/main/java/ai/langstream/agents/text/DocumentToJsonAgent.java
@@ -19,7 +19,6 @@ import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.runner.code.SingleRecordAgentProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -52,14 +51,18 @@ public class DocumentToJsonAgent extends SingleRecordAgentProcessor {
         Map<String, Object> asJson = new HashMap<>();
         asJson.put(textField, stream);
         if (copyProperties) {
-            record.headers().forEach(h -> {
-                Object headerValue = h.value();
-                // JSON doesn't deal well with byte arrays
-                if (headerValue instanceof byte[]) {
-                    headerValue = new String((byte[]) headerValue, StandardCharsets.UTF_8);
-                }
-                asJson.put(h.key(), headerValue);
-            });
+            record.headers()
+                    .forEach(
+                            h -> {
+                                Object headerValue = h.value();
+                                // JSON doesn't deal well with byte arrays
+                                if (headerValue instanceof byte[]) {
+                                    headerValue =
+                                            new String(
+                                                    (byte[]) headerValue, StandardCharsets.UTF_8);
+                                }
+                                asJson.put(h.key(), headerValue);
+                            });
         }
 
         return List.of(

--- a/langstream-agents/langstream-agents-text-processing/src/test/java/ai/langstream/agents/text/DocumentToJsonTest.java
+++ b/langstream-agents/langstream-agents-text-processing/src/test/java/ai/langstream/agents/text/DocumentToJsonTest.java
@@ -68,8 +68,13 @@ public class DocumentToJsonTest {
                         .key("filename.txt")
                         .value(text.getBytes(StandardCharsets.UTF_8))
                         .origin("origin")
-                        .headers(List.of(new SimpleRecord.SimpleHeader("detected-language", "en"),
-                                new SimpleRecord.SimpleHeader("other-header", "bytearray-value".getBytes(StandardCharsets.UTF_8))))
+                        .headers(
+                                List.of(
+                                        new SimpleRecord.SimpleHeader("detected-language", "en"),
+                                        new SimpleRecord.SimpleHeader(
+                                                "other-header",
+                                                "bytearray-value"
+                                                        .getBytes(StandardCharsets.UTF_8))))
                         .timestamp(System.currentTimeMillis())
                         .build();
 

--- a/langstream-agents/langstream-agents-text-processing/src/test/java/ai/langstream/agents/text/DocumentToJsonTest.java
+++ b/langstream-agents/langstream-agents-text-processing/src/test/java/ai/langstream/agents/text/DocumentToJsonTest.java
@@ -36,7 +36,23 @@ public class DocumentToJsonTest {
         instance.init(Map.of("text-field", "document", "copy-properties", "true"));
 
         assertEquals(
-                "{\"detected-language\":\"en\",\"document\":\"This is a English\"}",
+                "{\"detected-language\":\"en\",\"document\":\"This is a English\",\"other-header\":\"bytearray-value\"}",
+                convertToJson(instance, "This is a English"));
+
+        instance.init(Map.of("text-field", "document", "copy-properties", "false"));
+        assertEquals(
+                "{\"document\":\"This is a English\"}",
+                convertToJson(instance, "This is a English"));
+    }
+
+    @Test
+    public void textConvertToJsonWithRawHeaders() throws Exception {
+        TextProcessingAgentsCodeProvider provider = new TextProcessingAgentsCodeProvider();
+        SingleRecordAgentProcessor instance = provider.createInstance("document-to-json");
+        instance.init(Map.of("text-field", "document", "copy-properties", "true"));
+
+        assertEquals(
+                "{\"detected-language\":\"en\",\"document\":\"This is a English\",\"other-header\":\"bytearray-value\"}",
                 convertToJson(instance, "This is a English"));
 
         instance.init(Map.of("text-field", "document", "copy-properties", "false"));
@@ -52,7 +68,8 @@ public class DocumentToJsonTest {
                         .key("filename.txt")
                         .value(text.getBytes(StandardCharsets.UTF_8))
                         .origin("origin")
-                        .headers(List.of(new SimpleRecord.SimpleHeader("detected-language", "en")))
+                        .headers(List.of(new SimpleRecord.SimpleHeader("detected-language", "en"),
+                                new SimpleRecord.SimpleHeader("other-header", "bytearray-value".getBytes(StandardCharsets.UTF_8))))
                         .timestamp(System.currentTimeMillis())
                         .build();
 

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/SimpleRecord.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/SimpleRecord.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.api.runner.code;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Set;
 import lombok.AllArgsConstructor;
@@ -79,12 +80,12 @@ public final class SimpleRecord implements Record {
     @AllArgsConstructor
     public static class SimpleHeader implements Header {
 
-        public static SimpleHeader of(String key, String value) {
+        public static SimpleHeader of(String key, Object value) {
             return new SimpleHeader(key, value);
         }
 
         final String key;
-        final String value;
+        final Object value;
 
         @Override
         public String key() {
@@ -92,13 +93,19 @@ public final class SimpleRecord implements Record {
         }
 
         @Override
-        public String value() {
+        public Object value() {
             return value;
         }
 
         @Override
         public String valueAsString() {
-            return value;
+            if (value == null) {
+                return null;
+            } else if (value instanceof byte[] b) {
+                return new String(b, StandardCharsets.UTF_8);
+            } else {
+                return value.toString();
+            }
         }
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -111,7 +111,8 @@ public class AgentRunner {
             Path agentsDirectory,
             AgentInfo agentInfo,
             int maxLoops,
-            Runnable beforeStopSource)
+            Runnable beforeStopSource,
+            boolean startHttpServer)
             throws Exception {
         new AgentRunner()
                 .run(
@@ -121,7 +122,8 @@ public class AgentRunner {
                         agentsDirectory,
                         agentInfo,
                         maxLoops,
-                        beforeStopSource);
+                        beforeStopSource,
+                        startHttpServer);
     }
 
     public void run(
@@ -131,7 +133,8 @@ public class AgentRunner {
             Path agentsDirectory,
             AgentInfo agentInfo,
             int maxLoops,
-            Runnable beforeStopSource)
+            Runnable beforeStopSource,
+            boolean startHttpServer)
             throws Exception {
         log.info("Pod Configuration {}", configuration);
 
@@ -161,10 +164,10 @@ public class AgentRunner {
                 Server server = null;
                 try {
                     if (PythonCodeAgentProvider.isPythonCodeAgent(agentCode.agentCode())) {
-                        server = bootstrapHttpServer(null);
+                        server = startHttpServer ? bootstrapHttpServer(null) : null;
                         runPythonAgent(podRuntimeConfiguration, codeDirectory);
                     } else {
-                        server = bootstrapHttpServer(agentInfo);
+                        server = startHttpServer ? bootstrapHttpServer(agentInfo) : null;
                         runJavaAgent(
                                 configuration,
                                 maxLoops,

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
@@ -105,6 +105,7 @@ public class AgentRunnerStarter extends RuntimeStarter {
                 agentsDirectory,
                 new AgentInfo(),
                 -1,
-                null);
+                null,
+                true);
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -289,7 +289,8 @@ public abstract class AbstractApplicationRunner {
                                         agentsDirectory,
                                         agentInfo,
                                         10,
-                                        () -> validateAgentInfoBeforeStop(agentInfo));
+                                        () -> validateAgentInfoBeforeStop(agentInfo),
+                                        false);
                                 List<?> infos = agentInfo.serveWorkerStatus();
                                 log.info(
                                         "{} AgentPod {} AgentInfo {}",

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/TextProcessingAgentsRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/TextProcessingAgentsRunnerIT.java
@@ -19,7 +19,6 @@ import ai.langstream.AbstractApplicationRunner;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -97,17 +96,19 @@ class TextProcessingAgentsRunnerIT extends AbstractApplicationRunner {
     @ValueSource(booleans = {false, true})
     public void testSplitThenJson(boolean useIntermediateTopic) throws Exception {
         String tenant = "tenant";
-        String[] expectedAgents = useIntermediateTopic ?
-                new String[] {"app-step1", "app-step2"} : new String[] {"app-step1"};
-        String inputTopic = "input-topic-"+ UUID.randomUUID();
-        String outputTopic = "output-topic-"+ UUID.randomUUID();
-        String intermediateTopic = "intermediate-topic-"+ UUID.randomUUID();
+        String[] expectedAgents =
+                useIntermediateTopic
+                        ? new String[] {"app-step1", "app-step2"}
+                        : new String[] {"app-step1"};
+        String inputTopic = "input-topic-" + UUID.randomUUID();
+        String outputTopic = "output-topic-" + UUID.randomUUID();
+        String intermediateTopic = "intermediate-topic-" + UUID.randomUUID();
 
         Map<String, String> application =
                 Map.of(
                         "module.yaml",
-                        useIntermediateTopic ?
-                                """
+                        useIntermediateTopic
+                                ? """
                                 module: "module-1"
                                 id: "pipeline-1"
                                 topics:
@@ -136,8 +137,16 @@ class TextProcessingAgentsRunnerIT extends AbstractApplicationRunner {
                                     configuration:
                                         text-field: text
                                         copy-properties: true
-                                """.formatted(inputTopic, outputTopic, intermediateTopic, inputTopic, intermediateTopic, intermediateTopic, outputTopic)
-                        : """
+                                """
+                                        .formatted(
+                                                inputTopic,
+                                                outputTopic,
+                                                intermediateTopic,
+                                                inputTopic,
+                                                intermediateTopic,
+                                                intermediateTopic,
+                                                outputTopic)
+                                : """
                                 module: "module-1"
                                 id: "pipeline-1"
                                 topics:
@@ -161,13 +170,15 @@ class TextProcessingAgentsRunnerIT extends AbstractApplicationRunner {
                                     configuration:
                                         text-field: text
                                         copy-properties: true
-                                """.formatted(inputTopic, outputTopic, inputTopic, outputTopic));
+                                """
+                                        .formatted(
+                                                inputTopic, outputTopic, inputTopic, outputTopic));
 
         try (ApplicationRuntime applicationRuntime =
-                     deployApplication(
-                             tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
             try (KafkaProducer<String, String> producer = createProducer();
-                 KafkaConsumer<String, String> consumer = createConsumer(outputTopic)) {
+                    KafkaConsumer<String, String> consumer = createConsumer(outputTopic)) {
 
                 sendMessage(
                         inputTopic,

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/TextProcessingAgentsRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/TextProcessingAgentsRunnerIT.java
@@ -18,10 +18,14 @@ package ai.langstream.kafka;
 import ai.langstream.AbstractApplicationRunner;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Slf4j
 class TextProcessingAgentsRunnerIT extends AbstractApplicationRunner {
@@ -85,6 +89,98 @@ class TextProcessingAgentsRunnerIT extends AbstractApplicationRunner {
                                 "this text is written in english, but it is very",
                                 "long,",
                                 "so you may want to split it into chunks."));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testSplitThenJson(boolean useIntermediateTopic) throws Exception {
+        String tenant = "tenant";
+        String[] expectedAgents = useIntermediateTopic ?
+                new String[] {"app-step1", "app-step2"} : new String[] {"app-step1"};
+        String inputTopic = "input-topic-"+ UUID.randomUUID();
+        String outputTopic = "output-topic-"+ UUID.randomUUID();
+        String intermediateTopic = "intermediate-topic-"+ UUID.randomUUID();
+
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        useIntermediateTopic ?
+                                """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - name: "Split into chunks"
+                                    id: step1
+                                    type: "text-splitter"
+                                    input: %s
+                                    output: %s
+                                    configuration:
+                                      chunk_size: 50
+                                      chunk_overlap: 0
+                                      keep_separator: true
+                                      length_function: "length"
+                                  - name: "Convert chunks to JSON"
+                                    type: "document-to-json"
+                                    id: step2
+                                    input: %s
+                                    output: %s
+                                    configuration:
+                                        text-field: text
+                                        copy-properties: true
+                                """.formatted(inputTopic, outputTopic, intermediateTopic, inputTopic, intermediateTopic, intermediateTopic, outputTopic)
+                        : """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                  - name: "%s"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - name: "Split into chunks"
+                                    id: step1
+                                    type: "text-splitter"
+                                    input: %s
+                                    configuration:
+                                      chunk_size: 50
+                                      chunk_overlap: 0
+                                      keep_separator: true
+                                      length_function: "length"
+                                  - name: "Convert chunks to JSON"
+                                    type: "document-to-json"
+                                    output: %s
+                                    configuration:
+                                        text-field: text
+                                        copy-properties: true
+                                """.formatted(inputTopic, outputTopic, inputTopic, outputTopic));
+
+        try (ApplicationRuntime applicationRuntime =
+                     deployApplication(
+                             tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer();
+                 KafkaConsumer<String, String> consumer = createConsumer(outputTopic)) {
+
+                sendMessage(
+                        inputTopic,
+                        "This text is written in English, but it is very long,\nso you may want to split it into chunks.",
+                        producer);
+
+                executeAgentRunners(applicationRuntime);
+                waitForMessages(
+                        consumer,
+                        List.of(
+                                "{\"chunk_text_length\":\"47\",\"text\":\"This text is written in English, but it is very\",\"chunk_id\":\"0\",\"chunk_num_tokens\":\"47\"}",
+                                "{\"chunk_text_length\":\"5\",\"text\":\"long,\",\"chunk_id\":\"1\",\"chunk_num_tokens\":\"5\"}",
+                                "{\"chunk_text_length\":\"40\",\"text\":\"so you may want to split it into chunks.\",\"chunk_id\":\"2\",\"chunk_num_tokens\":\"40\"}"));
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
@@ -143,7 +143,8 @@ class PulsarRunnerDockerTest {
                     AbstractApplicationRunner.agentsDirectory,
                     new AgentInfo(),
                     5,
-                    null);
+                    null,
+                    false);
 
             // receive one message from the output-topic (written by the PodJavaRuntime)
             Message<byte[]> record = consumer.receive();

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
@@ -25,6 +25,8 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.eq;
+
 class AgentRunnerStarterTest {
 
     static ObjectMapper mapper = new ObjectMapper();
@@ -87,7 +89,8 @@ class AgentRunnerStarterTest {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.anyInt(),
-                        Mockito.any());
+                        Mockito.any(),
+                        eq(true));
     }
 
     static class TestDeployer extends AgentRunnerStarter {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.runtime.agent;
 
+import static org.mockito.ArgumentMatchers.eq;
+
 import ai.langstream.runtime.api.agent.AgentRunnerConstants;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,8 +26,6 @@ import java.util.Map;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import static org.mockito.ArgumentMatchers.eq;
 
 class AgentRunnerStarterTest {
 


### PR DESCRIPTION
Fixes #315


Summary:
- the problem is that when reading from a raw Kafka topic the headers are simple byte[], usually the document-to-json agent has always been used inside an in-memory pipeline after the "text-extractor" agent, that produces String headers (String java type)
- the fix is to convert byte[] and to try to keep the original type for other types (Strings, Numbers...)
