### PR TITLE
[new feature] Implement Assets - part 1

### DIFF
--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -289,7 +289,7 @@ public class AdminClient implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (executorService != null) {
             executorService.shutdownNow();
         }

--- a/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
@@ -16,13 +16,12 @@
 package ai.langstream.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.Objects;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import java.util.Map;
-import java.util.Objects;
 
 @Getter
 @Setter
@@ -59,6 +58,7 @@ public class AssetDefinition {
     private String creationMode;
 
     private Map<String, Object> config;
+
     @JsonProperty("asset-type")
     private String assetType;
 
@@ -71,5 +71,4 @@ public class AssetDefinition {
                 throw new IllegalArgumentException("Invalid creation mode: " + creationMode);
         }
     }
-
 }

--- a/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class AssetDefinition {
+
+    public static final String CREATE_MODE_NONE = "none";
+    public static final String CREATE_MODE_CREATE_IF_NOT_EXISTS = "create-if-not-exists";
+
+    public AssetDefinition() {
+        creationMode = CREATE_MODE_NONE;
+    }
+
+    public AssetDefinition(
+            String id,
+            String name,
+            String creationMode,
+            String assetType,
+            Map<String, Object> config) {
+        this();
+        this.id = id;
+        this.assetType = assetType;
+        this.name = name;
+        this.config = config;
+        this.creationMode = Objects.requireNonNullElse(creationMode, CREATE_MODE_NONE);
+        validateCreationMode();
+    }
+
+    private String id;
+    private String name;
+
+    @JsonProperty("creation-mode")
+    private String creationMode;
+
+    private Map<String, Object> config;
+    @JsonProperty("asset-type")
+    private String assetType;
+
+    private void validateCreationMode() {
+        switch (creationMode) {
+            case CREATE_MODE_NONE:
+            case CREATE_MODE_CREATE_IF_NOT_EXISTS:
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid creation mode: " + creationMode);
+        }
+    }
+
+}

--- a/langstream-api/src/main/java/ai/langstream/api/model/Module.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Module.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -49,18 +50,21 @@ public class Module {
     }
 
     public AssetDefinition addAsset(AssetDefinition assetDefinition) {
-        final String topicName = assetDefinition.getName();
-        TopicDefinition existing = topics.get(topicName);
+        final String assetId = assetDefinition.getId();
+        AssetDefinition existing =
+                assets.stream()
+                        .filter(a -> Objects.equals(a.getId(), assetId))
+                        .findFirst()
+                        .orElse(null);
+
         if (existing != null) {
-            // allow to declare the same topic in multiple pipelines of the same module
-            // but only if the definition is the same
             if (!existing.equals(assetDefinition)) {
                 throw new IllegalArgumentException(
-                        "Pipeline " + topicName + " already exists in module " + id);
+                        "Asset " + assetId + " already exists in module " + id);
             }
             return existing;
         }
-        topics.put(topicName, assetDefinition);
+        assets.add(assetDefinition);
         return assetDefinition;
     }
 
@@ -72,7 +76,7 @@ public class Module {
             // but only if the definition is the same
             if (!existing.equals(topicDefinition)) {
                 throw new IllegalArgumentException(
-                        "Pipeline " + topicName + " already exists in module " + id);
+                        "Topic " + topicName + " already exists in module " + id);
             }
             return existing;
         }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManager.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManager.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.runtime.api.agent;
+package ai.langstream.api.runner.assets;
 
-import ai.langstream.api.model.StreamingCluster;
-import java.util.List;
-import java.util.Map;
+import ai.langstream.api.model.AssetDefinition;
 
