### PR TITLE
[cli] Allow to refer to local files in secrets.yaml and in instance.yaml using <file:xxx> syntax

### DIFF
--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -32,7 +32,7 @@ secrets:
     data:
       url: https://us-central1-aiplatform.googleapis.com
       token: xxx
-      serviceAccountJson: xxx
+      # serviceAccountJson: "<file:service-account.json>"
       region: us-central1
       project: myproject
   - name: hugging-face
@@ -44,7 +44,7 @@ secrets:
     data:
       username: xxx
       password: xxx
-      secureBundle: xxx
+      # secureBundle: "<file:secure-connect-bundle.zip>"
   - name: s3
     id: s3
     data:

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.cli.commands.applications;
 
+import static ai.langstream.impl.parser.ModelBuilder.resolveFileReferencesInYAMLFile;
+
 import ai.langstream.admin.client.util.MultiPartBodyPublisher;
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.Dependency;
@@ -179,10 +181,10 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         final Map<String, Object> contents = new HashMap<>();
         contents.put("app", tempZip);
         if (instanceFile != null) {
-            contents.put("instance", Files.readString(instanceFile.toPath()));
+            contents.put("instance", resolveFileReferencesInYAMLFile(instanceFile.toPath()));
         }
         if (secretsFile != null) {
-            contents.put("secrets", Files.readString(secretsFile.toPath()));
+            contents.put("secrets", resolveFileReferencesInYAMLFile(secretsFile.toPath()));
         }
         final MultiPartBodyPublisher bodyPublisher = buildMultipartContentForAppZip(contents);
 

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -53,6 +53,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -109,7 +111,7 @@ public class ModelBuilder {
                                 if (existingSamePipelineName != null) {
                                     throw new IllegalArgumentException(
                                             "Duplicate pipeline file names in the application: "
-                                                    + path.getFileName().toString());
+                                                    + path.getFileName());
                                 }
                             } catch (java.nio.charset.MalformedInputException e) {
                                 log.warn("Skipping file {} due to encoding error", path);
@@ -547,5 +549,113 @@ public class ModelBuilder {
             }
         }
         return errorsSpec;
