### PR TITLE
Implement fully asynchronous Sinks and graceful pod shutdown (Java runtime)

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -234,6 +234,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         }
 
         Document document = foundDocuments.remove();
+        processed(0, 1);
         return List.of(
                 new WebCrawlerSourceRecord(
                         document.content().getBytes(StandardCharsets.UTF_8), document.url()));

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
@@ -375,7 +375,7 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
                         message,
                         last,
                         record);
-                topicProducer.write(List.of(record.get()));
+                topicProducer.write(record.get()).join();
             }
         }
 

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
@@ -96,8 +96,10 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
                             log.error("Error processing record: {}", record, e);
                             recordSink.emit(new SourceRecordAndResult(record, null, e));
                         } else {
-                            log.info("Processed record {}, results {}", record, resultRecords);
-                            processed(1, records.size());
+                            if (log.isDebugEnabled()) {
+                                log.debug("Processed record {}, results {}", record, resultRecords);
+                            }
+                            processed(0, 1);
                             recordSink.emit(new SourceRecordAndResult(record, resultRecords, null));
                         }
                     });
@@ -105,8 +107,6 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
     }
 
     public CompletableFuture<List<Record>> processRecord(Record record) {
-
-        log.info("Processing {}", record);
         if (log.isDebugEnabled()) {
             log.debug("Processing {}", record);
         }
@@ -119,7 +119,9 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
                     try {
                         context.convertMapToStringOrBytes();
                         Optional<Record> recordResult = transformContextToRecord(context);
-                        log.info("Result {}", recordResult);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Result {}", recordResult);
+                        }
                         return recordResult.map(List::of).orElseGet(List::of);
                     } catch (Exception e) {
                         log.error("Error processing record: {}", record, e);
@@ -369,12 +371,14 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
                 int index, String message, boolean last, TransformContext outputMessage) {
             Optional<Record> record = transformContextToRecord(outputMessage);
             if (record.isPresent()) {
-                log.info(
-                        "index: {}, message: {}, last: {}: record {}",
-                        index,
-                        message,
-                        last,
-                        record);
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "index: {}, message: {}, last: {}: record {}",
+                            index,
+                            message,
+                            last,
+                            record);
+                }
                 topicProducer.write(record.get()).join();
             }
         }

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
@@ -20,13 +20,14 @@ import ai.langstream.api.database.VectorDatabaseWriterProviderRegistry;
 import ai.langstream.api.runner.code.AbstractAgentCode;
 import ai.langstream.api.runner.code.AgentSink;
 import ai.langstream.api.runner.code.Record;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class VectorDBSinkAgent extends AbstractAgentCode implements AgentSink {
 
     private VectorDatabaseWriter writer;
-    private CommitCallback callback;
 
     @Override
     public void init(Map<String, Object> configuration) throws Exception {
@@ -47,18 +48,9 @@ public class VectorDBSinkAgent extends AbstractAgentCode implements AgentSink {
     }
 
     @Override
-    public void write(List<Record> records) throws Exception {
-
+    public CompletableFuture<?> write(Record record) {
         // naive implementation, no batching
         Map<String, Object> context = Map.of();
-        for (Record record : records) {
-            writer.upsert(record, context);
-            callback.commit(List.of(record));
-        }
-    }
-
-    @Override
-    public void setCommitCallback(CommitCallback callback) {
-        this.callback = callback;
+        return writer.upsert(record, context);
     }
 }

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/CassandraWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/CassandraWriterTest.java
@@ -24,10 +24,10 @@ import ai.langstream.api.runner.code.SimpleRecord;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.CassandraContainer;
@@ -76,13 +76,12 @@ public class CassandraWriterTest {
 
         agent.init(configuration);
         agent.start();
-        List<Record> committed = new ArrayList<>();
-        agent.setCommitCallback(committed::addAll);
+        List<Record> committed = new CopyOnWriteArrayList<>();
 
         Map<String, Object> value =
                 Map.of("id", "1", "description", "test-description", "name", "test-name");
         SimpleRecord record = SimpleRecord.of(null, new ObjectMapper().writeValueAsString(value));
-        agent.write(List.of(record));
+        agent.write(record).thenRun(() -> committed.add(record)).get();
 
         assertEquals(committed.get(0), record);
         agent.close();
@@ -117,13 +116,12 @@ public class CassandraWriterTest {
 
         agent.init(configuration);
         agent.start();
-        List<Record> committed = new ArrayList<>();
-        agent.setCommitCallback(committed::addAll);
+        List<Record> committed = new CopyOnWriteArrayList<>();
 
         Map<String, Object> value =
                 Map.of("id", "1", "description", "test-description", "name", "test-name");
         SimpleRecord record = SimpleRecord.of(null, new ObjectMapper().writeValueAsString(value));
-        agent.write(List.of(record));
+        agent.write(record).thenRun(() -> committed.add(record)).get();
 
         assertEquals(committed.get(0), record);
         agent.close();

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
@@ -157,7 +157,7 @@ public class ProduceHandler extends AbstractHandler {
         try {
             final ProduceHandlerRecord record =
                     new ProduceHandlerRecord(produceRequest.key(), produceRequest.value(), headers);
-            topicProducer.write(List.of(record));
+            topicProducer.write(record).get();
             log.info("[{}] Produced record {}", webSocketSession.getId(), record);
         } catch (Throwable tt) {
             sendResponse(webSocketSession, ProduceResponse.Status.PRODUCER_ERROR, tt.getMessage());

--- a/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriter.java
+++ b/langstream-api/src/main/java/ai/langstream/api/database/VectorDatabaseWriter.java
@@ -17,6 +17,7 @@ package ai.langstream.api.database;
 
 import ai.langstream.api.runner.code.Record;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * This is the interface for writing to a vector database. this interface is really simple by
@@ -31,9 +32,8 @@ public interface VectorDatabaseWriter {
      *
      * @param record the record
      * @param context additional context
-     * @throws Exception if an error occurs
      */
-    void upsert(Record record, Map<String, Object> context) throws Exception;
+    CompletableFuture<?> upsert(Record record, Map<String, Object> context);
 
     default void close() throws Exception {}
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeAndLoader.java
@@ -18,6 +18,7 @@ package ai.langstream.api.runner.code;
 import ai.langstream.api.runtime.ComponentType;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 public record AgentCodeAndLoader(AgentCode agentCode, ClassLoader classLoader) {
@@ -145,14 +146,9 @@ public record AgentCodeAndLoader(AgentCode agentCode, ClassLoader classLoader) {
         return new AgentSink() {
 
             @Override
-            public void write(List<Record> records) throws Exception {
-                executeWithContextClassloader(agentCode -> ((AgentSink) agentCode).write(records));
-            }
-
-            @Override
-            public void setCommitCallback(CommitCallback callback) {
-                executeNoExceptionWithContextClassloader(
-                        agentCode -> ((AgentSink) agentCode).setCommitCallback(callback));
+            public CompletableFuture<?> write(Record record) {
+                return callNoExceptionWithContextClassloader(
+                        agentCode -> ((AgentSink) agentCode).write(record));
             }
 
             @Override

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentSink.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentSink.java
@@ -16,7 +16,7 @@
 package ai.langstream.api.runner.code;
 
 import ai.langstream.api.runtime.ComponentType;
-import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /** Body of the agent */
 public interface AgentSink extends AgentCode {
@@ -24,21 +24,16 @@ public interface AgentSink extends AgentCode {
     /**
      * The agent processes records and typically writes then to an external service.
      *
-     * @param records the list of input records
+     * @param record the record to write
      * @throws Exception if the agent fails to process the records
+     * @return an handle to the asynchronous write
      */
-    void write(List<Record> records) throws Exception;
+    CompletableFuture<?> write(Record record);
 
     @Override
     default ComponentType componentType() {
         return ComponentType.SINK;
     }
-
-    interface CommitCallback {
-        void commit(List<Record> records);
-    }
-
-    void setCommitCallback(CommitCallback callback);
 
     /**
      * @return true if the agent handles commit of consumed record (e.g. in case of batching)

--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicProducer.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicProducer.java
@@ -16,8 +16,8 @@
 package ai.langstream.api.runner.topics;
 
 import ai.langstream.api.runner.code.Record;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public interface TopicProducer extends AutoCloseable {
 
@@ -25,7 +25,9 @@ public interface TopicProducer extends AutoCloseable {
 
     default void close() {}
 
-    default void write(List<Record> records) {}
+    default CompletableFuture<?> write(Record record) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     default Object getNativeProducer() {
         return null;

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
@@ -251,11 +251,13 @@ public class KafkaConsumerWrapper implements TopicConsumer, ConsumerRebalanceLis
             }
             if (offsetAndMetadata != null) {
                 committed.put(topicPartition, offsetAndMetadata);
-                log.info(
-                        "Committing offset {} on partition {} (record: {})",
-                        offset,
-                        topicPartition,
-                        kafkaRecord);
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Committing offset {} on partition {} (record: {})",
+                            offset,
+                            topicPartition,
+                            kafkaRecord);
+                }
             }
             if (!offsetsForPartition.isEmpty()) {
                 log.info(

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaReaderWrapper.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaReaderWrapper.java
@@ -120,10 +120,9 @@ class KafkaReaderWrapper implements TopicReader {
         final Set assignment = consumer.assignment();
         if (!records.isEmpty()) {
             log.info(
-                    "Received {} records from Kafka topics {}: {}",
+                    "Received {} records from Kafka topics {}",
                     records.size(),
-                    assignment,
-                    records);
+                    assignment);
         }
         Map<TopicPartition, Long> offsets = consumer.endOffsets(assignment);
 

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaReaderWrapper.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runner/KafkaReaderWrapper.java
@@ -119,10 +119,7 @@ class KafkaReaderWrapper implements TopicReader {
         }
         final Set assignment = consumer.assignment();
         if (!records.isEmpty()) {
-            log.info(
-                    "Received {} records from Kafka topics {}",
-                    records.size(),
-                    assignment);
+            log.info("Received {} records from Kafka topics {}", records.size(), assignment);
         }
         Map<TopicPartition, Long> offsets = consumer.endOffsets(assignment);
 

--- a/langstream-kafka/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
+++ b/langstream-kafka/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
@@ -132,7 +132,7 @@ class KafkaConsumerTest {
 
                 for (int j = 0; j < 2; j++) {
                     Record record1 = generateRecord("record" + i + "_" + j);
-                    producer.write(List.of(record1));
+                    producer.write(record1).join();
                 }
 
                 List<Record> readFromConsumer = consumeRecords(consumer, 2);
@@ -150,7 +150,7 @@ class KafkaConsumerTest {
             // partial acks, this is not an error
             for (int j = 0; j < numMessagesHere; j++) {
                 Record record1 = generateRecord("record_" + j);
-                producer.write(List.of(record1));
+                producer.write(record1).get();
             }
             log.info("Producer metrics: {}", producer.getInfo());
 
@@ -258,7 +258,7 @@ class KafkaConsumerTest {
 
                     for (int j = 0; j < 5; j++) {
                         Record record1 = generateRecord("record" + i + "_" + j);
-                        producer.write(List.of(record1));
+                        producer.write(record1).join();
                     }
 
                     List<Record> readFromConsumer = consumeRecords(consumer, 2);
@@ -347,7 +347,7 @@ class KafkaConsumerTest {
                     String text = "record" + i + "_" + j;
                     expected.add(text);
                     Record record1 = generateRecord(text);
-                    producer.write(List.of(record1));
+                    producer.write(record1).join();
                 }
 
                 try (KafkaConsumerWrapper consumer =

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -492,6 +492,7 @@ public class AgentRunner {
         }
 
         public void waitForNoPendingRecords() {
+            long start = System.currentTimeMillis();
             try {
                 while (!pendingRecords.isEmpty()) {
                     int size = pendingRecords.size();
@@ -512,6 +513,16 @@ public class AgentRunner {
                                 pendingRecords.size(),
                                 first);
                     }
+
+                    long now = System.currentTimeMillis();
+                    long delta = now - start;
+                    if (delta > 60000) {
+                        log.error(
+                                "Waited for {} pending records for more than 60 seconds, existing anyway",
+                                pendingRecords.size());
+                        return;
+                    }
+
                     Thread.sleep(1000);
                 }
             } catch (InterruptedException interruptedException) {

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -833,7 +833,9 @@ public class AgentRunner {
                                 }
                             }
                         } else {
-                            log.info("Passing {} to the Sink", result);
+                            if (log.isDebugEnabled()) {
+                                log.debug("Passing {} to the Sink", result);
+                            }
                             finalSink.emit(result);
                         }
                     } catch (Throwable error) {

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/SourceRecordTracker.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/SourceRecordTracker.java
@@ -16,7 +16,6 @@
 package ai.langstream.runtime.agent;
 
 import ai.langstream.api.runner.code.AgentProcessor;
-import ai.langstream.api.runner.code.AgentSink;
 import ai.langstream.api.runner.code.AgentSource;
 import ai.langstream.api.runner.code.Record;
 import java.util.ArrayList;
@@ -30,7 +29,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-class SourceRecordTracker implements AgentSink.CommitCallback {
+class SourceRecordTracker {
     final Map<Record, Record> sinkToSourceMapping = new ConcurrentHashMap<>();
     final Map<Record, AtomicInteger> remainingSinkRecordsForSourceRecord =
             new ConcurrentHashMap<>();
@@ -42,7 +41,6 @@ class SourceRecordTracker implements AgentSink.CommitCallback {
         this.source = source;
     }
 
-    @Override
     @SneakyThrows
     public synchronized void commit(List<Record> sinkRecords) {
         List<Record> sourceRecordsToCommit = new ArrayList<>();

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/TopicConsumerSource.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/TopicConsumerSource.java
@@ -51,7 +51,7 @@ public class TopicConsumerSource extends AbstractAgentCode implements AgentSourc
     public void permanentFailure(Record record, Exception error) {
         // DLQ
         log.error("Permanent failure on record {}", record, error);
-        deadLetterQueueProducer.write(List.of(record));
+        deadLetterQueueProducer.write(record).join();
     }
 
     @Override

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/TopicProducerSink.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/TopicProducerSink.java
@@ -19,21 +19,15 @@ import ai.langstream.api.runner.code.AbstractAgentCode;
 import ai.langstream.api.runner.code.AgentSink;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.topics.TopicProducer;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public class TopicProducerSink extends AbstractAgentCode implements AgentSink {
 
     private final TopicProducer producer;
-    private CommitCallback callback;
 
     public TopicProducerSink(TopicProducer producer) {
         this.producer = producer;
-    }
-
-    @Override
-    public void setCommitCallback(CommitCallback callback) {
-        this.callback = callback;
     }
 
     @Override
@@ -52,10 +46,9 @@ public class TopicProducerSink extends AbstractAgentCode implements AgentSink {
     }
 
     @Override
-    public void write(List<Record> records) throws Exception {
-        processed(records.size(), 0);
-        producer.write(records);
-        callback.commit(records);
+    public CompletableFuture<?> write(Record records) {
+        processed(1, 0);
+        return producer.write(records);
     }
 
     @Override

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -298,13 +299,17 @@ public abstract class AbstractApplicationRunner {
                                         podConfiguration.agent().agentId());
                                 AgentInfo agentInfo = new AgentInfo();
                                 allAgentsInfo.put(podConfiguration.agent().agentId(), agentInfo);
+                                AtomicInteger numLoops = new AtomicInteger();
                                 AgentRunner.runAgent(
                                         podConfiguration,
                                         null,
                                         null,
                                         agentsDirectory,
                                         agentInfo,
-                                        10,
+                                        () -> {
+                                            log.info("Num loops {}", numLoops.get());
+                                            return numLoops.incrementAndGet() <= 10;
+                                        },
                                         () -> validateAgentInfoBeforeStop(agentInfo),
                                         false);
                                 List<?> infos = agentInfo.serveWorkerStatus();

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockProcessorAgentsCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockProcessorAgentsCodeProvider.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -137,7 +138,6 @@ public class MockProcessorAgentsCodeProvider implements AgentCodeProvider {
         public static final List<Record> acceptedRecords = new CopyOnWriteArrayList<>();
 
         String failOnContent;
-        CommitCallback callback;
 
         @Override
         public void init(Map<String, Object> configuration) {
@@ -146,13 +146,8 @@ public class MockProcessorAgentsCodeProvider implements AgentCodeProvider {
         }
 
         @Override
-        public void setCommitCallback(CommitCallback callback) {
-            this.callback = callback;
-        }
-
-        @Override
-        public void write(List<Record> records) {
-            for (Record record : records) {
+        public CompletableFuture<?> write(Record record) {
+            try {
                 log.info(
                         "Processing record value {}, failOnContent {}",
                         record.value(),
@@ -166,7 +161,9 @@ public class MockProcessorAgentsCodeProvider implements AgentCodeProvider {
                     }
                 }
                 acceptedRecords.add(record);
-                callback.commit(List.of(record));
+                return CompletableFuture.completedFuture(null);
+            } catch (Throwable error) {
+                return CompletableFuture.failedFuture(error);
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/pulsar/PulsarRunnerDockerTest.java
@@ -37,6 +37,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -136,13 +137,14 @@ class PulsarRunnerDockerTest {
                     .send();
             producer.flush();
 
+            AtomicInteger numLoops = new AtomicInteger();
             AgentRunner.runAgent(
                     runtimePodConfiguration,
                     null,
                     null,
                     AbstractApplicationRunner.agentsDirectory,
                     new AgentInfo(),
-                    5,
+                    () -> numLoops.incrementAndGet() <= 5,
                     null,
                     false);
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.Map;
+import java.util.function.Supplier;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -88,7 +89,7 @@ class AgentRunnerStarterTest {
                         Mockito.any(),
                         Mockito.any(),
                         Mockito.any(),
-                        Mockito.anyInt(),
+                        Mockito.any(Supplier.class),
                         Mockito.any(),
                         eq(true));
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
@@ -151,17 +152,9 @@ class AgentRunnerTest {
     }
 
     private static class SimpleSink extends AbstractAgentCode implements AgentSink {
-
-        CommitCallback callback;
-
         @Override
-        public void write(List<Record> records) {
-            callback.commit(records);
-        }
-
-        @Override
-        public void setCommitCallback(CommitCallback callback) {
-            this.callback = callback;
+        public CompletableFuture<?> write(Record record) {
+            return CompletableFuture.completedFuture(null);
         }
     }
 


### PR DESCRIPTION
Summary:
- rework the internal Sink API to be fully async
- Kafka Topic Sink
- Kafka Connect Sinks
- Cassandra Sink
- Pinecone Sink (not really async)
- now that everything is async we have to wait for all the messages produced by the Source to be processed before shutting down the process (or the test)