-public record RuntimePodConfiguration(
-        Map<String, Object> input,
-        Map<String, Object> output,
-        AgentSpec agent,
-        StreamingCluster streamingCluster,
-        List<Map<String, Object>> assets) {}
+/** Body of the agent */
+public interface AssetManager {
+
+    boolean assetExists(AssetDefinition assetDefinition) throws Exception;
+
+    void deployAsset(AssetDefinition assetDefinition) throws Exception;
+
+    default void close() throws Exception {}
+}

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerAndLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.runner.assets;
+
+import ai.langstream.api.model.AssetDefinition;
+
+public record AssetManagerAndLoader(AssetManager agentCode, ClassLoader classLoader) {
+
+    public void executeWithContextClassloader(RunnableWithException code) throws Exception {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            code.run(agentCode);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public <T> T callWithContextClassloader(CallableWithException code) throws Exception {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return (T) code.call(agentCode);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public AssetManager asAssetManager() {
+
+        return new AssetManager() {
+
+            @Override
+            public boolean assetExists(AssetDefinition assetDefinition) throws Exception {
+                return callWithContextClassloader(
+                        agentCode -> agentCode.assetExists(assetDefinition));
+            }
+
+            @Override
+            public void deployAsset(AssetDefinition assetDefinition) throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.deployAsset(assetDefinition));
+            }
+
+            @Override
+            public void close() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.close());
+            }
+        };
+    }
+
+    public void close() throws Exception {
+        executeWithContextClassloader(agentCode -> agentCode.close());
+    }
+
+    @FunctionalInterface
+    public interface RunnableWithException {
+        void run(AssetManager agent) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface CallableWithException {
+        Object call(AssetManager agent) throws Exception;
+    }
+}

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerProvider.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerProvider.java
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.runtime.api.agent;
+package ai.langstream.api.runner.assets;
 
-import ai.langstream.api.model.StreamingCluster;
-import java.util.List;
-import java.util.Map;
+/** Factory */
+public interface AssetManagerProvider {
 
-public record RuntimePodConfiguration(
-        Map<String, Object> input,
-        Map<String, Object> output,
-        AgentSpec agent,
-        StreamingCluster streamingCluster,
-        List<Map<String, Object>> assets) {}
+    boolean supports(String assetType);
+
+    /**
+     * Create a new AssetManager for the given asset type
+     *
+     * @return the new AssetManager
+     */
+    AssetManager createInstance(String assetType);
+}

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerRegistry.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerRegistry.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.runner.assets;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The runtime registry is a singleton that holds all the runtime information about the possible
+ * implementations of the LangStream API.
+ */
+@Slf4j
+public class AssetManagerRegistry {
+
+    private AgentPackageLoader assetManagerPackageLoader;
+
+    public AssetManagerRegistry() {}
+
+    public interface AssetPackage {
+        String getName();
+
+        ClassLoader getClassloader();
+    }
+
+    public interface AgentPackageLoader {
+        AssetPackage loadPackageForAsset(String assetType) throws Exception;
+
+        List<? extends ClassLoader> getAllClassloaders() throws Exception;
+
+        ClassLoader getCustomCodeClassloader();
+    }
+
+    @SneakyThrows
+    public AssetManagerAndLoader getAssetManager(String assetType) {
+        log.info("Loading AssetManager code for type {}", assetType);
+        Objects.requireNonNull(assetType, "assetType cannot be null");
+
+        ClassLoader customCodeClassloader =
+                assetManagerPackageLoader != null
+                        ? assetManagerPackageLoader.getCustomCodeClassloader()
+                        : AssetManagerRegistry.class.getClassLoader();
+        // always allow to find the system agents
+        AssetManagerAndLoader agentCodeProviderProviderFromSystem =
+                loadFromClassloader(assetType, customCodeClassloader);
+        if (agentCodeProviderProviderFromSystem != null) {
+            log.info("The agent {} is loaded from the system classpath", assetType);
+            return agentCodeProviderProviderFromSystem;
+        }
+
+        if (assetManagerPackageLoader != null) {
+            AssetPackage assetPackage = assetManagerPackageLoader.loadPackageForAsset(assetType);
+
+            if (assetPackage != null) {
+                log.info("Found the package the agent belongs to: {}", assetPackage.getName());
+                AssetManagerAndLoader agentCodeProviderProvider =
+                        loadFromClassloader(assetType, assetPackage.getClassloader());
+                if (agentCodeProviderProvider == null) {
+                    throw new RuntimeException(
+                            "Package "
+                                    + assetPackage.getName()
+                                    + " declared to support agent type "
+                                    + assetType
+                                    + " but no agent found");
+                }
+                return agentCodeProviderProvider;
+            }
+
+            log.info("No agent found in the package, let's try to find it among all the packages");
+
+            // we are not lucky, let's try to find the agent in all the packages
+            List<ClassLoader> candidateClassloaders =
+                    new ArrayList<>(assetManagerPackageLoader.getAllClassloaders());
+
+            for (ClassLoader classLoader : candidateClassloaders) {
+                AssetManagerAndLoader agentCodeProviderProvider =
+                        loadFromClassloader(assetType, classLoader);
+                if (agentCodeProviderProvider != null) {
+                    return agentCodeProviderProvider;
+                }
+            }
+        }
+
+        throw new RuntimeException("No AgentCodeProvider found for type " + assetType);
+    }
+
+    private static AssetManagerAndLoader loadFromClassloader(
+            String assetType, ClassLoader classLoader) {
+        ServiceLoader<AssetManagerProvider> loader =
+                ServiceLoader.load(AssetManagerProvider.class, classLoader);
+        Optional<ServiceLoader.Provider<AssetManagerProvider>> agentCodeProviderProvider =
+                loader.stream().filter(p -> p.get().supports(assetType)).findFirst();
+
+        return agentCodeProviderProvider
+                .map(
+                        provider ->
+                                new AssetManagerAndLoader(
+                                        provider.get().createInstance(assetType), classLoader))
+                .orElse(null);
+    }
+
+    public void setAssetManagerPackageLoader(AgentPackageLoader loader) {
+        this.assetManagerPackageLoader = loader;
+    }
+}

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/DeployContext.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/DeployContext.java
@@ -15,10 +15,20 @@
  */
 package ai.langstream.api.runtime;
 
