### PR TITLE
Add CLI version (langstream -V)

### DIFF
--- a/langstream-cli/pom.xml
+++ b/langstream-cli/pom.xml
@@ -16,7 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>ai.langstream</groupId>
     <artifactId>langstream-ai</artifactId>
@@ -30,6 +31,8 @@
     <build.dir>${project.build.directory}</build.dir>
     <wiremock.version>3.0.0-beta-10</wiremock.version>
     <docker.platforms>linux/amd64</docker.platforms>
+    <appassembler-maven-plugin.version>1.10</appassembler-maven-plugin.version>
+    <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
   </properties>
   <dependencies>
     <dependency>
@@ -81,8 +84,44 @@
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>${buildnumber-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+          <shortRevisionLength>8</shortRevisionLength>
+          <attach>true</attach>
+          <addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <mainClass>ai.langstream.cli.LangStreamCLI</mainClass>
+              <addClasspath>true</addClasspath>
+            </manifest>
+            <manifestEntries>
+              <Implementation-Title>langstream-cli</Implementation-Title>
+              <Implementation-Git-Revision>${buildNumber}</Implementation-Git-Revision>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
-        <version>1.10</version>
+        <version>${appassembler-maven-plugin.version}</version>
         <configuration>
           <configurationSourceDirectory>../conf</configurationSourceDirectory>
           <configurationDirectory>conf</configurationDirectory>

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
@@ -26,8 +26,20 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "apps",
-        mixinStandardHelpOptions = true,
-        description = "Manage LangStream applications",
+        header = "Manage LangStream applications",
+        //        description =
+        //                """
+        //                # Deploy an application
+        //                langstream apps deploy myapp -app myapp-dir -i instance-file.yaml -s
+        // secret-file.yaml
+        //
+        //                # Get the application status
+        //                langstream apps get myapp
+        //                langstream apps get myapp -o yaml
+        //
+        //                # Delete the application
+        //                langstream apps delete myapp
+        //                """,
         subcommands = {
             AbstractDeployApplicationCmd.DeployApplicationCmd.class,
             AbstractDeployApplicationCmd.UpdateApplicationCmd.class,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
@@ -27,19 +27,19 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "apps",
         header = "Manage LangStream applications",
-        //        description =
-        //                """
-        //                # Deploy an application
-        //                langstream apps deploy myapp -app myapp-dir -i instance-file.yaml -s
-        // secret-file.yaml
-        //
-        //                # Get the application status
-        //                langstream apps get myapp
-        //                langstream apps get myapp -o yaml
-        //
-        //                # Delete the application
-        //                langstream apps delete myapp
-        //                """,
+                description =
+                        """
+                        # Deploy an application
+                        langstream apps deploy myapp -app myapp-dir -i instance-file.yaml -s
+         secret-file.yaml
+
+                        # Get the application status
+                        langstream apps get myapp
+                        langstream apps get myapp -o yaml
+
+                        # Delete the application
+                        langstream apps delete myapp
+                        """,
         subcommands = {
             AbstractDeployApplicationCmd.DeployApplicationCmd.class,
             AbstractDeployApplicationCmd.UpdateApplicationCmd.class,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
@@ -27,8 +27,8 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "apps",
         header = "Manage LangStream applications",
-                description =
-                        """
+        description =
+                """
                         # Deploy an application
                         langstream apps deploy myapp -app myapp-dir -i instance-file.yaml -s
          secret-file.yaml

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
@@ -27,19 +27,6 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "apps",
         header = "Manage LangStream applications",
-        description =
-                """
-                        # Deploy an application
-                        langstream apps deploy myapp -app myapp-dir -i instance-file.yaml -s
-         secret-file.yaml
-
-                        # Get the application status
-                        langstream apps get myapp
-                        langstream apps get myapp -o yaml
-
-                        # Delete the application
-                        langstream apps delete myapp
-                        """,
         subcommands = {
             AbstractDeployApplicationCmd.DeployApplicationCmd.class,
             AbstractDeployApplicationCmd.UpdateApplicationCmd.class,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
@@ -23,7 +23,9 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "langstream",
         mixinStandardHelpOptions = true,
-        description = "Manage LangStream",
+        versionProvider = VersionProvider.class,
+        scope = CommandLine.ScopeType.INHERIT,
+        header = "LangStream CLI",
         subcommands = {
             RootAppCmd.class,
             ConfigureCmd.class,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootGatewayCmd.java
@@ -23,8 +23,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "gateway",
-        mixinStandardHelpOptions = true,
-        description = "Interact with a application gateway",
+        header = "Interact with a application gateway",
         subcommands = {ProduceGatewayCmd.class, ConsumeGatewayCmd.class, ChatGatewayCmd.class})
 @Getter
 public class RootGatewayCmd {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootTenantCmd.java
@@ -26,8 +26,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "tenants",
-        mixinStandardHelpOptions = true,
-        description = "Manage LangStream tenants",
+        header = "Manage LangStream tenants",
         subcommands = {
             PutTenantCmd.class,
             DeleteTenantCmd.class,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/VersionProvider.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/VersionProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.cli.commands;
 
 import java.io.IOException;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/VersionProvider.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/VersionProvider.java
@@ -1,0 +1,86 @@
+package ai.langstream.cli.commands;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import picocli.CommandLine;
+
+public class VersionProvider implements CommandLine.IVersionProvider {
+
+    private static final String[] VERSION = new String[] {getVersionFromJar()};
+
+    public String[] getVersion() {
+        return VERSION;
+    }
+
+    private static String getVersionFromJar() {
+        try {
+            Manifest manifest = getManifest();
+            final String version = getVersionFromManifest(manifest);
+            final String gitRevision = getGitRevisionFromManifest(manifest);
+            return "LangStream CLI %s (%s)".formatted(version, gitRevision);
+        } catch (Throwable t) {
+            // never ever let this exception bubble up otherwise any command will fail
+            return "Error: %s".formatted(t.getMessage());
+        }
+    }
+
+    private static String getVersionFromManifest(Manifest manifest) {
+        final String implVersion = findAttributeByKey(manifest, "Implementation-Version");
+        if (implVersion == null) {
+            throw new RuntimeException(
+                    "Failed to read version from manifest: Implementation-Version not found in META-INF/MANIFEST.MF "
+                            + "for langstream-cli jar.");
+        }
+        return implVersion;
+    }
+
+    private static String getGitRevisionFromManifest(Manifest manifest) {
+        final String implVersion = findAttributeByKey(manifest, "Implementation-Git-Revision");
+        if (implVersion == null) {
+            throw new RuntimeException(
+                    "Failed to read version from manifest: Implementation-Git-Revision not found in META-INF/MANIFEST.MF "
+                            + "for langstream-cli jar.");
+        }
+        return implVersion;
+    }
+
+    private static Manifest getManifest() throws IOException {
+        Enumeration<URL> resources =
+                VersionProvider.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+        while (resources.hasMoreElements()) {
+            try (final InputStream in = resources.nextElement().openStream(); ) {
+                Manifest manifest = new Manifest(in);
+                final String implTitle = findAttributeByKey(manifest, "Implementation-Title");
+                if (implTitle == null) {
+                    continue;
+                }
+                if ("langstream-cli".equals(implTitle)) {
+                    return manifest;
+                }
+            } catch (IOException ioException) {
+            }
+        }
+        throw new RuntimeException(
+                "Failed to read version from manifest: META-INF/MANIFEST.MF not found with Implementation-Title: "
+                        + "langstream-cli.");
+    }
+
+    private static String findAttributeByKey(Manifest manifest, String key) {
+        final Attributes mainAttributes = manifest.getMainAttributes();
+
+        final Object implTitle =
+                mainAttributes.entrySet().stream()
+                        .filter(e -> e.getKey().toString().equals(key))
+                        .map(e -> e.getValue())
+                        .findFirst()
+                        .orElse(null);
+        if (implTitle == null) {
+            return null;
+        }
+        return implTitle.toString();
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -40,10 +40,7 @@ import picocli.CommandLine;
 
 public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
 
-    @CommandLine.Command(
-            name = "deploy",
-            mixinStandardHelpOptions = true,
-            description = "Deploy a LangStream application")
+    @CommandLine.Command(name = "deploy", header = "Deploy a LangStream application")
     public static class DeployApplicationCmd extends AbstractDeployApplicationCmd {
 
         @CommandLine.Parameters(description = "Name of the application")
@@ -92,10 +89,7 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         }
     }
 
-    @CommandLine.Command(
-            name = "update",
-            mixinStandardHelpOptions = true,
-            description = "Update an existing LangStream application")
+    @CommandLine.Command(name = "update", header = "Update an existing LangStream application")
     public static class UpdateApplicationCmd extends AbstractDeployApplicationCmd {
 
         @CommandLine.Parameters(description = "Name of the application")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
@@ -18,10 +18,7 @@ package ai.langstream.cli.commands.applications;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "delete",
-        mixinStandardHelpOptions = true,
-        description = "Delete an application")
+@CommandLine.Command(name = "delete", header = "Delete an application")
 public class DeleteApplicationCmd extends BaseApplicationCmd {
 
     @CommandLine.Parameters(description = "ID of the application")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DownloadApplicationCodeCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DownloadApplicationCodeCmd.java
@@ -24,10 +24,7 @@ import java.util.regex.Pattern;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "download",
-        mixinStandardHelpOptions = true,
-        description = "Get LangStream application code")
+@CommandLine.Command(name = "download", header = "Get LangStream application code")
 public class DownloadApplicationCodeCmd extends BaseApplicationCmd {
 
     protected static final Pattern REGEX_PATTERN =

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationCmd.java
@@ -18,10 +18,7 @@ package ai.langstream.cli.commands.applications;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "get",
-        mixinStandardHelpOptions = true,
-        description = "Get LangStream application status")
+@CommandLine.Command(name = "get", header = "Get LangStream application status")
 public class GetApplicationCmd extends BaseApplicationCmd {
 
     @CommandLine.Parameters(description = "ID of the application")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationLogsCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationLogsCmd.java
@@ -27,10 +27,7 @@ import java.util.List;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "logs",
-        mixinStandardHelpOptions = true,
-        description = "Get LangStream application logs")
+@CommandLine.Command(name = "logs", header = "Get LangStream application logs")
 public class GetApplicationLogsCmd extends BaseApplicationCmd {
 
     @CommandLine.Parameters(description = "Name of the application")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/ListApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/ListApplicationCmd.java
@@ -22,10 +22,7 @@ import java.util.function.BiFunction;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "list",
-        mixinStandardHelpOptions = true,
-        description = "List all LangStream applications")
+@CommandLine.Command(name = "list", header = "List all LangStream applications")
 public class ListApplicationCmd extends BaseApplicationCmd {
 
     protected static final String[] COLUMNS_FOR_RAW = {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/configure/ConfigureCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/configure/ConfigureCmd.java
@@ -22,10 +22,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "configure",
-        mixinStandardHelpOptions = true,
-        description = "Configure LangStream tenant and authentication")
+@CommandLine.Command(name = "configure", header = "Configure LangStream tenant and authentication")
 @Getter
 public class ConfigureCmd extends BaseCmd {
 

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
@@ -33,8 +33,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "chat",
-        mixinStandardHelpOptions = true,
-        description = "Produce and consume messages from gateway in a chat-like fashion")
+        header = "Produce and consume messages from gateway in a chat-like fashion")
 public class ChatGatewayCmd extends BaseGatewayCmd {
 
     @CommandLine.Parameters(description = "Application ID")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ConsumeGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ConsumeGatewayCmd.java
@@ -26,10 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "consume",
-        mixinStandardHelpOptions = true,
-        description = "Consume messages from a gateway")
+@CommandLine.Command(name = "consume", header = "Consume messages from a gateway")
 public class ConsumeGatewayCmd extends BaseGatewayCmd {
 
     @CommandLine.Parameters(description = "Application ID")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
@@ -25,10 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "produce",
-        mixinStandardHelpOptions = true,
-        description = "Produce messages to a gateway")
+@CommandLine.Command(name = "produce", header = "Produce messages to a gateway")
 public class ProduceGatewayCmd extends BaseGatewayCmd {
 
     record ProduceRequest(Object key, Object value, Map<String, String> headers) {}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/CreateTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/CreateTenantCmd.java
@@ -20,10 +20,7 @@ import java.net.http.HttpRequest;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "create",
-        mixinStandardHelpOptions = true,
-        description = "Create a new tenant")
+@CommandLine.Command(name = "create", header = "Create a new tenant")
 public class CreateTenantCmd extends BaseTenantCmd {
 
     @CommandLine.Parameters(description = "Name of the tenant")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/DeleteTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/DeleteTenantCmd.java
@@ -18,10 +18,7 @@ package ai.langstream.cli.commands.tenants;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "delete",
-        mixinStandardHelpOptions = true,
-        description = "Delete a tenant")
+@CommandLine.Command(name = "delete", header = "Delete a tenant")
 public class DeleteTenantCmd extends BaseTenantCmd {
 
     @CommandLine.Parameters(description = "Name of the tenant")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/GetTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/GetTenantCmd.java
@@ -18,10 +18,7 @@ package ai.langstream.cli.commands.tenants;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "get",
-        mixinStandardHelpOptions = true,
-        description = "Get tenant configuration")
+@CommandLine.Command(name = "get", header = "Get tenant configuration")
 public class GetTenantCmd extends BaseTenantCmd {
 
     @CommandLine.Parameters(description = "Name of the tenant")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/ListTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/ListTenantCmd.java
@@ -18,10 +18,7 @@ package ai.langstream.cli.commands.tenants;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "list",
-        mixinStandardHelpOptions = true,
-        description = "List all tenants")
+@CommandLine.Command(name = "list", header = "List all tenants")
 public class ListTenantCmd extends BaseTenantCmd {
 
     @Override

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/PutTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/PutTenantCmd.java
@@ -19,7 +19,7 @@ import java.net.http.HttpRequest;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "put", mixinStandardHelpOptions = true, description = "Put a tenant")
+@CommandLine.Command(name = "put", header = "Put a tenant")
 public class PutTenantCmd extends BaseTenantCmd {
 
     @CommandLine.Parameters(description = "Name of the tenant")

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/UpdateTenantCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/tenants/UpdateTenantCmd.java
@@ -20,10 +20,7 @@ import java.net.http.HttpRequest;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(
-        name = "update",
-        mixinStandardHelpOptions = true,
-        description = "Update an existing tenant")
+@CommandLine.Command(name = "update", header = "Update an existing tenant")
 public class UpdateTenantCmd extends BaseTenantCmd {
 
     @CommandLine.Parameters(description = "Name of the tenant")

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <commons-collections4.version>4.4</commons-collections4.version>
 <!--    minio requires okhttp3 v4-->
     <okhttp.version>4.11.0</okhttp.version>
+    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
   </properties>
 
   <scm>
@@ -530,7 +531,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>${maven-jar-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #325

* The CLI -V command now reads the jar manifest and get the version (maven version) + git revision
Result is
```
$ langstream -V        
LangStream CLI 0.0.11-SNAPSHOT (f89913a6)
```
* Fixed usage of header instead of description for every command