### PR TITLE
Expose metrics endpoint for all the services

### DIFF
--- a/langstream-api-gateway/pom.xml
+++ b/langstream-api-gateway/pom.xml
@@ -76,6 +76,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/langstream-api-gateway/src/main/resources/application.properties
+++ b/langstream-api-gateway/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.servlet.multipart.max-file-size=128MB
 spring.servlet.multipart.max-request-size=128MB
 
 management.endpoints.web.base-path=/management
-management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,threaddump
+management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,threaddump,prometheus
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.show-details=always
 

--- a/langstream-k8s-common/pom.xml
+++ b/langstream-k8s-common/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>kubernetes-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
       <scope>test</scope>

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/pom.xml
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/pom.xml
@@ -28,6 +28,8 @@
   <name>LangStream - K8s deployer operator</name>
   <properties>
     <quarkus.container-image.build>true</quarkus.container-image.build>
+    <quarkus-maven-plugin.version>3.3.1</quarkus-maven-plugin.version>
+    <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
   </properties>
 
   <dependencies>
@@ -72,6 +74,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -158,6 +164,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus-maven-plugin.version}</version>
             <executions>
               <execution>
                 <goals>
@@ -168,7 +175,7 @@
           </plugin>
           <plugin>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>3.0.2</version>
+            <version>${maven-resources-plugin.version}</version>
             <executions>
               <!--resources:copy-resources@sync-crd-->
               <execution>

--- a/langstream-webservice/pom.xml
+++ b/langstream-webservice/pom.xml
@@ -126,6 +126,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>

--- a/langstream-webservice/src/main/resources/application.properties
+++ b/langstream-webservice/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.servlet.multipart.max-file-size=128MB
 spring.servlet.multipart.max-request-size=128MB
 
 management.endpoints.web.base-path=/management
-management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,threaddump
+management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,threaddump,prometheus
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.show-details=always
 


### PR DESCRIPTION
Added micrometer prometheus registry in all the services. By default they are configured in the main port of the service. 

Control plane: /management/prometheus
Api Gateway: /management/prometheus
Deployer: /q/metrics

All the endpoints are in prometheus format. 
For now the services only expose jvm metrics.