+import ai.langstream.api.runner.assets.AssetManagerRegistry;
 import ai.langstream.api.webservice.application.ApplicationCodeInfo;
 
 public interface DeployContext extends AutoCloseable {
 
-    ApplicationCodeInfo getApplicationCodeInfo(
-            String tenant, String applicationId, String codeArchiveId);
+    default ApplicationCodeInfo getApplicationCodeInfo(
+            String tenant, String applicationId, String codeArchiveId) {
+        throw new UnsupportedOperationException();
+    }
+
+    default AssetManagerRegistry getAssetManagerRegistry() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default void close() {}
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/ExecutionPlan.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/ExecutionPlan.java
@@ -16,6 +16,7 @@
 package ai.langstream.api.runtime;
 
 import ai.langstream.api.model.Application;
+import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.model.Connection;
 import ai.langstream.api.model.Module;
 import ai.langstream.api.model.TopicDefinition;
@@ -32,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public final class ExecutionPlan {
 
     private final Map<TopicDefinition, Topic> topics = new HashMap<>();
+    private final List<AssetDefinition> assets = new ArrayList<>();
     private final Map<String, AgentNode> agents = new HashMap<>();
     private final String applicationId;
     private final Application application;
@@ -144,5 +146,13 @@ public final class ExecutionPlan {
                 .findFirst()
                 .map(Map.Entry::getKey)
                 .orElse(null);
+    }
+
+    public List<AssetDefinition> getAssets() {
+        return assets;
+    }
+
+    public void registerAsset(AssetDefinition asset) {
+        assets.add(asset);
     }
 }

--- a/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
@@ -101,6 +101,14 @@ public class ApplicationPlaceholderResolver {
                                 newTopics.put(resolveValue(context, topicName), definition);
                             });
             module.replaceTopics(newTopics);
+            if (module.getAssets() != null) {
+                module.getAssets()
+                        .forEach(
+                                asset -> {
+                                    asset.setConfig(resolveMap(context, asset.getConfig()));
+                                });
+            }
+
             for (Map.Entry<String, Pipeline> pipelineEntry : module.getPipelines().entrySet()) {
                 final Pipeline pipeline = pipelineEntry.getValue();
                 List<AgentConfiguration> newAgents = new ArrayList<>();

--- a/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
@@ -17,6 +17,7 @@ package ai.langstream.impl.common;
 
 import ai.langstream.api.model.AgentConfiguration;
 import ai.langstream.api.model.Application;
+import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.model.Connection;
 import ai.langstream.api.model.Module;
 import ai.langstream.api.model.Pipeline;
@@ -56,6 +57,8 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
 
         detectTopics(result, streamingClusterRuntime);
 
+        detectAssets(result);
+
         detectAgents(result, streamingClusterRuntime, pluginsRegistry);
 
         validateExecutionPlan(result, streamingClusterRuntime);
@@ -81,6 +84,23 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
                 Topic topicImplementation =
                         streamingClusterRuntime.createTopicImplementation(topic, result);
                 result.registerTopic(topic, topicImplementation);
+            }
+        }
+    }
+
+    /**
+     * Detects assets that are explicitly defined in the application instance.
+     *
+     * @param result the execution plan
+     */
+    protected void detectAssets(ExecutionPlan result) {
+        Application applicationInstance = result.getApplication();
+        for (Module module : applicationInstance.getModules().values()) {
+            if (module.getAssets() != null) {
+                // the order is important, there may be some dependencies between them
+                for (AssetDefinition asset : module.getAssets()) {
+                    result.registerAsset(asset);
+                }
             }
         }
     }

