### PR TITLE
Agent pods: set resource limits

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
@@ -425,15 +425,15 @@ public class AgentResourcesFactory {
                                     agentResourceUnitConfiguration.getMaxInstanceUnits()));
         }
 
-        final Map<String, Quantity> requests = new HashMap<>();
-        requests.put(
+        final Map<String, Quantity> quantities = new HashMap<>();
+        quantities.put(
                 "cpu",
                 Quantity.parse(
                         "%f"
                                 .formatted(
                                         memCpuUnits
                                                 * agentResourceUnitConfiguration.getCpuPerUnit())));
-        requests.put(
+        quantities.put(
                 "memory",
                 Quantity.parse(
                         "%dM"
@@ -441,7 +441,10 @@ public class AgentResourcesFactory {
                                         memCpuUnits
                                                 * agentResourceUnitConfiguration.getMemPerUnit())));
 
-        return new ResourceRequirementsBuilder().withRequests(requests).build();
+        return new ResourceRequirementsBuilder()
+                .withRequests(quantities)
+                .withLimits(quantities)
+                .build();
     }
 
     public static Map<String, String> getAgentLabels(String agentId, String applicationId) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
@@ -184,6 +184,9 @@ public class KubeUtil {
             if (state.getTerminated().getMessage() != null) {
                 return new PodStatus(
                         PodStatus.State.ERROR, state.getTerminated().getMessage(), null);
+            } else if (state.getTerminated().getReason() != null) {
+                return new PodStatus(
+                        PodStatus.State.ERROR, state.getTerminated().getReason(), null);
             } else {
                 return new PodStatus(PodStatus.State.ERROR, "Unknown error", null);
             }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentCustomResourceTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentCustomResourceTest.java
@@ -23,13 +23,16 @@ import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
 import ai.langstream.impl.k8s.tests.KubeK3sServer;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -37,7 +40,8 @@ import org.mockito.Mockito;
 
 class AgentCustomResourceTest {
 
-    @RegisterExtension static final KubeK3sServer k3s = new KubeK3sServer(true);
+    @RegisterExtension
+    static final KubeK3sServer k3s = new KubeK3sServer(true);
 
     @Test
     void testAggregatePodStatus() {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentCustomResourceTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentCustomResourceTest.java
@@ -23,16 +23,13 @@ import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
 import ai.langstream.impl.k8s.tests.KubeK3sServer;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
-import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -40,8 +37,7 @@ import org.mockito.Mockito;
 
 class AgentCustomResourceTest {
 
-    @RegisterExtension
-    static final KubeK3sServer k3s = new KubeK3sServer(true);
+    @RegisterExtension static final KubeK3sServer k3s = new KubeK3sServer(true);
 
     @Test
     void testAggregatePodStatus() {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -111,6 +111,9 @@ class AgentResourcesFactoryTest {
                                   name: http
                                   protocol: TCP
                                 resources:
+                                  limits:
+                                    cpu: 0.500000
+                                    memory: 256M
                                   requests:
                                     cpu: 0.500000
                                     memory: 256M

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/util/KubeUtilTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/util/KubeUtilTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.deployer.k8s.util;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/util/KubeUtilTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/util/KubeUtilTest.java
@@ -1,0 +1,78 @@
+package ai.langstream.deployer.k8s.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import io.fabric8.kubernetes.api.model.Pod;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class KubeUtilTest {
+
+    @Test
+    public void testOOMKilled() {
+        String podYaml = """
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: pod1
+                  namespace: langstream-default
+                spec: {subdomain: pod1-s}
+                status:
+                  containerStatuses:
+                  - containerID: docker://7b159d3eca344ef7ed43e31894735fac42e7ee629e0186818074417cf8948165
+                    image: xx
+                    imageID: xx
+                    lastState:
+                      terminated:
+                        containerID: docker://7b159d3eca344ef7ed43e31894735fac42e7ee629e0186818074417cf8948165
+                        exitCode: 137
+                        finishedAt: "2023-09-01T17:50:43Z"
+                        reason: OOMKilled
+                        startedAt: "2023-09-01T17:50:39Z"
+                    name: runtime
+                    ready: false
+                    restartCount: 8
+                    started: false
+                    state:
+                      waiting:
+                        message: back-off 5m0s restarting failed container=runtime pod=test-pipeline-python-function-1-0_langstream-default(a8333379-efc3-406f-a6e4-d2faeadf56bd)
+                        reason: CrashLoopBackOff
+                  initContainerStatuses:
+                  - containerID: docker://efd511fb2a9f17e39dde67fb34e38fc2fba28b973acad74509ae212d804e54f0
+                    image: xx
+                    imageID: xxxx
+                    lastState: {}
+                    name: code-download-init
+                    ready: true
+                    restartCount: 0
+                    state:
+                      terminated:
+                        containerID: docker://efd511fb2a9f17e39dde67fb34e38fc2fba28b973acad74509ae212d804e54f0
+                        exitCode: 0
+                        finishedAt: "2023-09-01T17:34:23Z"
+                        reason: Completed
+                        startedAt: "2023-09-01T17:34:23Z"
+                  - containerID: docker://cdf904ea4094c4e46142f83f8fe762e569ac28b46d62a11ccd75c647ce019cfa
+                    image: xxx
+                    imageID: xxx
+                    lastState: {}
+                    name: code-download
+                    ready: true
+                    restartCount: 0
+                    state:
+                      terminated:
+                        containerID: docker://cdf904ea4094c4e46142f83f8fe762e569ac28b46d62a11ccd75c647ce019cfa
+                        exitCode: 0
+                        finishedAt: "2023-09-01T17:34:25Z"
+                        reason: Completed
+                        startedAt: "2023-09-01T17:34:23Z"
+                  phase: Running
+                """;
+
+        final Pod pod = SerializationUtil.readYaml(podYaml, Pod.class);
+        final KubeUtil.PodStatus status = KubeUtil.getPodsStatuses(List.of(pod)).get("pod1");
+        assertEquals("http://pod1.pod1-s.langstream-default.svc.cluster.local:8080", status.getUrl());
+        assertEquals(KubeUtil.PodStatus.State.ERROR, status.getState());
+        assertEquals("OOMKilled", status.getMessage());
+    }
+
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/util/KubeUtilTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/util/KubeUtilTest.java
@@ -1,6 +1,7 @@
 package ai.langstream.deployer.k8s.util;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import io.fabric8.kubernetes.api.model.Pod;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,8 @@ class KubeUtilTest {
 
     @Test
     public void testOOMKilled() {
-        String podYaml = """
+        String podYaml =
+                """
                 apiVersion: v1
                 kind: Pod
                 metadata:
@@ -70,9 +72,9 @@ class KubeUtilTest {
 
         final Pod pod = SerializationUtil.readYaml(podYaml, Pod.class);
         final KubeUtil.PodStatus status = KubeUtil.getPodsStatuses(List.of(pod)).get("pod1");
-        assertEquals("http://pod1.pod1-s.langstream-default.svc.cluster.local:8080", status.getUrl());
+        assertEquals(
+                "http://pod1.pod1-s.langstream-default.svc.cluster.local:8080", status.getUrl());
         assertEquals(KubeUtil.PodStatus.State.ERROR, status.getState());
         assertEquals("OOMKilled", status.getMessage());
     }
-
 }


### PR DESCRIPTION
* Set resource limits with the same value of the requests to ensure the agent code doesn't use more resources than the 
* Ensure in case of OOMKilled the error is reported to the user

Fixes: #313