+    }
+
+    private static final Pattern patternPlaceholder = Pattern.compile("<file:(.*?)>");
+
+    public static String resolveFileReferencesInYAMLFile(Path file) throws Exception {
+        return resolveFileReferencesInYAMLFile(
+                Files.readString(file, StandardCharsets.UTF_8),
+                filename -> {
+                    Path fileToRead = file.getParent().resolve(filename);
+                    try {
+                        String fileNameString = filename.toString();
+                        if (isTextFile(fileNameString)) {
+                            log.info("Reading text file {}", fileToRead);
+                            return Files.readString(fileToRead, StandardCharsets.UTF_8);
+                        } else {
+                            byte[] content = Files.readAllBytes(fileToRead);
+                            log.info(
+                                    "Reading binary file {} and encoding it using base64 encoding",
+                                    fileToRead);
+                            return "base64:"
+                                    + java.util.Base64.getEncoder().encodeToString(content);
+                        }
+                    } catch (IOException error) {
+                        throw new IllegalArgumentException("Cannot read file " + fileToRead, error);
+                    }
+                });
+    }
+
+    private static final Set<String> TEXT_FILES_EXTENSIONS =
+            Set.of("txt", "yaml", "yml", "json", "text");
+
+    private static boolean isTextFile(String fileNameString) {
+        if (fileNameString == null) {
+            return false;
+        }
+        String lowerCase = fileNameString.toLowerCase();
+        for (String ext : TEXT_FILES_EXTENSIONS) {
+            if (lowerCase.endsWith(ext)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String resolveFileReferencesInYAMLFile(
+            String content, Function<String, String> readFileContents) throws Exception {
+        // first of all, we read te file with a generic YAML parser
+        // in order to fail fast if the file is not valid YAML
+        Map<String, Object> map = mapper.readValue(content, Map.class);
+
+        if (!patternPlaceholder.matcher(content).find()) {
+            return content;
+        }
+
+        resolveFileReferencesInMap(map, readFileContents);
+        return mapper.writeValueAsString(map);
+    }
+
+    private static void resolveFileReferencesInList(
+            List<Object> list, Function<String, String> readFileContents) throws Exception {
+        for (int i = 0; i < list.size(); i++) {
+            Object value = list.get(i);
+            if (value instanceof String string) {
+                String newValue = resolveFileReferences(string, readFileContents);
+                list.set(i, newValue);
+            } else if (value instanceof Map mapChild) {
+                resolveFileReferencesInMap(mapChild, readFileContents);
+            } else if (value instanceof List listChild) {
+                resolveFileReferencesInList(listChild, readFileContents);
+            }
+        }
+    }
+
+    private static void resolveFileReferencesInMap(
+            Map<String, Object> map, Function<String, String> readFileContents) throws Exception {
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            if (entry.getValue() instanceof String string) {
+                String newValue = resolveFileReferences(string, readFileContents);
+                entry.setValue(newValue);
+            } else if (entry.getValue() instanceof Map mapChild) {
+                resolveFileReferencesInMap(mapChild, readFileContents);
+            } else if (entry.getValue() instanceof List listChild) {
+                resolveFileReferencesInList(listChild, readFileContents);
+            }
+        }
+    }
+
+    /**
+     * Resolve references to local files in a text (YAML) file. References are always relative to
+     * the directory that contains the file.
+     *
+     * @param content contents of the YAML file
+     * @return the new content of the file
+     */
+    private static String resolveFileReferences(
+            String content, Function<String, String> readFileContents) throws Exception {
+
+        Matcher matcher = patternPlaceholder.matcher(content);
+        StringBuffer buffer = new StringBuffer();
+
+        while (matcher.find()) {
+            String filename = matcher.group(1);
+            String replacement = readFileContents.apply(filename);
+            matcher.appendReplacement(buffer, replacement);
+        }
+        matcher.appendTail(buffer);
+
+        return buffer.toString();
     }
 }

--- a/langstream-core/src/test/java/ai/langstream/impl/parser/ModelBuilderTest.java
+++ b/langstream-core/src/test/java/ai/langstream/impl/parser/ModelBuilderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.impl.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ModelBuilderTest {
+
+    @Test
+    void resolveFileReferencesInSecrets() throws Exception {
+        String content =
+                """
+                secrets:
+                  - name: vertex-ai
+                    id: vertex-ai
+                    data:
+                      url: https://us-central1-aiplatform.googleapis.com
+                      token: xxx
+                      serviceAccountJson: "<file:service.account.json>"
+                      region: us-central1
+                      project: myproject
+                      list:
+                        - "<file:some-text-file.txt>"
+                        - "<file:some-text-file.txt>"
+                  - name: astra
+                    id: astra
+                    data:
+                      username: xxx
+                      password: xxx
+                      secureBundle: "<file:secure-connect-bundle.zip>"
+                """;
+
+        String result =
+                ModelBuilder.resolveFileReferencesInYAMLFile(
+                        content,
+                        filename -> {
+                            switch (filename) {
+                                case "service.account.json":
+                                    return """
+                             { "user-id": "xxx", "password": "xxx" }
+                            """;
+                                case "secure-connect-bundle.zip":
+                                    return "base64:zip-content";
+                                case "some-text-file.txt":
+                                    return "text content with \" and ' and \n and \r and \t";
+                                default:
+                                    throw new IllegalStateException();
+                            }
+                        });
+
+        assertEquals(
+                result,
+                """
+                  ---
+                  secrets:
+                  - name: "vertex-ai"
+                    id: "vertex-ai"
+                    data:
+                      url: "https://us-central1-aiplatform.googleapis.com"
+                      token: "xxx"
+                      serviceAccountJson: " { \\"user-id\\": \\"xxx\\", \\"password\\": \\"xxx\\" }\\n"
+                      region: "us-central1"
+                      project: "myproject"
+                      list:
+                      - "text content with \\" and ' and \\n and \\r and \\t"
+                      - "text content with \\" and ' and \\n and \\r and \\t"
+                  - name: "astra"
+                    id: "astra"
+                    data:
+                      username: "xxx"
+                      password: "xxx"
+                      secureBundle: "base64:zip-content"
+                  """);
+    }
+
+    @Test
+    void dontRewriteFileWithoutReferences() throws Exception {
+        String content =
+                """
+                secrets:
+                  - name: vertex-ai
+                    id: vertex-ai
+                    data:
+                      url: https://us-central1-aiplatform.googleapis.com
+                  - name: astra
+                    id: astra
+                    data:
+                      username: xxx
+                      password: xxx
+                """;
+
+        String result =
+                ModelBuilder.resolveFileReferencesInYAMLFile(
+                        content,
+                        filename -> {
+                            throw new IllegalStateException();
+                        });
+
+        assertEquals(result, content);
+    }
+}


### PR DESCRIPTION
Summary:
- in secrets.yaml and instance.yaml you can now refer to local files using the <file:xxx> syntax
- the file is automatically read from the local file system and copied into the YAML file
- text files are kept as they are
- binary files (for instance secure bundle zip files) are base64 encoded and prepended with the "base64:" prefix

Sample usage:

```
secrets:
  - name: vertex-ai
    id: vertex-ai
    data:
      url: https://us-central1-aiplatform.googleapis.com
      token: xxx
      serviceAccountJson: "<file:service-account.json>"
      region: us-central1
      project: myproject
  - name: astra
    id: astra
    data:
      username: xxx
      password: xxx
      secureBundle: "<file:secure-connect-bundle.zip>"
```

Please note that this is a CLI only feature, we will have to implement support for this syntax in the VS Code extension independently