--- a/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
@@ -88,11 +88,7 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
         }
     }
 
-    /**
-     * Detects assets that are explicitly defined in the application instance.
-     *
-     * @param result the execution plan
-     */
+    /** Detects assets that are explicitly defined in the application instance. */
     protected void detectAssets(ExecutionPlan result) {
         Application applicationInstance = result.getApplication();
         for (Module module : applicationInstance.getModules().values()) {

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -21,6 +21,7 @@ import static ai.langstream.api.model.ErrorsSpec.SKIP;
 
 import ai.langstream.api.model.AgentConfiguration;
 import ai.langstream.api.model.Application;
+import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.model.ComputeCluster;
 import ai.langstream.api.model.Connection;
 import ai.langstream.api.model.Dependency;
@@ -430,6 +431,28 @@ public class ModelBuilder {
             }
         }
 
+        if (pipelineConfiguration.getAssets() != null) {
+            for (AssetDefinitionModel assetDefinition : pipelineConfiguration.getAssets()) {
+                String assetId =
+                        Objects.requireNonNullElse(
+                                assetDefinition.getId(), assetDefinition.getName());
+                if (assetId == null || assetId.isEmpty()) {
+                    throw new IllegalArgumentException("Asset id or name are required");
+                }
+                String name = assetDefinition.getName();
+                if (assetDefinition.getName() == null) {
+                    name = assetDefinition.getId();
+                }
+                module.addAsset(
+                        new AssetDefinition(
+                                assetId,
+                                name,
+                                assetDefinition.getCreationMode(),
+                                assetDefinition.getAssetType(),
+                                assetDefinition.getConfig()));
+            }
+        }
+
         int autoId = 1;
         if (pipelineConfiguration.getPipeline() != null) {
             for (AgentModel agent : pipelineConfiguration.getPipeline()) {
@@ -560,6 +583,8 @@ public class ModelBuilder {
 
         private List<TopicDefinitionModel> topics = new ArrayList<>();
 
+        private List<AssetDefinitionModel> assets = new ArrayList<>();
+
         private ResourcesSpec resources;
         private ErrorsSpec errors;
     }
@@ -579,6 +604,22 @@ public class ModelBuilder {
 
         private SchemaDefinition keySchema;
         private Map<String, Object> options;
+        private Map<String, Object> config;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class AssetDefinitionModel {
+        private String id;
+        private String name;
+
+        @JsonProperty("creation-mode")
+        private String creationMode;
+
+        @JsonProperty("asset-type")
+        private String assetType;
+
         private Map<String, Object> config;
     }
 

--- a/langstream-core/src/test/java/ai/langstream/model/parser/AssetsTest.java
+++ b/langstream-core/src/test/java/ai/langstream/model/parser/AssetsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.model.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import ai.langstream.api.model.AgentConfiguration;
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.Module;
+import ai.langstream.api.model.Pipeline;
+import ai.langstream.impl.parser.ModelBuilder;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ResourcesSpecsTest {
+
+    @Test
+    public void testConfigureResourceSpecs() throws Exception {
+        Application applicationInstance =
+                ModelBuilder.buildApplicationInstance(
+                                Map.of(
+                                        "module.yaml",
+                                                """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                resources:
+                                   parallelism: 7
+                                   size: 7
+                                topics:
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - name: "step1"
+                                    type: "noop"
+                                    input: "input-topic"
+                                  - name: "step2"
+                                    type: "noop"
+                                    resources:
+                                       parallelism: 2
+                                  - name: "step3"
+                                    type: "noop"
+                                    resources:
+                                       size: 3
+                                  - name: "step3"
+                                    type: "noop"
+                                    resources:
+                                       size: 3
+                                       parallelism: 5
+                                """,
+                                        "module2.yaml",
+                                                """
+                                module: "module-2"
+                                id: "pipeline-2"
+                                topics:
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - name: "step1"
+                                    type: "noop"
+                                    input: "input-topic"
+                                  - name: "step2"
+                                    type: "noop"
+                                    resources:
+                                       parallelism: 2
+                                  - name: "step3"
+                                    type: "noop"
+                                    resources:
+                                       size: 3
+                                  - name: "step3"
+                                    type: "noop"
+                                    resources:
+                                       size: 3
+                                       parallelism: 5
+                                """),
+                                buildInstanceYaml(),
+                                null)
+                        .getApplication();
+
+        {
+            Module module = applicationInstance.getModule("module-1");
+            Pipeline pipeline = module.getPipelines().get("pipeline-1");
+
+            AgentConfiguration agent1 = pipeline.getAgents().get(0);
+            assertNotNull(agent1.getResources());
+            assertEquals(7, agent1.getResources().parallelism());
+            assertEquals(7, agent1.getResources().size());
+
+            AgentConfiguration agent2 = pipeline.getAgents().get(1);
+            assertNotNull(agent2.getResources());
+            assertEquals(2, agent2.getResources().parallelism());
+            assertEquals(7, agent2.getResources().size());
+
+            AgentConfiguration agent3 = pipeline.getAgents().get(2);
+            assertNotNull(agent3.getResources());
+            assertEquals(7, agent3.getResources().parallelism());
+            assertEquals(3, agent3.getResources().size());
+        }
+
+        {
+            Module module = applicationInstance.getModule("module-2");
+            Pipeline pipeline = module.getPipelines().get("pipeline-2");
+
+            AgentConfiguration agent1 = pipeline.getAgents().get(0);
+            assertNotNull(agent1.getResources());
+            assertEquals(1, agent1.getResources().parallelism());
+            assertEquals(1, agent1.getResources().size());
+
+            AgentConfiguration agent2 = pipeline.getAgents().get(1);
+            assertNotNull(agent2.getResources());
+            assertEquals(2, agent2.getResources().parallelism());
+            assertEquals(1, agent2.getResources().size());
+
+            AgentConfiguration agent3 = pipeline.getAgents().get(2);
+            assertNotNull(agent3.getResources());
+            assertEquals(1, agent3.getResources().parallelism());
+            assertEquals(3, agent3.getResources().size());
+        }
+    }
+
+    private static String buildInstanceYaml() {
+        return """
+                instance:
+                  streamingCluster:
+                    type: "noop"
+                  computeCluster:
+                    type: "none"
+                """;
+    }
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AgentControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AgentControllerIT.java
@@ -70,7 +70,8 @@ public class AgentControllerIT {
                                                 "fn-type",
                                                 Map.of("config", true),
                                                 Map.of()),
-                                        new StreamingCluster("noop", Map.of("config", true)))))
+                                        new StreamingCluster("noop", Map.of("config", true)),
+                                        null)))
                 .inNamespace(namespace)
                 .serverSideApply();
 

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntime.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntime.java
@@ -158,10 +158,10 @@ public class KubernetesClusterRuntime extends BasicClusterRuntime {
                     .getConfig()
                     .forEach(
                             (key, value) -> {
-
                                 // automatically resolve resource references
                                 // should we do it depending on the asset type ?
-                                if (value instanceof String resourceId) {
+                                if ("datasource".equals(key)
+                                        && value instanceof String resourceId) {
                                     Resource resource = resources.get(resourceId);
                                     if (resource != null) {
                                         value = resource;
@@ -170,6 +170,7 @@ public class KubernetesClusterRuntime extends BasicClusterRuntime {
                                 configuration.put(key, value);
                             });
         }
+        asset.put("config", configuration);
         return asset;
     }
 

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntimeDockerTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntimeDockerTest.java
@@ -315,9 +315,6 @@ class KubernetesClusterRuntimeDockerTest {
                                         "java-%s-%s-%s".formatted(tenant, applicationId, last));
                                 return new ApplicationCodeInfo(digests);
                             }
-
-                            @Override
-                            public void close() throws Exception {}
                         });
 
         ExecutionPlan implementation = deployer.createImplementation("app", applicationInstance);

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntimeTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/KubernetesClusterRuntimeTest.java
@@ -126,9 +126,6 @@ class KubernetesClusterRuntimeTest {
                         }
                         return mapped;
                     }
