### PR TITLE
[agents] Chat Completion: allow to override the completion-field for the streaming response (streaming-response-completion-field)

### DIFF
--- a/examples/applications/openai-completions/pipeline.yaml
+++ b/examples/applications/openai-completions/pipeline.yaml
@@ -22,16 +22,33 @@ topics:
   - name: "history-topic"
     creation-mode: create-if-not-exists
 pipeline:
+  - name: "convert-to-json"
+    type: "document-to-json"
+    input: "input-topic"
+    configuration:
+      text-field: "question"
   - name: "ai-chat-completions"
     type: "ai-chat-completions"
-    input: "input-topic"
     output: "history-topic"
     configuration:
       model: "gpt-35-turbo" # This needs to be set to the model deployment name, not the base name
-      completion-field: "value"
-      stream-to-topic: "output-topic"
-      min-chunks-per-message: 5
+      # on the log-topic we add a field with the answer
+      completion-field: "value.answer"
+      # we are also logging the prompt we sent to the LLM
+      log-field: "value.prompt"
+      # here we configure the streaming behavior
+      # as soon as the LLM answers with a chunk we send it to the answers-topic
+      stream-to-topic: "answers-topic"
+      # on the streaming answer we send the answer as whole message
+      # the 'value' syntax is used to refer to the whole value of the message
+      stream-response-completion-field: "value"
+      # we want to stream the answer as soon as we have 20 chunks
+      # in order to reduce latency for the first message the agent sends the first message
+      # with 1 chunk, then with 2 chunks....up to the min-chunks-per-message value
+      # eventually we want to send bigger messages to reduce the overhead of each message on the topic
+      min-chunks-per-message: 20
+      # you can turn off the streaming behavior by setting this to false
       stream: true
       messages:
         - role: user
-          content: "You are an helpful assistant. Below you can fine a question from the user. Please try to help them the best way you can.\n\n{{% value}}"
+          content: "You are an helpful assistant. Below you can fine a question from the user. Please try to help them the best way you can.\n\n{{% value.question}}"

--- a/examples/applications/webcrawler-source/chatbot.yaml
+++ b/examples/applications/webcrawler-source/chatbot.yaml
@@ -48,8 +48,21 @@ pipeline:
 
     configuration:
       model: "gpt-35-turbo" # This needs to be set to the model deployment name, not the base name
+      # on the log-topic we add a field with the answer
       completion-field: "value.answer"
+      # we are also logging the prompt we sent to the LLM
       log-field: "value.prompt"
+      # here we configure the streaming behavior
+      # as soon as the LLM answers with a chunk we send it to the answers-topic
+      stream-to-topic: "answers-topic"
+      # on the streaming answer we send the answer as whole message
+      # the 'value' syntax is used to refer to the whole value of the message
+      stream-response-completion-field: "value"
+      # we want to stream the answer as soon as we have 20 chunks
+      # in order to reduce latency for the first message the agent sends the first message
+      # with 1 chunk, then with 2 chunks....up to the min-chunks-per-message value
+      # eventually we want to send bigger messages to reduce the overhead of each message on the topic
+      min-chunks-per-message: 20
       messages:
         - role: system
           content: |
@@ -67,12 +80,3 @@ pipeline:
       fields:
         - "question_embeddings"
         - "related_documents"
-  - name: "keep-only-the-answer"
-    type: "compute"
-    input: "log-topic"
-    output: "answers-topic"
-    configuration:
-      fields:
-        - name: "value"
-          expression: "value.answer"
-          type: STRING

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ChatCompletionsConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ChatCompletionsConfig.java
@@ -33,6 +33,9 @@ public class ChatCompletionsConfig extends StepConfig {
     @JsonProperty(value = "stream-to-topic")
     private String streamToTopic;
 
+    @JsonProperty(value = "stream-response-completion-field")
+    private String streamResponseCompletionField;
+
     @JsonProperty(value = "min-chunks-per-message")
     private int minChunksPerMessage = 20;
 

--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
@@ -250,6 +250,12 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
                                             newConfiguration,
                                             "min-chunks-per-message",
                                             null);
+                                    optionalField(
+                                            step,
+                                            agentConfiguration,
+                                            newConfiguration,
+                                            "stream-response-completion-field",
+                                            null);
                                     String streamTopic =
                                             optionalField(
                                                     step,


### PR DESCRIPTION
Motivation

Usually when you serve the answer to the end user you want to keep only the answer from the LLM but you still want to log the prompt and the answer in a structure.

Summary:
This patch introduces a new configuration option streaming-response-completion-field, that allows you to modify the contents of the streaming response independently of the main output of the agent.
Usually you are setting "streaming-response-completion-field" to "value", that means that you clear up the whole message and keep only the answer as text.
All the incoming message properties are kept, for instance a session-id or an user-id.

The patch changes the webcrawler and the openai-completions example applications with explanations for this feature


```
topics:
  - name: "input-topic"
    creation-mode: create-if-not-exists
  - name: "output-topic"
    creation-mode: create-if-not-exists
  - name: "history-topic"
    creation-mode: create-if-not-exists
pipeline:
  - name: "convert-to-json"
    type: "document-to-json"
    input: "input-topic"
    configuration:
      text-field: "question"
  - name: "ai-chat-completions"
    type: "ai-chat-completions"
    output: "history-topic"
    configuration:
      model: "gpt-35-turbo" # This needs to be set to the model deployment name, not the base name
      # on the log-topic we add a field with the answer
      completion-field: "value.answer"
      # we are also logging the prompt we sent to the LLM
      log-field: "value.prompt"
      # here we configure the streaming behavior
      # as soon as the LLM answers with a chunk we send it to the answers-topic
      stream-to-topic: "answers-topic"
      # on the streaming answer we send the answer as whole message
      # the 'value' syntax is used to refer to the whole value of the message
      stream-response-completion-field: "value"
      # we want to stream the answer as soon as we have 20 chunks
      # in order to reduce latency for the first message the agent sends the first message
      # with 1 chunk, then with 2 chunks....up to the min-chunks-per-message value
      # eventually we want to send bigger messages to reduce the overhead of each message on the topic
      min-chunks-per-message: 20
      # you can turn off the streaming behavior by setting this to false
      stream: true
      messages:
        - role: user
          content: "You are an helpful assistant. Below you can fine a question from the user. Please try to help them the best way you can.\n\n{{% value.question}}"
```