### PR TITLE
Add retries on admin http client

### DIFF
--- a/langstream-admin-client/pom.xml
+++ b/langstream-admin-client/pom.xml
@@ -26,8 +26,6 @@
 
   <artifactId>langstream-admin-client</artifactId>
 
-
-
   <dependencies>
     <dependency>
       <groupId>net.lingala.zip4j</groupId>
@@ -36,6 +34,15 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -17,7 +17,6 @@ package ai.langstream.admin.client;
 
 import ai.langstream.admin.client.http.HttpClientProperties;
 import ai.langstream.admin.client.http.Retry;
-import ai.langstream.admin.client.http.RetryPolicy;
 import ai.langstream.admin.client.model.Applications;
 import ai.langstream.admin.client.util.MultiPartBodyPublisher;
 import java.io.IOException;
@@ -48,7 +47,9 @@ public class AdminClient implements AutoCloseable {
     }
 
     public AdminClient(
-            AdminClientConfiguration adminClientConfiguration, AdminClientLogger logger, HttpClientProperties httpClientProperties) {
+            AdminClientConfiguration adminClientConfiguration,
+            AdminClientLogger logger,
+            HttpClientProperties httpClientProperties) {
         this.configuration = adminClientConfiguration;
         this.logger = logger;
         this.httpClientProperties = httpClientProperties;
@@ -81,7 +82,6 @@ public class AdminClient implements AutoCloseable {
         return http(httpRequest, bodyHandler, httpClientProperties.getRetry().get());
     }
 
-
     public <T> HttpResponse<T> http(
             HttpRequest httpRequest, HttpResponse.BodyHandler<T> bodyHandler, Retry retry) {
 
@@ -109,19 +109,17 @@ public class AdminClient implements AutoCloseable {
             if (shouldRetry(httpRequest, null, retry, error)) {
                 return http(httpRequest, bodyHandler, retry);
             }
-            throw new RuntimeException(
-                    "Cannot connect to " + httpRequest.uri(), error);
+            throw new RuntimeException("Cannot connect to " + httpRequest.uri(), error);
         } catch (IOException error) {
             if (shouldRetry(httpRequest, null, retry, error)) {
                 return http(httpRequest, bodyHandler, retry);
             }
             throw new RuntimeException("Unexpected network error " + error, error);
         }
-
     }
 
-    private <T> boolean shouldRetry(HttpRequest httpRequest, HttpResponse response, Retry retry,
-                                  Exception error) {
+    private <T> boolean shouldRetry(
+            HttpRequest httpRequest, HttpResponse response, Retry retry, Exception error) {
         final Optional<Long> next = retry.shouldRetryAfter(error, httpRequest, response);
         if (next.isPresent()) {
             try {

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -15,6 +15,9 @@
  */
 package ai.langstream.admin.client;
 
+import ai.langstream.admin.client.http.HttpClientProperties;
+import ai.langstream.admin.client.http.Retry;
+import ai.langstream.admin.client.http.RetryPolicy;
 import ai.langstream.admin.client.model.Applications;
 import ai.langstream.admin.client.util.MultiPartBodyPublisher;
 import java.io.IOException;
@@ -26,6 +29,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.SneakyThrows;
@@ -36,11 +40,18 @@ public class AdminClient implements AutoCloseable {
     private final AdminClientLogger logger;
     private ExecutorService executorService;
     private HttpClient httpClient;
+    private HttpClientProperties httpClientProperties;
 
     public AdminClient(
             AdminClientConfiguration adminClientConfiguration, AdminClientLogger logger) {
+        this(adminClientConfiguration, logger, new HttpClientProperties());
+    }
+
+    public AdminClient(
+            AdminClientConfiguration adminClientConfiguration, AdminClientLogger logger, HttpClientProperties httpClientProperties) {
         this.configuration = adminClientConfiguration;
         this.logger = logger;
+        this.httpClientProperties = httpClientProperties;
     }
 
     protected String getBaseWebServiceUrl() {
@@ -67,8 +78,18 @@ public class AdminClient implements AutoCloseable {
 
     public <T> HttpResponse<T> http(
             HttpRequest httpRequest, HttpResponse.BodyHandler<T> bodyHandler) {
+        return http(httpRequest, bodyHandler, httpClientProperties.getRetry().get());
+    }
+
+
+    public <T> HttpResponse<T> http(
+            HttpRequest httpRequest, HttpResponse.BodyHandler<T> bodyHandler, Retry retry) {
+
         try {
             final HttpResponse<T> response = getHttpClient().send(httpRequest, bodyHandler);
+            if (shouldRetry(httpRequest, response, retry, null)) {
+                return http(httpRequest, bodyHandler, retry);
+            }
             final int status = response.statusCode();
             if (status >= 200 && status < 300) {
                 return response;
@@ -81,12 +102,37 @@ public class AdminClient implements AutoCloseable {
                 throw new RuntimeException("Request failed: " + response.statusCode());
             }
             throw new RuntimeException("Unexpected status code: " + status);
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(error);
         } catch (ConnectException error) {
+            if (shouldRetry(httpRequest, null, retry, error)) {
+                return http(httpRequest, bodyHandler, retry);
+            }
             throw new RuntimeException(
-                    "Cannot connect to " + httpRequest.uri() + ": " + error.getMessage(), error);
-        } catch (IOException | InterruptedException error) {
+                    "Cannot connect to " + httpRequest.uri(), error);
+        } catch (IOException error) {
+            if (shouldRetry(httpRequest, null, retry, error)) {
+                return http(httpRequest, bodyHandler, retry);
+            }
             throw new RuntimeException("Unexpected network error " + error, error);
         }
+
+    }
+
+    private <T> boolean shouldRetry(HttpRequest httpRequest, HttpResponse response, Retry retry,
+                                  Exception error) {
+        final Optional<Long> next = retry.shouldRetryAfter(error, httpRequest, response);
+        if (next.isPresent()) {
+            try {
+                Thread.sleep(next.get());
+            } catch (InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(interruptedException);
+            }
+            return true;
+        }
+        return false;
     }
 
     private HttpRequest.Builder withAuth(HttpRequest.Builder builder) {

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/ExponentialRetryPolicy.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/ExponentialRetryPolicy.java
@@ -1,5 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.admin.client.http;
-
 
 public class ExponentialRetryPolicy implements RetryPolicy {
 
@@ -9,7 +23,8 @@ public class ExponentialRetryPolicy implements RetryPolicy {
     private final int maxAttempts;
     private final long[] intervals;
 
-    public ExponentialRetryPolicy(int maxAttempts, long initialInterval, double intervalMultiplier) {
+    public ExponentialRetryPolicy(
+            int maxAttempts, long initialInterval, double intervalMultiplier) {
         this.maxAttempts = maxAttempts;
         this.intervals = new long[maxAttempts];
         this.intervals[0] = initialInterval;

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/ExponentialRetryPolicy.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/ExponentialRetryPolicy.java
@@ -1,0 +1,49 @@
+package ai.langstream.admin.client.http;
+
+
+public class ExponentialRetryPolicy implements RetryPolicy {
+
+    protected static final int DEFAULT_INITIAL_INTERVAL = 2000;
+    protected static final double DEFAULT_INTERVAL_MULTIPLIER = 1.5d;
+    protected static final int DEFAULT_MAX_ATTEMPTS = 5;
+    private final int maxAttempts;
+    private final long[] intervals;
+
+    public ExponentialRetryPolicy(int maxAttempts, long initialInterval, double intervalMultiplier) {
+        this.maxAttempts = maxAttempts;
+        this.intervals = new long[maxAttempts];
+        this.intervals[0] = initialInterval;
+        for (int i = 1; i < maxAttempts; i++) {
+            intervals[i] = (long) (intervals[i - 1] * intervalMultiplier);
+        }
+    }
+
+    public ExponentialRetryPolicy(int maxAttempts, long initialInterval) {
+        this(maxAttempts, initialInterval, DEFAULT_INTERVAL_MULTIPLIER);
+    }
+
+    public ExponentialRetryPolicy(int maxAttempts) {
+        this(maxAttempts, DEFAULT_INITIAL_INTERVAL, DEFAULT_INTERVAL_MULTIPLIER);
+    }
+
+    public ExponentialRetryPolicy() {
+        this(DEFAULT_MAX_ATTEMPTS, DEFAULT_INITIAL_INTERVAL, DEFAULT_INTERVAL_MULTIPLIER);
+    }
+
+    @Override
+    public int maxAttempts() {
+        return maxAttempts;
+    }
+
+    @Override
+    public long delay(int attempt) {
+        if (attempt > intervals.length) {
+            throw new IllegalArgumentException();
+        }
+        return intervals[attempt - 1];
+    }
+
+    long[] getIntervals() {
+        return intervals;
+    }
+}

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/GenericRetryExecution.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/GenericRetryExecution.java
@@ -1,0 +1,59 @@
+package ai.langstream.admin.client.http;
+
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GenericRetryExecution implements Retry {
+    private final RetryPolicy policy;
+    private int currentAttempts = 0;
+
+    public GenericRetryExecution(RetryPolicy policy) {
+        this.policy = policy;
+    }
+
+    @Override
+    public Optional<Long> shouldRetryAfter(Exception exception, HttpRequest request, HttpResponse<?> response) {
+        final boolean retryable = isRetryable(exception, response);
+        if (!retryable) {
+            return Optional.empty();
+        }
+        currentAttempts++;
+        final long delay = policy.delay(currentAttempts);
+        log.info("Retrying request {} after {} ms, status code :{}, err: {}", request.uri(), delay, response == null ? null : response.statusCode(), exception == null ? null : exception.getClass().getName() + " " + exception.getMessage());
+        return Optional.of(delay);
+    }
+
+    boolean isRetryable(Exception exception, HttpResponse<?> response) {
+        if (exception != null && !isExceptionRetryable(exception)) {
+            return false;
+        }
+        if (response != null && !isResponseCodeRetryable(response)) {
+            return false;
+        }
+
+        if (currentAttempts >= policy.maxAttempts()) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isResponseCodeRetryable(HttpResponse<?> response) {
+        final int code = response.statusCode();
+        if (code >= 500) {
+            return true;
+        }
+        return false;
+
+    }
+
+    private boolean isExceptionRetryable(Exception exception) {
+        if (exception instanceof IOException) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/GenericRetryExecution.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/GenericRetryExecution.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.admin.client.http;
 
 import java.io.IOException;
@@ -16,14 +31,22 @@ public class GenericRetryExecution implements Retry {
     }
 
     @Override
-    public Optional<Long> shouldRetryAfter(Exception exception, HttpRequest request, HttpResponse<?> response) {
+    public Optional<Long> shouldRetryAfter(
+            Exception exception, HttpRequest request, HttpResponse<?> response) {
         final boolean retryable = isRetryable(exception, response);
         if (!retryable) {
             return Optional.empty();
         }
         currentAttempts++;
         final long delay = policy.delay(currentAttempts);
-        log.info("Retrying request {} after {} ms, status code :{}, err: {}", request.uri(), delay, response == null ? null : response.statusCode(), exception == null ? null : exception.getClass().getName() + " " + exception.getMessage());
+        log.info(
+                "Retrying request {} after {} ms, status code :{}, err: {}",
+                request.uri(),
+                delay,
+                response == null ? null : response.statusCode(),
+                exception == null
+                        ? null
+                        : exception.getClass().getName() + " " + exception.getMessage());
         return Optional.of(delay);
     }
 
@@ -47,7 +70,6 @@ public class GenericRetryExecution implements Retry {
             return true;
         }
         return false;
-
     }
 
     private boolean isExceptionRetryable(Exception exception) {

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/HttpClientProperties.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/HttpClientProperties.java
@@ -1,0 +1,16 @@
+package ai.langstream.admin.client.http;
+
+import java.util.function.Supplier;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HttpClientProperties {
+    private Supplier<Retry> retry = () -> new GenericRetryExecution(new ExponentialRetryPolicy());
+
+}

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/HttpClientProperties.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/HttpClientProperties.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.admin.client.http;
 
 import java.util.function.Supplier;
@@ -12,5 +27,4 @@ import lombok.NoArgsConstructor;
 @Builder
 public class HttpClientProperties {
     private Supplier<Retry> retry = () -> new GenericRetryExecution(new ExponentialRetryPolicy());
-
 }

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/Retry.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/Retry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.admin.client.http;
 
 import java.net.http.HttpRequest;
@@ -6,5 +21,6 @@ import java.util.Optional;
 
 public interface Retry {
 
-    Optional<Long> shouldRetryAfter(Exception exception, HttpRequest request, HttpResponse<?> response);
+    Optional<Long> shouldRetryAfter(
+            Exception exception, HttpRequest request, HttpResponse<?> response);
 }

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/Retry.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/Retry.java
@@ -1,0 +1,10 @@
+package ai.langstream.admin.client.http;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+public interface Retry {
+
+    Optional<Long> shouldRetryAfter(Exception exception, HttpRequest request, HttpResponse<?> response);
+}

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/RetryPolicy.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/RetryPolicy.java
@@ -1,13 +1,23 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.admin.client.http;
-
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 
 public interface RetryPolicy {
 
     int maxAttempts();
 
     long delay(int attempt);
-
 }
-

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/RetryPolicy.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/RetryPolicy.java
@@ -1,0 +1,13 @@
+package ai.langstream.admin.client.http;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public interface RetryPolicy {
+
+    int maxAttempts();
+
+    long delay(int attempt);
+
+}
+

--- a/langstream-admin-client/src/test/java/ai/langstream/admin/client/http/GenericRetryExecutionTest.java
+++ b/langstream-admin-client/src/test/java/ai/langstream/admin/client/http/GenericRetryExecutionTest.java
@@ -1,16 +1,31 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.admin.client.http;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
@@ -30,13 +45,10 @@ class GenericRetryExecutionTest {
     private boolean testIsRetryable(int code) {
         return new GenericRetryExecution(new ExponentialRetryPolicy())
                 .isRetryable(null, responseWithCode(code));
-
     }
 
     private boolean testIsRetryable(Exception exception) {
-        return new GenericRetryExecution(new ExponentialRetryPolicy())
-                .isRetryable(exception, null);
-
+        return new GenericRetryExecution(new ExponentialRetryPolicy()).isRetryable(exception, null);
     }
 
     private static HttpResponse<?> responseWithCode(int code) {
@@ -52,18 +64,21 @@ class GenericRetryExecutionTest {
 
     @Test
     void testDelays() {
-        assertEquals(List.of(2000L, 3000L, 4500L, 6750L, 10125L),
-                Arrays.stream(new ExponentialRetryPolicy().getIntervals()).boxed().collect(Collectors.toList()));
+        assertEquals(
+                List.of(2000L, 3000L, 4500L, 6750L, 10125L),
+                Arrays.stream(new ExponentialRetryPolicy().getIntervals())
+                        .boxed()
+                        .collect(Collectors.toList()));
     }
 
     @Test
     void testMaxAttempts() {
-        final GenericRetryExecution retry = new GenericRetryExecution(new ExponentialRetryPolicy(3));
+        final GenericRetryExecution retry =
+                new GenericRetryExecution(new ExponentialRetryPolicy(3));
 
         assertTrue(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
         assertTrue(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
         assertTrue(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
         assertFalse(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
     }
-
 }

--- a/langstream-admin-client/src/test/java/ai/langstream/admin/client/http/GenericRetryExecutionTest.java
+++ b/langstream-admin-client/src/test/java/ai/langstream/admin/client/http/GenericRetryExecutionTest.java
@@ -1,0 +1,69 @@
+package ai.langstream.admin.client.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class GenericRetryExecutionTest {
+
+    @Test
+    void testIsRetryable() {
+        assertFalse(testIsRetryable(200));
+        assertFalse(testIsRetryable(400));
+        assertTrue(testIsRetryable(500));
+        assertTrue(testIsRetryable(503));
+        assertFalse(testIsRetryable(new RuntimeException("")));
+        assertTrue(testIsRetryable(new ConnectException("")));
+        assertTrue(testIsRetryable(new IOException("")));
+    }
+
+    private boolean testIsRetryable(int code) {
+        return new GenericRetryExecution(new ExponentialRetryPolicy())
+                .isRetryable(null, responseWithCode(code));
+
+    }
+
+    private boolean testIsRetryable(Exception exception) {
+        return new GenericRetryExecution(new ExponentialRetryPolicy())
+                .isRetryable(exception, null);
+
+    }
+
+    private static HttpResponse<?> responseWithCode(int code) {
+        final HttpResponse mock = mock(HttpResponse.class);
+        when(mock.statusCode()).thenReturn(code);
+        return mock;
+    }
+
+    private static HttpRequest request() {
+        final HttpRequest mock = mock(HttpRequest.class);
+        return mock;
+    }
+
+    @Test
+    void testDelays() {
+        assertEquals(List.of(2000L, 3000L, 4500L, 6750L, 10125L),
+                Arrays.stream(new ExponentialRetryPolicy().getIntervals()).boxed().collect(Collectors.toList()));
+    }
+
+    @Test
+    void testMaxAttempts() {
+        final GenericRetryExecution retry = new GenericRetryExecution(new ExponentialRetryPolicy(3));
+
+        assertTrue(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
+        assertTrue(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
+        assertTrue(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
+        assertFalse(retry.shouldRetryAfter(new IOException(), request(), null).isPresent());
+    }
+
+}


### PR DESCRIPTION
Fixes: #275


* Added retries logic in the http client. It affects the code download runtime step and all the CLI calls.
* Unfortunately the java11 http client doesn't offer a retry mechanism so I had to implement one from scratch
By default a http call is retried at max 5 times, with a exponential algo (inital 2 seconds, multiplier 1.5)