-
-                    @Override
-                    public void close() throws Exception {}
                 };
 
         final String result =

--- a/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreLogsTest.java
+++ b/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreLogsTest.java
@@ -149,7 +149,8 @@ class KubernetesApplicationStoreLogsTest {
                                                 "fn-type",
                                                 Map.of("config", true),
                                                 Map.of()),
-                                        new StreamingCluster("noop", Map.of("config", true)))))
+                                        new StreamingCluster("noop", Map.of("config", true)),
+                                        null)))
                 .inNamespace("langstream-" + tenant)
                 .serverSideApply();
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -19,6 +19,10 @@ import static ai.langstream.api.model.ErrorsSpec.DEAD_LETTER;
 import static ai.langstream.api.model.ErrorsSpec.FAIL;
 import static ai.langstream.api.model.ErrorsSpec.SKIP;
 
+import ai.langstream.api.model.AssetDefinition;
+import ai.langstream.api.runner.assets.AssetManager;
+import ai.langstream.api.runner.assets.AssetManagerAndLoader;
+import ai.langstream.api.runner.assets.AssetManagerRegistry;
 import ai.langstream.api.runner.code.AgentCode;
 import ai.langstream.api.runner.code.AgentCodeAndLoader;
 import ai.langstream.api.runner.code.AgentCodeRegistry;
