### PR TITLE
Read resource max units from tenant metadata

### DIFF
--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -30,6 +30,8 @@ public interface ApplicationStore extends GenericStore {
 
     void onTenantCreated(String tenant);
 
+    void onTenantUpdated(String tenant);
+
     void onTenantDeleted(String tenant);
 
     void put(

--- a/langstream-api/src/main/java/ai/langstream/api/storage/GlobalMetadataStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/GlobalMetadataStore.java
@@ -18,6 +18,7 @@ package ai.langstream.api.storage;
 import java.util.LinkedHashMap;
 
 public interface GlobalMetadataStore extends GenericStore {
+    String TENANT_KEY_PREFIX = "t-";
 
     void put(String key, String value);
 

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/CreateTenantRequest.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/CreateTenantRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.api.webservice.tenant;
 
 import lombok.AllArgsConstructor;

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/CreateTenantRequest.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/CreateTenantRequest.java
@@ -1,0 +1,15 @@
+package ai.langstream.api.webservice.tenant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateTenantRequest {
+
+    private Integer maxTotalResourceUnits;
+}

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/TenantConfiguration.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/TenantConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.api.model;
+package ai.langstream.api.webservice.tenant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,4 +26,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TenantConfiguration {
     private String name;
+    private int maxTotalResourceUnits;
 }

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/UpdateTenantRequest.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/UpdateTenantRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.api.webservice.tenant;
 
 import lombok.AllArgsConstructor;

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/UpdateTenantRequest.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/tenant/UpdateTenantRequest.java
@@ -1,0 +1,15 @@
+package ai.langstream.api.webservice.tenant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateTenantRequest {
+
+    private Integer maxTotalResourceUnits;
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -21,6 +21,7 @@ import ai.langstream.admin.client.AdminClientLogger;
 import ai.langstream.cli.LangStreamCLIConfig;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
@@ -52,6 +53,8 @@ public abstract class BaseCmd implements Runnable {
             new ObjectMapper(new YAMLFactory())
                     .enable(SerializationFeature.INDENT_OUTPUT)
                     .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+    protected static final ObjectWriter jsonBodyWriter = new ObjectMapper().writer();
 
     @CommandLine.Spec protected CommandLine.Model.CommandSpec command;
     private AdminClient client;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootTenantCmd.java
@@ -15,10 +15,12 @@
  */
 package ai.langstream.cli.commands;
 
+import ai.langstream.cli.commands.tenants.CreateTenantCmd;
 import ai.langstream.cli.commands.tenants.DeleteTenantCmd;
 import ai.langstream.cli.commands.tenants.GetTenantCmd;
 import ai.langstream.cli.commands.tenants.ListTenantCmd;
 import ai.langstream.cli.commands.tenants.PutTenantCmd;
+import ai.langstream.cli.commands.tenants.UpdateTenantCmd;
 import lombok.Getter;
 import picocli.CommandLine;
 
@@ -30,7 +32,9 @@ import picocli.CommandLine;
             PutTenantCmd.class,
             DeleteTenantCmd.class,
             ListTenantCmd.class,
-            GetTenantCmd.class
+            GetTenantCmd.class,
+            CreateTenantCmd.class,
+            UpdateTenantCmd.class
         })
 @Getter
 public class RootTenantCmd {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/CreateTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/CreateTenantCmd.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.tenants;
+
+import ai.langstream.api.webservice.tenant.CreateTenantRequest;
+import java.net.http.HttpRequest;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "create",
+        mixinStandardHelpOptions = true,
+        description = "Create a new tenant")
+public class CreateTenantCmd extends BaseTenantCmd {
+
+    @CommandLine.Parameters(description = "Name of the tenant")
+    private String name;
+
+    @CommandLine.Option(
+            names = {"--max-total-resource-units"},
+            description = "Max application's units for the tenant.")
+    private Integer maxUnits;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        final CreateTenantRequest request =
+                CreateTenantRequest.builder().maxTotalResourceUnits(maxUnits).build();
+        final String body = jsonBodyWriter.writeValueAsString(request);
+
+        final HttpRequest httpRequest =
+                getClient()
+                        .newPost(
+                                pathForTenant(name),
+                                "application/json",
+                                HttpRequest.BodyPublishers.ofString(body));
+        getClient().http(httpRequest);
+        log("tenant %s created".formatted(name));
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/UpdateTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/UpdateTenantCmd.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.tenants;
+
+import ai.langstream.api.webservice.tenant.UpdateTenantRequest;
+import java.net.http.HttpRequest;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "update",
+        mixinStandardHelpOptions = true,
+        description = "Update an existing tenant")
+public class UpdateTenantCmd extends BaseTenantCmd {
+
+    @CommandLine.Parameters(description = "Name of the tenant")
+    private String name;
+
+    @CommandLine.Option(
+            names = {"--max-total-resource-units"},
+            description = "Max application's units for the tenant.")
+    private Integer maxUnits;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        final UpdateTenantRequest request =
+                UpdateTenantRequest.builder().maxTotalResourceUnits(maxUnits).build();
+        final String body = jsonBodyWriter.writeValueAsString(request);
+
+        final HttpRequest httpRequest =
+                getClient()
+                        .newPatch(
+                                pathForTenant(name),
+                                "application/json",
+                                HttpRequest.BodyPublishers.ofString(body));
+        getClient().http(httpRequest);
+        log("tenant %s updated".formatted(name));
+    }
+}

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/TenantsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/TenantsCmdTest.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.cli.commands.applications;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,44 @@ class TenantsCmdTest extends CommandTestBase {
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
         Assertions.assertEquals("tenant newt created/updated", result.out());
+    }
+
+    @Test
+    public void testCreate() {
+        wireMock.register(
+                WireMock.post("/api/tenants/%s".formatted("newt"))
+                        .withRequestBody(WireMock.equalToJson("{\"maxTotalResourceUnits\":null}"))
+                        .willReturn(WireMock.ok("")));
+        CommandResult result = executeCommand("tenants", "create", "newt");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("tenant newt created", result.out());
+    }
+
+    @Test
+    public void testCreatemaxTotalResourceUnits() {
+        wireMock.register(
+                WireMock.post("/api/tenants/%s".formatted("newt"))
+                        .withRequestBody(WireMock.equalToJson("{\"maxTotalResourceUnits\":10}"))
+                        .willReturn(WireMock.ok("")));
+        CommandResult result =
+                executeCommand("tenants", "create", "newt", "--max-total-resource-units", "10");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("tenant newt created", result.out());
+    }
+
+    @Test
+    public void testUpdatemaxTotalResourceUnits() {
+        wireMock.register(
+                WireMock.patch(urlEqualTo("/api/tenants/%s".formatted("newt")))
+                        .withRequestBody(WireMock.equalToJson("{\"maxTotalResourceUnits\":10}"))
+                        .willReturn(WireMock.ok("")));
+        CommandResult result =
+                executeCommand("tenants", "update", "newt", "--max-total-resource-units", "10");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("tenant newt updated", result.out());
     }
 
     @Test

--- a/langstream-core/src/main/java/ai/langstream/impl/storage/GlobalMetadataStoreManager.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/storage/GlobalMetadataStoreManager.java
@@ -15,20 +15,27 @@
  */
 package ai.langstream.impl.storage;
 
-import ai.langstream.api.model.TenantConfiguration;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.api.storage.GlobalMetadataStore;
+import ai.langstream.api.webservice.tenant.CreateTenantRequest;
+import ai.langstream.api.webservice.tenant.TenantConfiguration;
+import ai.langstream.api.webservice.tenant.UpdateTenantRequest;
+import ai.langstream.impl.storage.tenants.TenantException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
+@Slf4j
 public class GlobalMetadataStoreManager {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
-    protected static final String TENANT_KEY_PREFIX = "t-";
+    private static final ObjectMapper mapper =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
     private final GlobalMetadataStore globalMetadataStore;
     private final ApplicationStore applicationStore;
 
@@ -41,10 +48,69 @@ public class GlobalMetadataStoreManager {
     }
 
     @SneakyThrows
+    public void createTenant(String tenant, CreateTenantRequest request) throws TenantException {
+        final String key = keyedTenantName(tenant);
+        if (globalMetadataStore.get(key) != null) {
+            throw new TenantException(
+                    "Tenant " + tenant + " already exists", TenantException.Type.AlreadyExists);
+        }
+        final TenantConfiguration configuration = createConfiguration(tenant, request);
+        log.info("Creating tenant {} with configuration {}", tenant, configuration);
+
+        globalMetadataStore.put(key, mapper.writeValueAsString(configuration));
+        applicationStore.onTenantCreated(tenant);
+    }
+
+    private TenantConfiguration createConfiguration(String tenant, CreateTenantRequest request) {
+        final TenantConfiguration.TenantConfigurationBuilder builder =
+                TenantConfiguration.builder().name(tenant);
+        final Integer maxTotalResourceUnits = request.getMaxTotalResourceUnits();
+        if (maxTotalResourceUnits != null && maxTotalResourceUnits < 0) {
+            throw new IllegalArgumentException("maxTotalResourceUnits must be positive");
+        }
+        builder.maxTotalResourceUnits(
+                maxTotalResourceUnits == null ? 0 : maxTotalResourceUnits.intValue());
+
+        final TenantConfiguration configuration = builder.build();
+        return configuration;
+    }
+
+    @SneakyThrows
+    public void updateTenant(String tenant, UpdateTenantRequest request) throws TenantException {
+        final String key = keyedTenantName(tenant);
+        final String before = globalMetadataStore.get(key);
+        if (before == null) {
+            throw new TenantException(
+                    "Tenant " + tenant + " not found", TenantException.Type.NotFound);
+        }
+        final TenantConfiguration mergeConfig = mapper.readValue(before, TenantConfiguration.class);
+        mergeConfiguration(request, mergeConfig);
+
+        log.info("Updating tenant {} with configuration {}", tenant, mergeConfig);
+
+        globalMetadataStore.put(key, mapper.writeValueAsString(mergeConfig));
+        applicationStore.onTenantUpdated(tenant);
+    }
+
+    private void mergeConfiguration(UpdateTenantRequest request, TenantConfiguration mergeConfig) {
+        final Integer maxTotalResourceUnits = request.getMaxTotalResourceUnits();
+        if (maxTotalResourceUnits != null && maxTotalResourceUnits < 0) {
+            throw new IllegalArgumentException("maxTotalResourceUnits must be positive");
+        }
+        mergeConfig.setMaxTotalResourceUnits(
+                maxTotalResourceUnits != null ? maxTotalResourceUnits : 0);
+    }
+
+    @SneakyThrows
     public void putTenant(String tenant, TenantConfiguration tenantConfiguration) {
         final String key = keyedTenantName(tenant);
+        final String before = globalMetadataStore.get(key);
         globalMetadataStore.put(key, mapper.writeValueAsString(tenantConfiguration));
-        applicationStore.onTenantCreated(tenant);
+        if (before != null) {
+            applicationStore.onTenantUpdated(tenant);
+        } else {
+            applicationStore.onTenantCreated(tenant);
+        }
     }
 
     public TenantConfiguration getTenant(String tenant) {
@@ -71,14 +137,18 @@ public class GlobalMetadataStoreManager {
     @SneakyThrows
     public Map<String, TenantConfiguration> listTenants() {
         return globalMetadataStore.list().entrySet().stream()
-                .filter(e -> e.getKey().startsWith(TENANT_KEY_PREFIX))
+                .filter(e -> e.getKey().startsWith(GlobalMetadataStore.TENANT_KEY_PREFIX))
                 .collect(
                         Collectors.toMap(
-                                e -> e.getKey().substring(TENANT_KEY_PREFIX.length()),
+                                e ->
+                                        e.getKey()
+                                                .substring(
+                                                        GlobalMetadataStore.TENANT_KEY_PREFIX
+                                                                .length()),
                                 e -> parseTenantConfiguration(e.getValue())));
     }
 
-    private static String keyedTenantName(String tenant) {
-        return TENANT_KEY_PREFIX + tenant;
+    public static String keyedTenantName(String tenant) {
+        return GlobalMetadataStore.TENANT_KEY_PREFIX + tenant;
     }
 }

--- a/langstream-core/src/main/java/ai/langstream/impl/storage/tenants/TenantException.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/storage/tenants/TenantException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.impl.storage.tenants;
 
 import lombok.Getter;

--- a/langstream-core/src/main/java/ai/langstream/impl/storage/tenants/TenantException.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/storage/tenants/TenantException.java
@@ -1,0 +1,18 @@
+package ai.langstream.impl.storage.tenants;
+
+import lombok.Getter;
+
+public class TenantException extends Exception {
+
+    public enum Type {
+        NotFound,
+        AlreadyExists;
+    }
+
+    @Getter private final Type type;
+
+    public TenantException(String message, Type type) {
+        super(message);
+        this.type = type;
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/pom.xml
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/pom.xml
@@ -34,10 +34,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
-    </dependency>
-    <dependency>
       <groupId>ai.langstream</groupId>
       <artifactId>langstream-api</artifactId>
       <version>${project.version}</version>

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/pom.xml
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/pom.xml
@@ -33,6 +33,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-k8s-deployer-api</artifactId>
       <version>${project.version}</version>

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/PodTemplate.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/PodTemplate.java
@@ -24,7 +24,7 @@ public record PodTemplate(
         Map<String, String> nodeSelector,
         Map<String, String> annotations) {
 
-    static PodTemplate merge(PodTemplate primary, PodTemplate secondary) {
+    public static PodTemplate merge(PodTemplate primary, PodTemplate secondary) {
         return new PodTemplate(
                 merge(primary.tolerations(), secondary.tolerations()),
                 merge(primary.nodeSelector(), secondary.nodeSelector()),

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
@@ -31,5 +31,5 @@ public class AgentResourceUnitConfiguration {
     private int maxCpuMemUnits = 8;
     private int maxInstanceUnits = 8;
 
-    private int defaultMaxUnitsPerTenant = 0;
+    private int defaultMaxTotalResourceUnitsPerTenant = 0;
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/pom.xml
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/pom.xml
@@ -41,6 +41,16 @@
       <artifactId>langstream-k8s-deployer-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-k8s-storage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
 
     <dependency>
@@ -90,6 +100,25 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kubernetes-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-k8s-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-k8s-common</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/DeployerConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/DeployerConfiguration.java
@@ -22,6 +22,9 @@ import java.util.Optional;
 @ConfigMapping(prefix = "deployer")
 public interface DeployerConfiguration {
 
+    @WithDefault("{}")
+    String globalStorage();
+
     // workaround: quarkus doesn't support dynamic maps
     @WithDefault("{}")
     String clusterRuntime();

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/GlobalStorageConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/GlobalStorageConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.deployer.k8s;
 
 import java.util.HashMap;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/GlobalStorageConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/GlobalStorageConfiguration.java
@@ -1,0 +1,16 @@
+package ai.langstream.deployer.k8s;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GlobalStorageConfiguration {
+
+    private String type;
+    private Map<String, Object> configuration = new HashMap<>();
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
@@ -22,12 +22,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Singleton;
 import java.util.Map;
 import lombok.Getter;
 import lombok.SneakyThrows;
 
-@ApplicationScoped
+@Singleton
 public class ResolvedDeployerConfiguration {
 
     private static final ObjectMapper yamlMapper =
@@ -62,6 +62,9 @@ public class ResolvedDeployerConfiguration {
 
         this.runtimeImage = configuration.runtimeImage().orElse(null);
         this.runtimeImagePullPolicy = configuration.runtimeImagePullPolicy().orElse(null);
+        this.globalStorageConfiguration =
+                yamlMapper.readValue(
+                        configuration.globalStorage(), GlobalStorageConfiguration.class);
     }
 
     @Getter private Map<String, Object> clusterRuntime;
@@ -75,4 +78,6 @@ public class ResolvedDeployerConfiguration {
     @Getter private String runtimeImage;
 
     @Getter private String runtimeImagePullPolicy;
+
+    @Getter private GlobalStorageConfiguration globalStorageConfiguration;
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantsConfigurationReader.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantsConfigurationReader.java
@@ -19,7 +19,7 @@ public class TenantsConfigurationReader {
     public TenantsConfigurationReader(ResolvedDeployerConfiguration resolvedDeployerConfiguration) {
         final GlobalStorageConfiguration configuration =
                 resolvedDeployerConfiguration.getGlobalStorageConfiguration();
-        if (configuration == null) {
+        if (configuration == null || configuration.getType() == null) {
             log.warnf("No global storage configuration found. Tenants metadata won't be used.");
             this.globalMetadataStore = null;
         } else {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantsConfigurationReader.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantsConfigurationReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.deployer.k8s;
 
 import ai.langstream.api.storage.GlobalMetadataStore;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantsConfigurationReader.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/TenantsConfigurationReader.java
@@ -1,0 +1,48 @@
+package ai.langstream.deployer.k8s;
+
+import ai.langstream.api.storage.GlobalMetadataStore;
+import ai.langstream.api.storage.GlobalMetadataStoreRegistry;
+import ai.langstream.api.webservice.tenant.TenantConfiguration;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.SneakyThrows;
+import lombok.extern.jbosslog.JBossLog;
+
+@ApplicationScoped
+@JBossLog
+public class TenantsConfigurationReader {
+    private static final ObjectMapper mapper =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private final GlobalMetadataStore globalMetadataStore;
+
+    public TenantsConfigurationReader(ResolvedDeployerConfiguration resolvedDeployerConfiguration) {
+        final GlobalStorageConfiguration configuration =
+                resolvedDeployerConfiguration.getGlobalStorageConfiguration();
+        if (configuration == null) {
+            log.warnf("No global storage configuration found. Tenants metadata won't be used.");
+            this.globalMetadataStore = null;
+        } else {
+            this.globalMetadataStore =
+                    GlobalMetadataStoreRegistry.loadStore(
+                            configuration.getType(), configuration.getConfiguration());
+        }
+    }
+
+    public TenantConfiguration getTenantConfiguration(String tenant) {
+        if (globalMetadataStore == null) {
+            return null;
+        }
+        final String config =
+                globalMetadataStore.get(GlobalMetadataStore.TENANT_KEY_PREFIX + tenant);
+        if (config == null) {
+            return null;
+        }
+        return parseTenantConfiguration(config);
+    }
+
+    @SneakyThrows
+    private TenantConfiguration parseTenantConfiguration(String res) {
+        return mapper.readValue(res, TenantConfiguration.class);
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/TenantLimitsCheckerTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/TenantLimitsCheckerTest.java
@@ -1,0 +1,64 @@
+package ai.langstream.deployer.k8s;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@WithKubernetesTestServer
+@TestProfile(TenantLimitsCheckerTest.MyTestProfile.class)
+class TenantLimitsCheckerTest {
+
+    @KubernetesTestServer KubernetesServer mockServer;
+
+    public static class MyTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "deployer.agent-resources", "{\"defaultMaxTotalResourceUnitsPerTenant\":10}",
+                    "deployer.global-storage",
+                    "{\"type\":\"kubernetes\",\"configuration\":{\"namespace\":\"default\"}}");
+        }
+    }
+
+    @Inject TenantLimitsChecker checker;
+
+    @BeforeEach
+    public void before() {
+        mockServer.getKubernetesMockServer()
+                .expect()
+                .get()
+                .withPath("/api/v1/namespaces/default/configmaps/langstream-t-my-tenant")
+                .andReturn(200, new ConfigMapBuilder()
+                        .withData(Map.of("value", "{\"maxTotalResourceUnits\":20}"))
+                        .build()
+                ).always();
+
+        mockServer.getKubernetesMockServer()
+                .expect()
+                .get()
+                .withPath("/api/v1/namespaces/default/configmaps/langstream-t-my-tenant3")
+                .andReturn(200, new ConfigMapBuilder()
+                        .withData(Map.of("value", "{\"maxTotalResourceUnits\":0}"))
+                        .build()
+                ).always();
+    }
+
+    @Test
+    void testLimitsSupplier() {
+        final TenantLimitsChecker.LimitsSupplier supplier = checker.getLimitsSupplier();
+        Assertions.assertEquals(10, supplier.apply("my-tenant2"));
+        Assertions.assertEquals(10, supplier.apply("my-tenant3"));
+        Assertions.assertEquals(20, supplier.apply("my-tenant"));
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/TenantLimitsCheckerTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/TenantLimitsCheckerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.deployer.k8s;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/TenantLimitsCheckerTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/TenantLimitsCheckerTest.java
@@ -25,7 +25,8 @@ class TenantLimitsCheckerTest {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
-                    "deployer.agent-resources", "{\"defaultMaxTotalResourceUnitsPerTenant\":10}",
+                    "deployer.agent-resources",
+                    "{\"defaultMaxTotalResourceUnitsPerTenant\":10}",
                     "deployer.global-storage",
                     "{\"type\":\"kubernetes\",\"configuration\":{\"namespace\":\"default\"}}");
         }
@@ -35,23 +36,29 @@ class TenantLimitsCheckerTest {
 
     @BeforeEach
     public void before() {
-        mockServer.getKubernetesMockServer()
+        mockServer
+                .getKubernetesMockServer()
                 .expect()
                 .get()
                 .withPath("/api/v1/namespaces/default/configmaps/langstream-t-my-tenant")
-                .andReturn(200, new ConfigMapBuilder()
-                        .withData(Map.of("value", "{\"maxTotalResourceUnits\":20}"))
-                        .build()
-                ).always();
+                .andReturn(
+                        200,
+                        new ConfigMapBuilder()
+                                .withData(Map.of("value", "{\"maxTotalResourceUnits\":20}"))
+                                .build())
+                .always();
 
-        mockServer.getKubernetesMockServer()
+        mockServer
+                .getKubernetesMockServer()
                 .expect()
                 .get()
                 .withPath("/api/v1/namespaces/default/configmaps/langstream-t-my-tenant3")
-                .andReturn(200, new ConfigMapBuilder()
-                        .withData(Map.of("value", "{\"maxTotalResourceUnits\":0}"))
-                        .build()
-                ).always();
+                .andReturn(
+                        200,
+                        new ConfigMapBuilder()
+                                .withData(Map.of("value", "{\"maxTotalResourceUnits\":0}"))
+                                .build())
+                .always();
     }
 
     @Test

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -43,7 +43,8 @@ public class AppControllerIT {
     static final OperatorExtension deployment =
             new OperatorExtension(
                     Map.of(
-                            "DEPLOYER_AGENT_RESOURCES", "{defaultMaxUnitsPerTenant: 3}",
+                            "DEPLOYER_AGENT_RESOURCES",
+                                    "{defaultMaxTotalResourceUnitsPerTenant: 3}",
                             "DEPLOYER_RUNTIME_IMAGE", "busybox",
                             "DEPLOYER_RUNTIME_IMAGE_PULL_POLICY", "IfNotPresent"));
 

--- a/langstream-k8s-deployer/pom.xml
+++ b/langstream-k8s-deployer/pom.xml
@@ -37,6 +37,8 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <quarkus-operator-sdk-bom.version>6.2.1</quarkus-operator-sdk-bom.version>
+    <!--    override global okhttp3 v4 with v3, used by the k8s client -->
+    <okhttp.version>3.14.9</okhttp.version>
     <jsonassert.version>1.5.1</jsonassert.version>
   </properties>
 
@@ -53,6 +55,21 @@
         <groupId>org.skyscreamer</groupId>
         <artifactId>jsonassert</artifactId>
         <version>${jsonassert.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>logging-interceptor</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${okhttp.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
+++ b/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
@@ -90,6 +90,9 @@ public class KubernetesApplicationStore implements ApplicationStore {
     }
 
     @Override
+    public void onTenantUpdated(String tenant) {}
+
+    @Override
     public void onTenantDeleted(String tenant) {
         final String namespace = tenantToNamespace(tenant);
         if (client.namespaces().withName(namespace).get() != null) {

--- a/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
+++ b/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
@@ -52,7 +52,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 public class KubernetesApplicationStore implements ApplicationStore {
@@ -206,7 +205,6 @@ public class KubernetesApplicationStore implements ApplicationStore {
         return null;
     }
 
-    @Nullable
     private ApplicationCustomResource getApplicationCustomResource(
             String tenant, String applicationId) {
         final String namespace = tenantToNamespace(tenant);

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -495,7 +495,7 @@
                   <type>nar</type>
                   <classifier>nar</classifier>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
                 </artifactItem>
 
                 <artifactItem>
@@ -505,7 +505,7 @@
                     <type>nar</type>
                     <classifier>nar</classifier>
                     <overWrite>false</overWrite>
-                    <outputDirectory>${build.directory}/agents</outputDirectory>
+                    <outputDirectory>${project.build.directory}/agents</outputDirectory>
                 </artifactItem>
 
                 <artifactItem>
@@ -515,7 +515,7 @@
                   <type>nar</type>
                   <classifier>nar</classifier>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
                 </artifactItem>
 
                 <artifactItem>
@@ -525,7 +525,7 @@
                   <type>nar</type>
                   <classifier>nar</classifier>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
                 </artifactItem>
 
                 <artifactItem>
@@ -535,7 +535,7 @@
                   <type>nar</type>
                   <classifier>nar</classifier>
                   <overWrite>false</overWrite>
-                  <outputDirectory>${build.directory}/agents</outputDirectory>
+                  <outputDirectory>${project.build.directory}/agents</outputDirectory>
                 </artifactItem>
 
               </artifactItems>

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/LangStreamEventListener.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/LangStreamEventListener.java
@@ -15,7 +15,7 @@
  */
 package ai.langstream.webservice;
 
-import ai.langstream.api.model.TenantConfiguration;
+import ai.langstream.api.webservice.tenant.TenantConfiguration;
 import ai.langstream.webservice.common.GlobalMetadataService;
 import ai.langstream.webservice.config.TenantProperties;
 import lombok.AllArgsConstructor;

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/common/GlobalMetadataService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/common/GlobalMetadataService.java
@@ -36,7 +36,9 @@ public class GlobalMetadataService {
     private final TenantProperties tenantProperties;
 
     public GlobalMetadataService(
-            StorageProperties storageProperties, ApplicationStore applicationStore, TenantProperties tenantProperties) {
+            StorageProperties storageProperties,
+            ApplicationStore applicationStore,
+            TenantProperties tenantProperties) {
         final GlobalMetadataStore globalMetadataStore =
                 GlobalMetadataStoreRegistry.loadStore(
                         storageProperties.getGlobal().getType(),
@@ -64,7 +66,8 @@ public class GlobalMetadataService {
                 && maxTotalResourceUnits > 0
                 && maxTotalResourceUnits > tenantProperties.getMaxTotalResourceUnitsLimit()) {
             throw new IllegalArgumentException(
-                    "Max total resource units limit is " + tenantProperties.getMaxTotalResourceUnitsLimit());
+                    "Max total resource units limit is "
+                            + tenantProperties.getMaxTotalResourceUnitsLimit());
         }
     }
 

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/common/ResourceErrorsHandler.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/common/ResourceErrorsHandler.java
@@ -38,7 +38,6 @@ public class ResourceErrorsHandler {
             log.error("Bad request", exception);
             return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.getMessage());
         }
-
         log.error("Internal error", exception);
         return ProblemDetail.forStatusAndDetail(
                 HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/config/TenantProperties.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/config/TenantProperties.java
@@ -36,5 +36,6 @@ public class TenantProperties {
     }
 
     private DefaultTenantProperties defaultTenant;
-    private int defaultMaxUnitsPerTenant;
+    private int defaultMaxTotalResourceUnits;
+    private int maxTotalResourceUnitsLimit;
 }

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/LocalKubernetesJwksUriSigningKeyResolver.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/LocalKubernetesJwksUriSigningKeyResolver.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
-
 @Slf4j
 public class LocalKubernetesJwksUriSigningKeyResolver {
 

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/LocalKubernetesJwksUriSigningKeyResolver.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/security/infrastructure/primary/LocalKubernetesJwksUriSigningKeyResolver.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.Nullable;
+
 
 @Slf4j
 public class LocalKubernetesJwksUriSigningKeyResolver {
@@ -108,7 +108,6 @@ public class LocalKubernetesJwksUriSigningKeyResolver {
         return kubeOpenIDUrl;
     }
 
-    @Nullable
     private JwksUriSigningKeyResolver.JwksUri getJwksUri(String kubeOpenIDUrl) {
         try {
             final Map<String, ?> response =

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/WebAppTestConfig.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/WebAppTestConfig.java
@@ -40,7 +40,6 @@ public class WebAppTestConfig {
                                         .toFile()
                                         .getAbsolutePath())),
                 new StorageProperties.CodeStorageProperties());
-
     }
 
     @Bean

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/WebAppTestConfig.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/WebAppTestConfig.java
@@ -27,10 +27,8 @@ import org.springframework.context.annotation.Primary;
 @TestConfiguration
 public class WebAppTestConfig {
 
-    @Bean
-    @Primary
     @SneakyThrows
-    public StorageProperties storageProperties() {
+    public static StorageProperties buildStorageProperties() {
         return new StorageProperties(
                 new StorageProperties.AppsStoreProperties(
                         "kubernetes", Map.of("namespaceprefix", "langstream-")),
@@ -42,5 +40,13 @@ public class WebAppTestConfig {
                                         .toFile()
                                         .getAbsolutePath())),
                 new StorageProperties.CodeStorageProperties());
+
+    }
+
+    @Bean
+    @Primary
+    @SneakyThrows
+    public StorageProperties storageProperties() {
+        return buildStorageProperties();
     }
 }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
@@ -21,7 +21,6 @@ import ai.langstream.api.model.Secrets;
 import ai.langstream.api.model.StoredApplication;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.storage.ApplicationStore;
-import ai.langstream.api.webservice.tenant.CreateTenantRequest;
 import ai.langstream.api.webservice.tenant.TenantConfiguration;
 import ai.langstream.api.webservice.tenant.UpdateTenantRequest;
 import ai.langstream.impl.k8s.tests.KubeTestServer;
@@ -44,9 +43,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @Slf4j
 class ApplicationServiceResourceLimitTest {
 
-    @RegisterExtension
-    static final KubeTestServer k3s = new KubeTestServer();
-    protected static final StorageProperties STORAGE_PROPERTIES = WebAppTestConfig.buildStorageProperties();
+    @RegisterExtension static final KubeTestServer k3s = new KubeTestServer();
+    protected static final StorageProperties STORAGE_PROPERTIES =
+            WebAppTestConfig.buildStorageProperties();
 
     @Test
     void test() {
@@ -154,8 +153,13 @@ class ApplicationServiceResourceLimitTest {
 
     @SneakyThrows
     private void putTenantLimit(int limit) {
-        new GlobalMetadataService(STORAGE_PROPERTIES, new TestApplicationStore(Map.of()), new TenantProperties())
-                .updateTenant("tenant", UpdateTenantRequest.builder().maxTotalResourceUnits(limit).build());
+        new GlobalMetadataService(
+                        STORAGE_PROPERTIES,
+                        new TestApplicationStore(Map.of()),
+                        new TenantProperties())
+                .updateTenant(
+                        "tenant",
+                        UpdateTenantRequest.builder().maxTotalResourceUnits(limit).build());
     }
 
     @NotNull
@@ -177,18 +181,13 @@ class ApplicationServiceResourceLimitTest {
         private final Map<String, Integer> currentUsage;
 
         @Override
-        public void onTenantCreated(String tenant) {
-
-        }
+        public void onTenantCreated(String tenant) {}
 
         @Override
-        public void onTenantDeleted(String tenant) {
-
-        }
+        public void onTenantDeleted(String tenant) {}
 
         @Override
-        public void onTenantUpdated(String tenant) {
-        }
+        public void onTenantUpdated(String tenant) {}
 
         @Override
         public void put(

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/TenantResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/TenantResourceTest.java
@@ -35,10 +35,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(
-        properties = {
-                "application.tenants.max-total-resource-units-limit=8"
-        })
+@SpringBootTest(properties = {"application.tenants.max-total-resource-units-limit=8"})
 @AutoConfigureMockMvc
 @Slf4j
 @Import(WebAppTestConfig.class)

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <json-schema-validator.version>1.0.72</json-schema-validator.version>
     <tomcat-embed-el.version>10.1.4</tomcat-embed-el.version>
     <commons-collections4.version>4.4</commons-collections4.version>
-    <okhttp.version>3.14.9</okhttp.version>
+    <okhttp.version>3.12.13</okhttp.version>
   </properties>
 
   <scm>
@@ -313,17 +313,6 @@
         <version>${kubernetes-client.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp-bom</artifactId>
-        <version>${okhttp.version}</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>${okhttp.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bouncy-castle.version}</version>
@@ -407,6 +396,21 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
         <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>logging-interceptor</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${okhttp.version}</version>
       </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,8 @@
     <json-schema-validator.version>1.0.72</json-schema-validator.version>
     <tomcat-embed-el.version>10.1.4</tomcat-embed-el.version>
     <commons-collections4.version>4.4</commons-collections4.version>
-    <okhttp.version>3.12.13</okhttp.version>
+<!--    minio requires okhttp3 v4-->
+    <okhttp.version>4.11.0</okhttp.version>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <json-schema-validator.version>1.0.72</json-schema-validator.version>
     <tomcat-embed-el.version>10.1.4</tomcat-embed-el.version>
     <commons-collections4.version>4.4</commons-collections4.version>
+    <okhttp.version>3.14.9</okhttp.version>
   </properties>
 
   <scm>
@@ -310,6 +311,17 @@
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-server-mock</artifactId>
         <version>${kubernetes-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp-bom</artifactId>
+        <version>${okhttp.version}</version>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${okhttp.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
* Changed config properties (control plane) `defaultMaxTotalResourceUnits` and `defaultMaxTotalResourceUnitsPerTenant`
* Both the service gets the tenant metadata and check if there's a custom value for that tenant
* Now the deployer uses the global metadata store to get the tenant metadata - an alternative would be to pass to the control plane but it's better to not create service dependencies. So now it requires the metadata storage configuration. If not set, there's a WARN in the log saying that the tenant limit will not be checked (to handle backw compatiblity)
  