### PR TITLE
Set default unit memory to 512M

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
@@ -22,7 +22,7 @@ public class AgentResourceUnitConfiguration {
 
     private float cpuPerUnit = 0.5f;
     // MB
-    private long memPerUnit = 256;
+    private long memPerUnit = 512;
     private int instancePerUnit = 1;
 
     private int defaultCpuMemUnits = 1;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -214,7 +214,7 @@ class AgentResourcesFactoryTest {
         final Container container =
                 statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0);
         assertEquals(Quantity.parse("2"), container.getResources().getRequests().get("cpu"));
-        assertEquals(Quantity.parse("1024M"), container.getResources().getRequests().get("memory"));
+        assertEquals(Quantity.parse("2048M"), container.getResources().getRequests().get("memory"));
     }
 
     @Test

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -113,10 +113,10 @@ class AgentResourcesFactoryTest {
                                 resources:
                                   limits:
                                     cpu: 0.500000
-                                    memory: 256M
+                                    memory: 512M
                                   requests:
                                     cpu: 0.500000
-                                    memory: 256M
+                                    memory: 512M
                                 terminationMessagePolicy: FallbackToLogsOnError
                                 volumeMounts:
                                 - mountPath: /app-config


### PR DESCRIPTION
The default memory limit for 1 unit is 256M. This value is too low for some builtin agents and they get killed by k8s. 