@@ -158,6 +162,12 @@ public class AgentRunner {
         try (NarFileHandler narFileHandler =
                 new NarFileHandler(agentsDirectory, customLibClassloader)) {
             narFileHandler.scan();
+
+            AssetManagerRegistry assetManagerRegistry = new AssetManagerRegistry();
+            assetManagerRegistry.setAssetManagerPackageLoader(narFileHandler);
+
+            deployAssets(configuration, assetManagerRegistry);
+
             AgentCodeRegistry agentCodeRegistry = new AgentCodeRegistry();
             agentCodeRegistry.setAgentPackageLoader(narFileHandler);
 
@@ -165,7 +175,6 @@ public class AgentRunner {
                     TOPIC_CONNECTIONS_REGISTRY.getTopicConnectionsRuntime(
                             configuration.streamingCluster());
 
-            log.info("TopicConnectionsRuntime {}", topicConnectionsRuntime);
             try {
                 AgentCodeAndLoader agentCode = initAgent(configuration, agentCodeRegistry);
                 Server server = null;
@@ -967,6 +976,45 @@ public class AgentRunner {
         @Override
         public TopicConnectionProvider getTopicConnectionProvider() {
             return topicConnectionProvider;
+        }
+    }
+
+    private void deployAssets(
+            RuntimePodConfiguration configuration, AssetManagerRegistry assetManagerRegistry)
+            throws Exception {
+        if (configuration.assets() != null) {
+            for (Map<String, Object> assetDefinition : configuration.assets()) {
+                AssetDefinition asset = MAPPER.convertValue(assetDefinition, AssetDefinition.class);
+                deployAsset(asset, assetManagerRegistry);
+            }
+        }
+    }
+
+    private void deployAsset(AssetDefinition asset, AssetManagerRegistry assetManagerRegistry)
+            throws Exception {
+        log.info("Deploying asset {}", asset);
+        AssetManagerAndLoader assetManager =
+                assetManagerRegistry.getAssetManager(asset.getAssetType());
+        if (assetManager == null) {
+            throw new RuntimeException(
+                    "No asset manager found for asset type " + asset.getAssetType());
+        }
+        try {
+            String creationMode = asset.getCreationMode();
+            switch (creationMode) {
+                case AssetDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS -> {
+                    AssetManager assetManagerImpl = assetManager.asAssetManager();
+                    boolean exists = assetManagerImpl.assetExists(asset);
+                    if (!exists) {
+                        assetManagerImpl.deployAsset(asset);
+                    }
+                }
+                case AssetDefinition.CREATE_MODE_NONE -> {
+                    return;
+                }
+            }
+        } finally {
+            assetManager.close();
         }
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -1005,7 +1005,12 @@ public class AgentRunner {
                 case AssetDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS -> {
                     AssetManager assetManagerImpl = assetManager.asAssetManager();
                     boolean exists = assetManagerImpl.assetExists(asset);
+
                     if (!exists) {
+                        log.info(
+                                "Asset {}  of type {} needs to be created",
+                                asset.getName(),
+                                asset.getAssetType());
                         assetManagerImpl.deployAsset(asset);
                     }
                 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/deployer/RuntimeDeployer.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/deployer/RuntimeDeployer.java
@@ -138,7 +138,7 @@ public class RuntimeDeployer {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             if (adminClient != null) {
                 adminClient.close();
             }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -111,13 +111,26 @@ public abstract class AbstractApplicationRunner {
             String instance,
             String... expectedAgents)
             throws Exception {
+        return deployApplicationWithSecrets(
+                tenant, appId, application, instance, null, expectedAgents);
+    }
+
+    protected ApplicationRuntime deployApplicationWithSecrets(
+            String tenant,
+            String appId,
+            Map<String, String> application,
+            String instance,
+            String secretsContents,
+            String... expectedAgents)
+            throws Exception {
 
         kubeServer.spyAgentCustomResources(tenant, expectedAgents);
         final Map<String, Secret> secrets =
                 kubeServer.spyAgentCustomResourcesSecrets(tenant, expectedAgents);
 
         Application applicationInstance =
-                ModelBuilder.buildApplicationInstance(application, instance, null).getApplication();
+                ModelBuilder.buildApplicationInstance(application, instance, secretsContents)
+                        .getApplication();
 
         ExecutionPlan implementation =
                 applicationDeployer.createImplementation(appId, applicationInstance);

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/assets/DeployAssetsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.assets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.langstream.AbstractApplicationRunner;
+import ai.langstream.api.model.AssetDefinition;
+import ai.langstream.mockagents.MockAssetManagerCodeProvider;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class DeployAssetsTest extends AbstractApplicationRunner {
+
+    @Test
+    public void testDeployAsset() throws Exception {
+        String tenant = "tenant";
+        String[] expectedAgents = {"app-step1"};
+
+        Map<String, String> application =
+                Map.of(
+                        "configuration.yaml",
+                        """
+                configuration:
+                   resources:
+                        - name: "the-resource"
+                          type: "datasource"
+                          configuration:
+                              foo: bar
+                """);
+        Map.of(
+                "module.yaml",
+                """
+                        module: "module-1"
+                        id: "pipeline-1"
+                        assets:
+                          - name: "my-table"
+                            asset-type: "mock-database-resource"
+                            config:
+                                table: "my-table"
+                                datasource: "the-resource"
+                        topics:
+                          - name: "input-topic"
+                            creation-mode: create-if-not-exists
+                          - name: "output-topic"
+                            creation-mode: create-if-not-exists
+                        pipeline:
+                          - name: "identity"
+                            id: "step1"
+                            type: "identity"
+                            input: "input-topic"
+                            output: "output-topic"
+                        """);
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer();
+                    KafkaConsumer<String, String> consumer = createConsumer("output-topic")) {
+                sendMessage("input-topic", "test", producer);
+                executeAgentRunners(applicationRuntime);
+                waitForMessages(consumer, List.of("test"));
+            }
+
+            CopyOnWriteArrayList<AssetDefinition> deployedAssets =
+                    MockAssetManagerCodeProvider.MockDatabaseResourceAssetManager.DEPLOYED_ASSETS;
+            assertEquals(1, deployedAssets.size());
+            AssetDefinition deployedAsset = deployedAssets.get(0);
+            Map<String, Object> datasource =
+                    (Map<String, Object>) deployedAsset.getConfig().get("datasource");
+            assertEquals("bar", datasource.get("foo"));
+        }
+    }
+
+    @Override
+    protected String buildInstanceYaml() {
+        return """
+                instance:
+                  streamingCluster:
+                    type: "kafka"
+                    configuration:
+                      admin:
+                        bootstrap.servers: "%s"
+                  computeCluster:
+                     type: "kubernetes"
+                """
+                .formatted(kafkaContainer.getBootstrapServers());
+    }
+}

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
@@ -44,12 +44,13 @@ public class MockAssetManagerCodeProvider implements AssetManagerProvider {
                 new CopyOnWriteArrayList<>();
 
         @Override
-        public boolean assetExists(AssetDefinition assetDefinition) throws Exception {
-            return false;
+        public synchronized boolean assetExists(AssetDefinition assetDefinition) throws Exception {
+            return DEPLOYED_ASSETS.stream()
+                    .anyMatch(a -> a.getId().equals(assetDefinition.getId()));
         }
 
         @Override
-        public void deployAsset(AssetDefinition assetDefinition) throws Exception {
+        public synchronized void deployAsset(AssetDefinition assetDefinition) throws Exception {
             log.info("Deploying asset {}", assetDefinition);
             DEPLOYED_ASSETS.add(assetDefinition);
         }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.mockagents;
+
+import ai.langstream.api.model.AssetDefinition;
+import ai.langstream.api.runner.assets.AssetManager;
+import ai.langstream.api.runner.assets.AssetManagerProvider;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MockAssetManagerCodeProvider implements AssetManagerProvider {
+    @Override
+    public boolean supports(String agentType) {
+        return "mock-database-resource".equals(agentType);
+    }
+
+    @Override
+    public AssetManager createInstance(String agentType) {
+        switch (agentType) {
+            case "mock-database-resource":
+                return new MockDatabaseResourceAssetManager();
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    public static class MockDatabaseResourceAssetManager implements AssetManager {
+
+        public static CopyOnWriteArrayList<AssetDefinition> DEPLOYED_ASSETS =
+                new CopyOnWriteArrayList<>();
+
+        @Override
+        public boolean assetExists(AssetDefinition assetDefinition) throws Exception {
+            return false;
+        }
+
+        @Override
+        public void deployAsset(AssetDefinition assetDefinition) throws Exception {
+            log.info("Deploying asset {}", assetDefinition);
+            DEPLOYED_ASSETS.add(assetDefinition);
+        }
+    }
+}

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/LoadAgentCodeTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/LoadAgentCodeTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.kafka;
+package ai.langstream.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/LoadAssertManagerCodeTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/LoadAssertManagerCodeTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import ai.langstream.api.model.AssetDefinition;
+import ai.langstream.api.runner.assets.AssetManager;
+import ai.langstream.api.runner.assets.AssetManagerRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class LoadAssertManagerCodeTest {
+
+    @Test
+    public void testLoadNoop() throws Exception {
+        AssetManagerRegistry registry = new AssetManagerRegistry();
+        AssetDefinition assetDefinition = new AssetDefinition();
+        assetDefinition.setAssetType("mock-database-resource");
+        AssetManager assetManager =
+                registry.getAssetManager(assetDefinition.getAssetType()).agentCode();
+
+        assertFalse(assetManager.assetExists(assetDefinition));
+        assetManager.deployAsset(assetDefinition);
+    }
+}

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
@@ -38,7 +38,8 @@ class AgentRunnerStarterTest {
         String podRuntimeFile =
                 Files.createTempFile("langstream", ".json").toFile().getAbsolutePath();
         mapper.writeValue(
-                new File(podRuntimeFile), new RuntimePodConfiguration(null, null, null, null));
+                new File(podRuntimeFile),
+                new RuntimePodConfiguration(null, null, null, null, null));
         String codeDir =
                 Files.createTempDirectory("langstream-cli-test").toFile().getAbsolutePath();
         String agentsDir =

--- a/langstream-runtime/langstream-runtime-impl/src/test/resources/META-INF/services/ai.langstream.api.runner.assets.AssetManagerProvider
+++ b/langstream-runtime/langstream-runtime-impl/src/test/resources/META-INF/services/ai.langstream.api.runner.assets.AssetManagerProvider
@@ -1,0 +1,1 @@
+ai.langstream.mockagents.MockAssetManagerCodeProvider


### PR DESCRIPTION
Fixes #353 

Summary:
- Add the new concept of "asset"
- An Asset is an external resource that is handled by the LangStream application
- At deploy time and undeploy time the "init job" and the "clean up job" can execute some code, dependent on the type of the asset


The main use case here is to create tables of vector databases in order to fully set up the application when you deploy it 


This is a preliminary PR that builds all the infrastructure to make Assets work.
The next step is to implement the "cassandra-table" AssetManager (and maybe validation at the planner side of the available  asset types)
