### PR TITLE
Cassandra Sink: set 2 resource units in all the examples

### DIFF
--- a/examples/applications/kafka-connect/pipeline.yaml
+++ b/examples/applications/kafka-connect/pipeline.yaml
@@ -22,6 +22,8 @@ pipeline:
   - name: "Write to Cassandra"
     type: "sink"
     input: "input-topic"
+    resources:
+      size: 2
     configuration:
       connector.class: com.datastax.oss.kafka.sink.CassandraSinkConnector
       key.converter: org.apache.kafka.connect.storage.StringConverter

--- a/examples/applications/text-processing/write-to-astra.yaml
+++ b/examples/applications/text-processing/write-to-astra.yaml
@@ -22,6 +22,8 @@ pipeline:
   - name: "Write to AstraDB"
     type: "sink"
     input: "chunks-topic"
+    resources:
+      size: 2
     configuration:
       connector.class: com.datastax.oss.kafka.sink.CassandraSinkConnector
       key.converter: org.apache.kafka.connect.storage.StringConverter

--- a/examples/applications/webcrawler-source/write-to-astra.yaml
+++ b/examples/applications/webcrawler-source/write-to-astra.yaml
@@ -22,6 +22,8 @@ pipeline:
   - name: "Write to AstraDB"
     type: "sink"
     input: "chunks-topic"
+    resources:
+       size: 2
     configuration:
       connector.class: com.datastax.oss.kafka.sink.CassandraSinkConnector
       key.converter: org.apache.kafka.connect.storage.StringConverter

--- a/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/pipeline.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/pipeline.yaml
@@ -24,6 +24,8 @@ pipeline:
   - name: "Write to Cassandra"
     type: "sink"
     input: "TEST_TOPIC_C1"
+    resources:
+      size: 2
     configuration:
       connector.class: com.datastax.oss.kafka.sink.CassandraSinkConnector
       key.converter: org.apache.kafka.connect.storage.StringConverter


### PR DESCRIPTION
Summary:
- now that we enforce the resource limits on K8S the Kafka Connect Sink for Cassandra started to go OOM
- this patch changes the resource requirements to 2 units on every CassandraSinkConnector in the examples and in the e2e tests