### PR TITLE
Cli: add profiles

### DIFF
--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,19 +1,13 @@
-#
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-webServiceUrl: http://localhost:8090
-apiGatewayUrl: ws://localhost:8091
-tenant: default
+---
+webServiceUrl: "http://localhost:8090"
+apiGatewayUrl: "ws://localhost:8091"
+tenant: "default"
+token: null
+profiles:
+  new:
+    webServiceUrl: "ss"
+    apiGatewayUrl: null
+    tenant: "gigio"
+    token: null
+    name: "new"
+currentProfile: "new"

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -14,16 +14,6 @@
 # limitations under the License.
 #
 
----
-webServiceUrl: "http://localhost:8090"
-apiGatewayUrl: "ws://localhost:8091"
-tenant: "default"
-token: null
-profiles:
-  new:
-    webServiceUrl: "ss"
-    apiGatewayUrl: null
-    tenant: "gigio"
-    token: null
-    name: "new"
-currentProfile: "new"
+webServiceUrl: http://localhost:8090
+apiGatewayUrl: ws://localhost:8091
+tenant: default

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -205,7 +205,7 @@ public class AdminClient implements AutoCloseable {
         final String tenant = configuration.getTenant();
         if (tenant == null) {
             throw new IllegalStateException(
-                    "Tenant not set. Run 'langstream configure tenant <tenant>' to set it.");
+                    "Tenant not set. Please set the tenant in the configuration.");
         }
         logger.debug("Using tenant: %s".formatted(tenant));
         return "/applications/%s%s".formatted(tenant, uri);

--- a/langstream-cli/src/main/java/ai/langstream/cli/NamedProfile.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/NamedProfile.java
@@ -1,0 +1,11 @@
+package ai.langstream.cli;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NamedProfile extends Profile {
+
+    private String name;
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/NamedProfile.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/NamedProfile.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.cli;
 
 import lombok.Getter;

--- a/langstream-cli/src/main/java/ai/langstream/cli/Profile.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/Profile.java
@@ -1,0 +1,17 @@
+package ai.langstream.cli;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Profile {
+
+    @JsonProperty(required = true)
+    private String webServiceUrl;
+
+    private String apiGatewayUrl;
+    private String tenant;
+    private String token;
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/Profile.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/Profile.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.cli;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -19,6 +19,8 @@ import ai.langstream.admin.client.AdminClient;
 import ai.langstream.admin.client.AdminClientConfiguration;
 import ai.langstream.admin.client.AdminClientLogger;
 import ai.langstream.cli.LangStreamCLIConfig;
+import ai.langstream.cli.NamedProfile;
+import ai.langstream.cli.commands.profiles.BaseProfileCmd;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -44,7 +46,8 @@ public abstract class BaseCmd implements Runnable {
         yaml
     }
 
-    private static final ObjectMapper yamlConfigReader = new ObjectMapper(new YAMLFactory());
+    protected static final ObjectMapper yamlConfigReader = new ObjectMapper(new YAMLFactory());
+    protected static final ObjectMapper jsonConfigReader = new ObjectMapper();
     protected static final ObjectMapper jsonPrinter =
             new ObjectMapper()
                     .enable(SerializationFeature.INDENT_OUTPUT)
@@ -81,7 +84,7 @@ public abstract class BaseCmd implements Runnable {
                             BaseCmd.this.debug(message);
                         }
                     };
-            client = new AdminClient(toAdminConfiguration(getConfig()), logger);
+            client = new AdminClient(toAdminConfiguration(), logger);
         }
         return client;
     }
@@ -91,11 +94,46 @@ public abstract class BaseCmd implements Runnable {
         return config;
     }
 
-    private static AdminClientConfiguration toAdminConfiguration(LangStreamCLIConfig config) {
+    protected NamedProfile getDefaultProfile() {
+        final LangStreamCLIConfig config = getConfig();
+        final NamedProfile defaultProfile =
+                new NamedProfile();
+        defaultProfile.setName(BaseProfileCmd.DEFAULT_PROFILE_NAME);
+        defaultProfile.setTenant(config.getTenant());
+        defaultProfile.setToken(config.getToken());
+        defaultProfile.setWebServiceUrl(config.getWebServiceUrl());
+        defaultProfile.setApiGatewayUrl(config.getApiGatewayUrl());
+        return defaultProfile;
+    }
+
+    protected NamedProfile getCurrentProfile() {
+        final String profile;
+        if (getRootCmd().getProfile() != null) {
+            profile = getRootCmd().getProfile();
+        } else {
+            profile = getConfig().getCurrentProfile();
+        }
+        if (BaseProfileCmd.DEFAULT_PROFILE_NAME.equals(profile)) {
+            return getDefaultProfile();
+        }
+        final NamedProfile result = getConfig().getProfiles().get(profile);
+        if (result == null) {
+            throw new IllegalStateException(
+                    "No profile '%s' defined in configuration".formatted(profile));
+        }
+        return result;
+    }
+
+    private AdminClientConfiguration toAdminConfiguration() {
+        final NamedProfile profile = getCurrentProfile();
+        if (profile.getWebServiceUrl() == null) {
+            throw new IllegalStateException(
+                    "No webServiceUrl defined for profile '%s'".formatted(profile.getName()));
+        }
         return AdminClientConfiguration.builder()
-                .webServiceUrl(config.getWebServiceUrl())
-                .token(config.getToken())
-                .tenant(config.getTenant())
+                .webServiceUrl(profile.getWebServiceUrl())
+                .token(profile.getToken())
+                .tenant(profile.getTenant())
                 .build();
     }
 
@@ -247,7 +285,7 @@ public abstract class BaseCmd implements Runnable {
             if (i > 0) {
                 formatTemplate.append("  ");
             }
-            formatTemplate.append("%-15.15s");
+            formatTemplate.append("%-25.25s");
         }
         return formatTemplate.toString();
     }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -233,7 +233,11 @@ public abstract class BaseCmd implements Runnable {
                                 .elements()
                                 .forEachRemaining(
                                         element ->
-                                                rows.add(prepareRawRow(element, columnsForRaw, valueSupplier)));
+                                                rows.add(
+                                                        prepareRawRow(
+                                                                element,
+                                                                columnsForRaw,
+                                                                valueSupplier)));
                     } else {
                         rows.add(prepareRawRow(readValue, columnsForRaw, valueSupplier));
                     }
@@ -256,7 +260,6 @@ public abstract class BaseCmd implements Runnable {
             String[] columnsForRaw,
             BiFunction<JsonNode, String, Object> valueSupplier) {
         final int numColumns = columnsForRaw.length;
-
 
         String[] row = new String[numColumns];
         for (int i = 0; i < numColumns; i++) {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -96,8 +96,7 @@ public abstract class BaseCmd implements Runnable {
 
     protected NamedProfile getDefaultProfile() {
         final LangStreamCLIConfig config = getConfig();
-        final NamedProfile defaultProfile =
-                new NamedProfile();
+        final NamedProfile defaultProfile = new NamedProfile();
         defaultProfile.setName(BaseProfileCmd.DEFAULT_PROFILE_NAME);
         defaultProfile.setTenant(config.getTenant());
         defaultProfile.setToken(config.getToken());

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
@@ -31,6 +31,7 @@ import picocli.CommandLine;
             ConfigureCmd.class,
             RootTenantCmd.class,
             RootGatewayCmd.class,
+            RootProfileCmd.class,
             AutoComplete.GenerateCompletion.class
         })
 public class RootCmd {
@@ -40,6 +41,12 @@ public class RootCmd {
             description = "LangStream CLI configuration file.")
     @Getter
     private String configPath;
+
+    @CommandLine.Option(
+            names = {"-p", "--profile"},
+            description = "Profile to use with the command.")
+    @Getter
+    private String profile;
 
     @CommandLine.Option(
             names = {"-v", "--verbose"},

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootProfileCmd.java
@@ -18,10 +18,10 @@ package ai.langstream.cli.commands;
 import ai.langstream.cli.commands.profiles.CreateUpdateProfileCmd;
 import ai.langstream.cli.commands.profiles.DeleteProfileCmd;
 import ai.langstream.cli.commands.profiles.GetCurrentProfileCmd;
+import ai.langstream.cli.commands.profiles.GetProfileCmd;
 import ai.langstream.cli.commands.profiles.ImportProfileCmd;
 import ai.langstream.cli.commands.profiles.ListProfileCmd;
 import ai.langstream.cli.commands.profiles.SetCurrentProfileCmd;
-import ai.langstream.cli.commands.profiles.GetProfileCmd;
 import lombok.Getter;
 import picocli.CommandLine;
 

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootProfileCmd.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands;
+
+import ai.langstream.cli.commands.profiles.CreateUpdateProfileCmd;
+import ai.langstream.cli.commands.profiles.DeleteProfileCmd;
+import ai.langstream.cli.commands.profiles.GetCurrentProfileCmd;
+import ai.langstream.cli.commands.profiles.ImportProfileCmd;
+import ai.langstream.cli.commands.profiles.ListProfileCmd;
+import ai.langstream.cli.commands.profiles.SetCurrentProfileCmd;
+import ai.langstream.cli.commands.profiles.GetProfileCmd;
+import lombok.Getter;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "profiles",
+        header = "Manage local profiles",
+        subcommands = {
+            CreateUpdateProfileCmd.CreateProfileCmd.class,
+            CreateUpdateProfileCmd.UpdateProfileCmd.class,
+            ListProfileCmd.class,
+            GetCurrentProfileCmd.class,
+            SetCurrentProfileCmd.class,
+            GetProfileCmd.class,
+            ImportProfileCmd.class,
+            DeleteProfileCmd.class
+        })
+@Getter
+public class RootProfileCmd {
+    @CommandLine.ParentCommand private RootCmd rootCmd;
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DownloadApplicationCodeCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DownloadApplicationCodeCmd.java
@@ -57,7 +57,7 @@ public class DownloadApplicationCodeCmd extends BaseApplicationCmd {
                 }
             }
             if (filename == null) {
-                filename = "%s-%s.zip".formatted(getConfig().getTenant(), applicationId);
+                filename = "%s-%s.zip".formatted(getCurrentProfile().getTenant(), applicationId);
             }
             path = Path.of(filename);
         }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/configure/ConfigureCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/configure/ConfigureCmd.java
@@ -17,12 +17,16 @@ package ai.langstream.cli.commands.configure;
 
 import ai.langstream.cli.commands.BaseCmd;
 import ai.langstream.cli.commands.RootCmd;
+import ai.langstream.cli.commands.profiles.BaseProfileCmd;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "configure", header = "Configure LangStream tenant and authentication")
+@CommandLine.Command(
+        name = "configure",
+        header =
+                "Configure LangStream tenant and authentication. DEPRECATED. Use 'langstream profiles' instead.")
 @Getter
 public class ConfigureCmd extends BaseCmd {
 
@@ -44,6 +48,9 @@ public class ConfigureCmd extends BaseCmd {
     @Override
     @SneakyThrows
     public void run() {
+        if (getRootCmd().getProfile() != null) {
+            throw new IllegalArgumentException("Global profile flag is not allowed here");
+        }
         updateConfig(
                 clientConfig -> {
                     switch (configKey) {
@@ -56,6 +63,8 @@ public class ConfigureCmd extends BaseCmd {
                                         .formatted(configKey, Arrays.toString(ConfigKey.values())));
                     }
                 });
-        log("Config updated: %s=%s".formatted(configKey, newValue));
+        log(
+                "profile %s updated: %s=%s"
+                        .formatted(BaseProfileCmd.DEFAULT_PROFILE_NAME, configKey, newValue));
     }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
@@ -88,12 +88,20 @@ public abstract class BaseGatewayCmd extends BaseCmd {
         validateGateway(applicationId, gatewayId, type, params, options, credentials);
         return "%s/v1/%s/%s/%s/%s?%s"
                 .formatted(
-                        getConfig().getApiGatewayUrl(),
+                        getApiGatewayUrl(),
                         type.toString(),
-                        getConfig().getTenant(),
+                        getTenant(),
                         applicationId,
                         gatewayId,
                         computeQueryString(credentials, params, options));
+    }
+
+    private String getTenant() {
+        return getCurrentProfile().getTenant();
+    }
+
+    private String getApiGatewayUrl() {
+        return getCurrentProfile().getApiGatewayUrl();
     }
 
     private Map<String, String> applicationDescriptions = new HashMap<>();

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/BaseProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/BaseProfileCmd.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.profiles;
+
+import ai.langstream.cli.LangStreamCLIConfig;
+import ai.langstream.cli.NamedProfile;
+import ai.langstream.cli.Profile;
+import ai.langstream.cli.commands.BaseCmd;
+import ai.langstream.cli.commands.RootCmd;
+import ai.langstream.cli.commands.RootProfileCmd;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import picocli.CommandLine;
+
+public abstract class BaseProfileCmd extends BaseCmd {
+
+    public static final String DEFAULT_PROFILE_NAME = "default";
+    @CommandLine.ParentCommand private RootProfileCmd cmd;
+
+    @Override
+    protected RootCmd getRootCmd() {
+        return cmd.getRootCmd();
+    }
+
+    protected void checkGlobalFlags() {
+        if (getRootCmd().getProfile() != null) {
+            throw new IllegalArgumentException(
+                    "Global profile flag is not allowed for profiles commands");
+        }
+    }
+
+    protected void validateProfile(Profile profile) {
+        if (StringUtils.isBlank(profile.getWebServiceUrl())) {
+            throw new IllegalArgumentException("webServiceUrl is required");
+        }
+    }
+
+    protected List<NamedProfile> listAllProfiles() {
+        final LangStreamCLIConfig config = getConfig();
+        List<NamedProfile> all = new ArrayList<>();
+        final NamedProfile defaultProfile = getDefaultProfile();
+        all.add(defaultProfile);
+        final Collection<NamedProfile> values = config.getProfiles().values();
+        all.addAll(values);
+        return all;
+    }
+
+    protected NamedProfile getProfileOrThrow(String name) {
+        if (DEFAULT_PROFILE_NAME.equals(name)) {
+            return getDefaultProfile();
+        }
+        final NamedProfile profile = getConfig().getProfiles().get(name);
+        if (profile == null) {
+            throw new IllegalArgumentException(getProfileNotFoundMessage(name));
+        }
+        return profile;
+    }
+
+    protected String getProfileNotFoundMessage(String name) {
+        return "Profile %s not found, maybe you meant one of these: %s"
+                .formatted(
+                        name,
+                        listAllProfiles().stream()
+                                .map(NamedProfile::getName)
+                                .collect(Collectors.joining(", ")));
+    }
+
+    protected void checkProfileName(String name) {
+        if (DEFAULT_PROFILE_NAME.equals(name)) {
+            throw new IllegalArgumentException("Profile name %s is reserved".formatted(name));
+        }
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/CreateUpdateProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/CreateUpdateProfileCmd.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.profiles;
+
+import ai.langstream.cli.NamedProfile;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+public abstract class CreateUpdateProfileCmd extends BaseProfileCmd {
+
+    @CommandLine.Parameters(description = "Name of the profile")
+    private String name;
+
+    @CommandLine.Option(
+            names = {"--set-current"},
+            description = "Set this profile as current")
+    private boolean setAsCurrent;
+
+    @CommandLine.Option(
+            names = {"--web-service-url"},
+            description = "webServiceUrl of the profile")
+    private String webServiceUrl;
+
+    @CommandLine.Option(
+            names = {"--api-gateway-url"},
+            description = "apiGatewayUrl of the profile")
+    private String apiGatewayUrl;
+
+    @CommandLine.Option(
+            names = {"--tenant"},
+            description = "tenant of the profile")
+    private String tenant;
+
+    @CommandLine.Option(
+            names = {"--token"},
+            description = "token of the profile")
+    private String token;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        checkGlobalFlags();
+        checkProfileName(name);
+
+        NamedProfile profile = getConfig().getProfiles().get(name);
+        if (isCreate()) {
+            if (profile != null) {
+                throw new IllegalArgumentException("Profile %s already exists".formatted(name));
+            }
+            profile = new NamedProfile();
+            profile.setName(name);
+        } else {
+            if (profile == null) {
+                throw new IllegalArgumentException(getProfileNotFoundMessage(name));
+            }
+        }
+
+        if (webServiceUrl != null) {
+            profile.setWebServiceUrl(webServiceUrl);
+        }
+        if (apiGatewayUrl != null) {
+            profile.setApiGatewayUrl(apiGatewayUrl);
+        }
+        if (tenant != null) {
+            profile.setTenant(tenant);
+        }
+        if (token != null) {
+            profile.setToken(token);
+        }
+        validateProfile(profile);
+
+        final NamedProfile finalProfile = profile;
+
+        updateConfig(
+                langStreamCLIConfig -> {
+                    langStreamCLIConfig.getProfiles().put(name, finalProfile);
+                    if (isCreate()) {
+                        log("profile %s created".formatted(name));
+                    } else {
+                        log("profile %s updated".formatted(name));
+                    }
+                    if (setAsCurrent) {
+                        langStreamCLIConfig.setCurrentProfile(name);
+                        log("profile %s set as current".formatted(name));
+                    }
+                });
+    }
+
+    protected abstract boolean isCreate();
+
+    @CommandLine.Command(name = "create", header = "Create a new profile")
+    public static class CreateProfileCmd extends CreateUpdateProfileCmd {
+
+        @Override
+        protected boolean isCreate() {
+            return true;
+        }
+    }
+
+    @CommandLine.Command(name = "update", header = "Update an existing profile")
+    public static class UpdateProfileCmd extends CreateUpdateProfileCmd {
+
+        @Override
+        protected boolean isCreate() {
+            return false;
+        }
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/DeleteProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/DeleteProfileCmd.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.profiles;
+
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "delete", header = "Delete an existing profile")
+public class DeleteProfileCmd extends BaseProfileCmd {
+
+    @CommandLine.Parameters(description = "Name of the profile")
+    private String name;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        checkGlobalFlags();
+        checkProfileName(name);
+        getProfileOrThrow(name);
+        updateConfig(
+                langStreamCLIConfig -> {
+                    if (name.equals(langStreamCLIConfig.getCurrentProfile())) {
+                        throw new IllegalArgumentException("Cannot delete the current profile");
+                    }
+
+                    langStreamCLIConfig.getProfiles().remove(name);
+                    log("profile %s deleted".formatted(name));
+                });
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/GetCurrentProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/GetCurrentProfileCmd.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.cli;
+package ai.langstream.cli.commands.profiles;
 
-import java.util.Map;
-import java.util.TreeMap;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
 
-@Getter
-@Setter
-public class LangStreamCLIConfig extends Profile {
+@CommandLine.Command(name = "get-current", header = "Get current profile")
+public class GetCurrentProfileCmd extends BaseProfileCmd {
 
-    private Map<String, NamedProfile> profiles = new TreeMap<>();
-
-    private String currentProfile = "default";
+    @Override
+    @SneakyThrows
+    public void run() {
+        checkGlobalFlags();
+        log(getConfig().getCurrentProfile());
+    }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/GetProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/GetProfileCmd.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.profiles;
+
+import ai.langstream.cli.LangStreamCLIConfig;
+import ai.langstream.cli.NamedProfile;
+import java.util.List;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "get", header = "Get an existing profile configuration")
+public class GetProfileCmd extends BaseProfileCmd {
+
+    @CommandLine.Parameters(description = "Name of the profile")
+    private String name;
+
+    @CommandLine.Option(
+            names = {"-o"},
+            description = "Output format")
+    private Formats format = Formats.raw;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        checkGlobalFlags();
+        final NamedProfile profile = getProfileOrThrow(name);
+        final LangStreamCLIConfig config = getConfig();
+        final Object object = format == Formats.raw ? List.of(profile) : profile;
+        print(
+                format,
+                jsonPrinter.writeValueAsString(object),
+                ListProfileCmd.COLUMNS_FOR_RAW,
+                ListProfileCmd.rawMapping(config));
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ImportProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ImportProfileCmd.java
@@ -71,9 +71,7 @@ public class ImportProfileCmd extends BaseProfileCmd {
             if (!Files.isRegularFile(file.toPath())) {
                 throw new IllegalArgumentException("File %s does not exist".formatted(fromFile));
             }
-            profile =
-                    yamlConfigReader.readValue(
-                            new File(fromFile), Profile.class);
+            profile = yamlConfigReader.readValue(new File(fromFile), Profile.class);
         } else if (inline != null) {
             String jsonProfile;
             if (inline.startsWith("base64:")) {
@@ -83,8 +81,7 @@ public class ImportProfileCmd extends BaseProfileCmd {
             } else {
                 jsonProfile = inline;
             }
-            profile =
-                    jsonConfigReader.readValue(jsonProfile, Profile.class);
+            profile = jsonConfigReader.readValue(jsonProfile, Profile.class);
         } else {
             throw new IllegalStateException();
         }
@@ -100,13 +97,11 @@ public class ImportProfileCmd extends BaseProfileCmd {
 
         updateConfig(
                 langStreamCLIConfig -> {
-                    final NamedProfile existing =
-                            langStreamCLIConfig.getProfiles().get(name);
+                    final NamedProfile existing = langStreamCLIConfig.getProfiles().get(name);
                     if (!allowUpdate && existing != null) {
                         throw new IllegalArgumentException(
                                 "Profile %s already exists".formatted(name));
                     }
-
 
                     langStreamCLIConfig.getProfiles().put(name, newProfile);
                     if (existing == null) {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ImportProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ImportProfileCmd.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.profiles;
+
+import ai.langstream.cli.NamedProfile;
+import ai.langstream.cli.Profile;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "import", header = "Import profile from file or inline json")
+public class ImportProfileCmd extends BaseProfileCmd {
+
+    @CommandLine.Parameters(description = "Name of the profile")
+    private String name;
+
+    @CommandLine.Option(
+            names = {"-f", "--file"},
+            description = "Import profile from file")
+    private String fromFile;
+
+    @CommandLine.Option(
+            names = {"-i", "--inline"},
+            description = "Import profile from inline json")
+    private String inline;
+
+    @CommandLine.Option(
+            names = {"-u", "--update"},
+            description = "Allow updating the profile if it already exists")
+    private boolean allowUpdate;
+
+    @CommandLine.Option(
+            names = {"--set-current"},
+            description = "Set this profile as current")
+    private boolean setAsCurrent;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        checkGlobalFlags();
+        checkProfileName(name);
+
+        if (fromFile == null && inline == null) {
+            throw new IllegalArgumentException("Either --file or --inline must be specified");
+        }
+        if (fromFile != null && inline != null) {
+            throw new IllegalArgumentException("Only one of --file or --inline must be specified");
+        }
+
+        final Profile profile;
+
+        if (fromFile != null) {
+
+            final File file = new File(fromFile);
+            if (!Files.isRegularFile(file.toPath())) {
+                throw new IllegalArgumentException("File %s does not exist".formatted(fromFile));
+            }
+            profile =
+                    yamlConfigReader.readValue(
+                            new File(fromFile), Profile.class);
+        } else if (inline != null) {
+            String jsonProfile;
+            if (inline.startsWith("base64:")) {
+                final String base64Value = inline.substring("base64:".length());
+                jsonProfile =
+                        new String(Base64.getDecoder().decode(base64Value), StandardCharsets.UTF_8);
+            } else {
+                jsonProfile = inline;
+            }
+            profile =
+                    jsonConfigReader.readValue(jsonProfile, Profile.class);
+        } else {
+            throw new IllegalStateException();
+        }
+
+        final NamedProfile newProfile = new NamedProfile();
+        newProfile.setName(name);
+        newProfile.setTenant(profile.getTenant());
+        newProfile.setApiGatewayUrl(profile.getApiGatewayUrl());
+        newProfile.setWebServiceUrl(profile.getWebServiceUrl());
+        newProfile.setToken(profile.getToken());
+
+        validateProfile(newProfile);
+
+        updateConfig(
+                langStreamCLIConfig -> {
+                    final NamedProfile existing =
+                            langStreamCLIConfig.getProfiles().get(name);
+                    if (!allowUpdate && existing != null) {
+                        throw new IllegalArgumentException(
+                                "Profile %s already exists".formatted(name));
+                    }
+
+
+                    langStreamCLIConfig.getProfiles().put(name, newProfile);
+                    if (existing == null) {
+                        log("profile %s created".formatted(name));
+                    } else {
+                        log("profile %s updated".formatted(name));
+                    }
+
+                    if (setAsCurrent) {
+                        langStreamCLIConfig.setCurrentProfile(name);
+                        log("profile %s set as current".formatted(name));
+                    }
+                });
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ListProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ListProfileCmd.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.profiles;
+
+import ai.langstream.cli.LangStreamCLIConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.function.BiFunction;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "list", header = "List profiles")
+public class ListProfileCmd extends BaseProfileCmd {
+
+    static final String[] COLUMNS_FOR_RAW = {
+        "profile", "webServiceUrl", "tenant", "token", "current"
+    };
+
+    @CommandLine.Option(
+            names = {"-o"},
+            description = "Output format")
+    private Formats format = Formats.raw;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        checkGlobalFlags();
+        final LangStreamCLIConfig config = getConfig();
+        final Object object = format == Formats.raw ? listAllProfiles() : config;
+
+        print(format, jsonPrinter.writeValueAsString(object), COLUMNS_FOR_RAW, rawMapping(config));
+    }
+
+    static BiFunction<JsonNode, String, Object> rawMapping(LangStreamCLIConfig config) {
+        return (jsonNode, s) -> {
+            switch (s) {
+                case "profile":
+                    return searchValueInJson(jsonNode, "name");
+                case "webServiceUrl":
+                    return searchValueInJson(jsonNode, "webServiceUrl");
+                case "tenant":
+                    return searchValueInJson(jsonNode, "tenant");
+                case "token":
+                    final Object token = searchValueInJson(jsonNode, "token");
+                    return token == null ? null : "********";
+                case "current":
+                    final Object name = searchValueInJson(jsonNode, "name");
+                    return name.equals(config.getCurrentProfile()) ? "*" : "";
+                default:
+                    return null;
+            }
+        };
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/SetCurrentProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/SetCurrentProfileCmd.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.profiles;
+
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "set-current", header = "Set current profile")
+public class SetCurrentProfileCmd extends BaseProfileCmd {
+
+    @CommandLine.Parameters(description = "Name of the profile")
+    private String name;
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        checkGlobalFlags();
+        getProfileOrThrow(name);
+        updateConfig(
+                langStreamCLIConfig -> {
+                    langStreamCLIConfig.setCurrentProfile(name);
+                    log("profile %s set as current".formatted(name));
+                });
+    }
+}

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
@@ -1105,8 +1105,7 @@ class AppsCmdTest extends CommandTestBase {
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
         Assertions.assertEquals(
-                "ID         STREAMING  COMPUTE    STATUS     EXECUTORS  REPLICAS",
-                result.out());
+                "ID         STREAMING  COMPUTE    STATUS     EXECUTORS  REPLICAS", result.out());
         result = executeCommand("apps", "list", "-o", "json");
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
@@ -1055,8 +1055,8 @@ class AppsCmdTest extends CommandTestBase {
         Assertions.assertEquals("", result.err());
         Assertions.assertEquals(
                 """
-                        ID               STREAMING        COMPUTE          STATUS           EXECUTORS        REPLICAS      \s
-                        test             kafka            kubernetes       DEPLOYED         2/2              2/2""",
+                        ID          STREAMING   COMPUTE     STATUS      EXECUTORS   REPLICAS \s
+                        test        kafka       kubernetes  DEPLOYED    2/2         2/2""",
                 result.out());
         ObjectMapper jsonPrinter =
                 new ObjectMapper()
@@ -1105,7 +1105,7 @@ class AppsCmdTest extends CommandTestBase {
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
         Assertions.assertEquals(
-                "ID               STREAMING        COMPUTE          STATUS           EXECUTORS        REPLICAS",
+                "ID         STREAMING  COMPUTE    STATUS     EXECUTORS  REPLICAS",
                 result.out());
         result = executeCommand("apps", "list", "-o", "json");
         Assertions.assertEquals(0, result.exitCode());

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/CommandTestBase.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/CommandTestBase.java
@@ -112,6 +112,7 @@ public class CommandTestBase {
 
     @SneakyThrows
     protected LangStreamCLIConfig getConfig() {
-        return new ObjectMapper(new YAMLFactory()).readValue(cliYaml.toFile(), LangStreamCLIConfig.class);
+        return new ObjectMapper(new YAMLFactory())
+                .readValue(cliYaml.toFile(), LangStreamCLIConfig.class);
     }
 }

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/CommandTestBase.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/CommandTestBase.java
@@ -16,6 +16,9 @@
 package ai.langstream.cli.commands.applications;
 
 import ai.langstream.cli.LangStreamCLI;
+import ai.langstream.cli.LangStreamCLIConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -25,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Stream;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -104,5 +108,10 @@ public class CommandTestBase {
         log.info("COMMAND OUTPUT:\n");
         log.info(outRes);
         return new CommandResult(exitCode, outRes, errRes);
+    }
+
+    @SneakyThrows
+    protected LangStreamCLIConfig getConfig() {
+        return new ObjectMapper(new YAMLFactory()).readValue(cliYaml.toFile(), LangStreamCLIConfig.class);
     }
 }

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.applications;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import ai.langstream.cli.NamedProfile;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ProfilesCmdTest extends CommandTestBase {
+
+    @Test
+    public void testCrud() {
+        CommandResult result = executeCommand("profiles", "create", "new", "--web-service-url", "http://my.localhost:8080", "--tenant", "t", "--token", "tok", "--api-gateway-url", "http://my.localhost:8091");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile new created", result.out());
+        NamedProfile newProfile = getConfig().getProfiles().get("new");
+        assertEquals("new", newProfile.getName());
+        assertEquals("http://my.localhost:8080", newProfile.getWebServiceUrl());
+        assertEquals("t", newProfile.getTenant());
+        assertEquals("tok", newProfile.getToken());
+        assertEquals("http://my.localhost:8091", newProfile.getApiGatewayUrl());
+
+        result = executeCommand("profiles", "update", "new", "--token", "tok2");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile new updated", result.out());
+        newProfile = getConfig().getProfiles().get("new");
+        assertEquals("new", newProfile.getName());
+        assertEquals("http://my.localhost:8080", newProfile.getWebServiceUrl());
+        assertEquals("t", newProfile.getTenant());
+        assertEquals("tok2", newProfile.getToken());
+        assertEquals("http://my.localhost:8091", newProfile.getApiGatewayUrl());
+
+        result = executeCommand("profiles", "get", "new");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
+                new                        http://my.localhost:8080   t                          ********                """, result.out());
+
+        result = executeCommand("profiles", "get", "new", "-o", "json");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                {
+                  "webServiceUrl" : "http://my.localhost:8080",
+                  "apiGatewayUrl" : "http://my.localhost:8091",
+                  "tenant" : "t",
+                  "token" : "tok2",
+                  "name" : "new"
+                }""", result.out());
+
+        result = executeCommand("profiles", "get", "new", "-o", "yaml");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                ---
+                webServiceUrl: "http://my.localhost:8080"
+                apiGatewayUrl: "http://my.localhost:8091"
+                tenant: "t"
+                token: "tok2"
+                name: "new" """, result.out());
+
+        result = executeCommand("profiles", "get", "notexists");
+        assertEquals(1, result.exitCode());
+        assertEquals("Profile notexists not found, maybe you meant one of these: default, new", result.err());
+        assertEquals("", result.out());
+
+
+        result = executeCommand("profiles", "list");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
+                default                    %s     my-tenant                                             *                       \s
+                new                        http://my.localhost:8080   t                          ********                """.formatted(getConfig().getWebServiceUrl()), result.out());
+
+        result = executeCommand("profiles", "get-current");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("default", result.out());
+
+        result = executeCommand("profiles", "set-current", "new");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile new set as current", result.out());
+        assertEquals("new", getConfig().getCurrentProfile());
+
+
+        result = executeCommand("profiles", "delete", "new");
+        assertEquals(1, result.exitCode());
+        assertEquals("Cannot delete the current profile", result.err());
+        assertEquals("", result.out());
+        assertEquals("new", getConfig().getCurrentProfile());
+
+        result = executeCommand("profiles", "set-current", "default");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile default set as current", result.out());
+        assertEquals("new", getConfig().getCurrentProfile());
+
+
+        result = executeCommand("profiles", "delete", "new");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile new deleted", result.out());
+        assertEquals("default", getConfig().getCurrentProfile());
+
+    }
+
+    @Test
+    public void testCreateAndSet() {
+        CommandResult result = executeCommand("profiles", "create", "new", "--web-service-url", "http://my.localhost:8080", "--set-current");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                profile new created
+                profile new set as current""", result.out());
+        assertEquals("new", getConfig().getCurrentProfile());
+
+        result = executeCommand("profiles", "create", "new1", "--web-service-url", "http://my.localhost:8080");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile new1 created", result.out());
+        assertEquals("new", getConfig().getCurrentProfile());
+
+        result = executeCommand("profiles", "update", "new1", "--web-service-url", "http://my.localhost:8080", "--set-current");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                profile new1 updated
+                profile new1 set as current""", result.out());
+        assertEquals("new1", getConfig().getCurrentProfile());
+
+    }
+
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"file", "json", "base64"})
+    public void testImport(String input) throws IOException {
+
+        final String json = "{\"webServiceUrl\":\"http://my.localhost:8080\",\"apiGatewayUrl\":\"http://my.localhost:8091\",\"tenant\":\"t\",\"token\":\"tok\"}";
+        String paramName = switch (input) {
+            case "file" -> "--file";
+            case "json", "base64" -> "--inline";
+            default -> throw new IllegalArgumentException("Unexpected value: " + input);
+        };
+
+
+        final File file = Files.createTempFile("test", ".json").toFile();
+        Files.writeString(file.toPath(), json);
+        String paramValue = switch (input) {
+            case "file" -> file.getAbsolutePath();
+            case "json" -> json;
+            case "base64" -> "base64:" + Base64.getEncoder().encodeToString(json.getBytes());
+            default -> throw new IllegalArgumentException("Unexpected value: " + input);
+        };
+
+        CommandResult result = executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                profile new created
+                profile new set as current""", result.out());
+        assertEquals("new", getConfig().getCurrentProfile());
+
+        NamedProfile newProfile = getConfig().getProfiles().get("new");
+        assertEquals("new", newProfile.getName());
+        assertEquals("http://my.localhost:8080", newProfile.getWebServiceUrl());
+        assertEquals("t", newProfile.getTenant());
+        assertEquals("tok", newProfile.getToken());
+        assertEquals("http://my.localhost:8091", newProfile.getApiGatewayUrl());
+
+        result = executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current");
+        assertEquals(1, result.exitCode());
+        assertEquals("Profile new already exists", result.err());
+        assertEquals("", result.out());
+
+        result = executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current", "-u");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                profile new updated
+                profile new set as current""", result.out());
+
+
+    }
+
+    @Test
+    public void testDefaultProfile() {
+
+        CommandResult result = executeCommand("profiles", "get", "default");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("""
+                PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
+                default                    %s     my-tenant                                             *                """.formatted(getConfig().getWebServiceUrl()), result.out());
+
+        result = executeCommand("profiles", "get-current");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("default", result.out());
+
+        result = executeCommand("profiles", "create", "default");
+        assertEquals(1, result.exitCode());
+        assertEquals("Profile name default is reserved", result.err());
+        assertEquals("", result.out());
+
+
+        result = executeCommand("profiles", "update", "default");
+        assertEquals(1, result.exitCode());
+        assertEquals("Profile name default is reserved", result.err());
+        assertEquals("", result.out());
+
+        result = executeCommand("profiles", "import", "default");
+        assertEquals(1, result.exitCode());
+        assertEquals("Profile name default is reserved", result.err());
+        assertEquals("", result.out());
+
+        result = executeCommand("profiles", "delete", "default");
+        assertEquals(1, result.exitCode());
+        assertEquals("Profile name default is reserved", result.err());
+        assertEquals("", result.out());
+
+
+    }
+
+    @Test
+    public void testGlobalParam() {
+        wireMock.register(
+                WireMock.get("/api/applications/" + TENANT)
+                        .willReturn(WireMock.ok("[]")));
+
+        CommandResult result = executeCommand("apps", "list", "-o", "json");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("[ ]", result.out());
+
+
+        result = executeCommand("profiles", "create", "new", "--web-service-url", "http://my.localhost:8080", "--set-current");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile new created\n"
+                + "profile new set as current", result.out());
+
+        result = executeCommand("apps", "list", "-o", "json");
+        assertEquals(1, result.exitCode());
+        assertEquals("Tenant not set. Please set the tenant in the configuration.", result.err());
+        assertEquals("", result.out());
+
+        result = executeCommand("-p", "default", "apps", "list", "-o", "json");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("[ ]", result.out());
+
+        result = executeCommand("-p", "notexists", "apps", "list", "-o", "json");
+        assertEquals(1, result.exitCode());
+        assertEquals("No profile 'notexists' defined in configuration", result.err());
+        assertEquals("", result.out());
+    }
+}

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
@@ -16,6 +16,7 @@
 package ai.langstream.cli.commands.applications;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import ai.langstream.cli.NamedProfile;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -70,8 +71,8 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("", result.err());
         assertEquals(
                 """
-                PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
-                new                        http://my.localhost:8080   t                          ********                """,
+                        PROFILE                   WEBSERVICEURL             TENANT                    TOKEN                     CURRENT                \s
+                        new                       http://my.localhost:8080  t                         ******** """,
                 result.out());
 
         result = executeCommand("profiles", "get", "new", "-o", "json");
@@ -113,9 +114,9 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("", result.err());
         assertEquals(
                 """
-                PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
-                default                    %s     my-tenant                                             *                       \s
-                new                        http://my.localhost:8080   t                          ********                """
+                        PROFILE                   WEBSERVICEURL             TENANT                    TOKEN                     CURRENT                \s
+                        default                   %s    my-tenant                                           *                      \s
+                        new                       http://my.localhost:8080  t                         ********"""
                         .formatted(getConfig().getWebServiceUrl()),
                 result.out());
 
@@ -140,13 +141,14 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("profile default set as current", result.out());
-        assertEquals("new", getConfig().getCurrentProfile());
+        assertEquals("default", getConfig().getCurrentProfile());
 
         result = executeCommand("profiles", "delete", "new");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("profile new deleted", result.out());
         assertEquals("default", getConfig().getCurrentProfile());
+        assertNull(getConfig().getProfiles().get("new"));
     }
 
     @Test
@@ -266,8 +268,8 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("", result.err());
         assertEquals(
                 """
-                PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
-                default                    %s     my-tenant                                             *                """
+                        PROFILE                 WEBSERVICEURL           TENANT                  TOKEN                   CURRENT              \s
+                        default                 %s  my-tenant                                       *"""
                         .formatted(getConfig().getWebServiceUrl()),
                 result.out());
 

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
@@ -16,6 +16,7 @@
 package ai.langstream.cli.commands.applications;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import ai.langstream.cli.NamedProfile;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.io.File;
@@ -30,7 +31,19 @@ class ProfilesCmdTest extends CommandTestBase {
 
     @Test
     public void testCrud() {
-        CommandResult result = executeCommand("profiles", "create", "new", "--web-service-url", "http://my.localhost:8080", "--tenant", "t", "--token", "tok", "--api-gateway-url", "http://my.localhost:8091");
+        CommandResult result =
+                executeCommand(
+                        "profiles",
+                        "create",
+                        "new",
+                        "--web-service-url",
+                        "http://my.localhost:8080",
+                        "--tenant",
+                        "t",
+                        "--token",
+                        "tok",
+                        "--api-gateway-url",
+                        "http://my.localhost:8091");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("profile new created", result.out());
@@ -55,46 +68,56 @@ class ProfilesCmdTest extends CommandTestBase {
         result = executeCommand("profiles", "get", "new");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
-                new                        http://my.localhost:8080   t                          ********                """, result.out());
+                new                        http://my.localhost:8080   t                          ********                """,
+                result.out());
 
         result = executeCommand("profiles", "get", "new", "-o", "json");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 {
                   "webServiceUrl" : "http://my.localhost:8080",
                   "apiGatewayUrl" : "http://my.localhost:8091",
                   "tenant" : "t",
                   "token" : "tok2",
                   "name" : "new"
-                }""", result.out());
+                }""",
+                result.out());
 
         result = executeCommand("profiles", "get", "new", "-o", "yaml");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 ---
                 webServiceUrl: "http://my.localhost:8080"
                 apiGatewayUrl: "http://my.localhost:8091"
                 tenant: "t"
                 token: "tok2"
-                name: "new" """, result.out());
+                name: "new" """,
+                result.out());
 
         result = executeCommand("profiles", "get", "notexists");
         assertEquals(1, result.exitCode());
-        assertEquals("Profile notexists not found, maybe you meant one of these: default, new", result.err());
+        assertEquals(
+                "Profile notexists not found, maybe you meant one of these: default, new",
+                result.err());
         assertEquals("", result.out());
-
 
         result = executeCommand("profiles", "list");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
                 default                    %s     my-tenant                                             *                       \s
-                new                        http://my.localhost:8080   t                          ********                """.formatted(getConfig().getWebServiceUrl()), result.out());
+                new                        http://my.localhost:8080   t                          ********                """
+                        .formatted(getConfig().getWebServiceUrl()),
+                result.out());
 
         result = executeCommand("profiles", "get-current");
         assertEquals(0, result.exitCode());
@@ -106,7 +129,6 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("", result.err());
         assertEquals("profile new set as current", result.out());
         assertEquals("new", getConfig().getCurrentProfile());
-
 
         result = executeCommand("profiles", "delete", "new");
         assertEquals(1, result.exitCode());
@@ -120,70 +142,95 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("profile default set as current", result.out());
         assertEquals("new", getConfig().getCurrentProfile());
 
-
         result = executeCommand("profiles", "delete", "new");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("profile new deleted", result.out());
         assertEquals("default", getConfig().getCurrentProfile());
-
     }
 
     @Test
     public void testCreateAndSet() {
-        CommandResult result = executeCommand("profiles", "create", "new", "--web-service-url", "http://my.localhost:8080", "--set-current");
+        CommandResult result =
+                executeCommand(
+                        "profiles",
+                        "create",
+                        "new",
+                        "--web-service-url",
+                        "http://my.localhost:8080",
+                        "--set-current");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 profile new created
-                profile new set as current""", result.out());
+                profile new set as current""",
+                result.out());
         assertEquals("new", getConfig().getCurrentProfile());
 
-        result = executeCommand("profiles", "create", "new1", "--web-service-url", "http://my.localhost:8080");
+        result =
+                executeCommand(
+                        "profiles",
+                        "create",
+                        "new1",
+                        "--web-service-url",
+                        "http://my.localhost:8080");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("profile new1 created", result.out());
         assertEquals("new", getConfig().getCurrentProfile());
 
-        result = executeCommand("profiles", "update", "new1", "--web-service-url", "http://my.localhost:8080", "--set-current");
+        result =
+                executeCommand(
+                        "profiles",
+                        "update",
+                        "new1",
+                        "--web-service-url",
+                        "http://my.localhost:8080",
+                        "--set-current");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 profile new1 updated
-                profile new1 set as current""", result.out());
+                profile new1 set as current""",
+                result.out());
         assertEquals("new1", getConfig().getCurrentProfile());
-
     }
-
-
 
     @ParameterizedTest
     @ValueSource(strings = {"file", "json", "base64"})
     public void testImport(String input) throws IOException {
 
-        final String json = "{\"webServiceUrl\":\"http://my.localhost:8080\",\"apiGatewayUrl\":\"http://my.localhost:8091\",\"tenant\":\"t\",\"token\":\"tok\"}";
-        String paramName = switch (input) {
-            case "file" -> "--file";
-            case "json", "base64" -> "--inline";
-            default -> throw new IllegalArgumentException("Unexpected value: " + input);
-        };
-
+        final String json =
+                "{\"webServiceUrl\":\"http://my.localhost:8080\",\"apiGatewayUrl\":\"http://my.localhost:8091\",\"tenant\":\"t\",\"token\":\"tok\"}";
+        String paramName =
+                switch (input) {
+                    case "file" -> "--file";
+                    case "json", "base64" -> "--inline";
+                    default -> throw new IllegalArgumentException("Unexpected value: " + input);
+                };
 
         final File file = Files.createTempFile("test", ".json").toFile();
         Files.writeString(file.toPath(), json);
-        String paramValue = switch (input) {
-            case "file" -> file.getAbsolutePath();
-            case "json" -> json;
-            case "base64" -> "base64:" + Base64.getEncoder().encodeToString(json.getBytes());
-            default -> throw new IllegalArgumentException("Unexpected value: " + input);
-        };
+        String paramValue =
+                switch (input) {
+                    case "file" -> file.getAbsolutePath();
+                    case "json" -> json;
+                    case "base64" -> "base64:"
+                            + Base64.getEncoder().encodeToString(json.getBytes());
+                    default -> throw new IllegalArgumentException("Unexpected value: " + input);
+                };
 
-        CommandResult result = executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current");
+        CommandResult result =
+                executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 profile new created
-                profile new set as current""", result.out());
+                profile new set as current""",
+                result.out());
         assertEquals("new", getConfig().getCurrentProfile());
 
         NamedProfile newProfile = getConfig().getProfiles().get("new");
@@ -193,19 +240,22 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("tok", newProfile.getToken());
         assertEquals("http://my.localhost:8091", newProfile.getApiGatewayUrl());
 
-        result = executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current");
+        result =
+                executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current");
         assertEquals(1, result.exitCode());
         assertEquals("Profile new already exists", result.err());
         assertEquals("", result.out());
 
-        result = executeCommand("profiles", "import", "new", paramName, paramValue, "--set-current", "-u");
+        result =
+                executeCommand(
+                        "profiles", "import", "new", paramName, paramValue, "--set-current", "-u");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 profile new updated
-                profile new set as current""", result.out());
-
-
+                profile new set as current""",
+                result.out());
     }
 
     @Test
@@ -214,9 +264,12 @@ class ProfilesCmdTest extends CommandTestBase {
         CommandResult result = executeCommand("profiles", "get", "default");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("""
+        assertEquals(
+                """
                 PROFILE                    WEBSERVICEURL              TENANT                     TOKEN                      CURRENT                 \s
-                default                    %s     my-tenant                                             *                """.formatted(getConfig().getWebServiceUrl()), result.out());
+                default                    %s     my-tenant                                             *                """
+                        .formatted(getConfig().getWebServiceUrl()),
+                result.out());
 
         result = executeCommand("profiles", "get-current");
         assertEquals(0, result.exitCode());
@@ -227,7 +280,6 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals(1, result.exitCode());
         assertEquals("Profile name default is reserved", result.err());
         assertEquals("", result.out());
-
 
         result = executeCommand("profiles", "update", "default");
         assertEquals(1, result.exitCode());
@@ -243,27 +295,29 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals(1, result.exitCode());
         assertEquals("Profile name default is reserved", result.err());
         assertEquals("", result.out());
-
-
     }
 
     @Test
     public void testGlobalParam() {
         wireMock.register(
-                WireMock.get("/api/applications/" + TENANT)
-                        .willReturn(WireMock.ok("[]")));
+                WireMock.get("/api/applications/" + TENANT).willReturn(WireMock.ok("[]")));
 
         CommandResult result = executeCommand("apps", "list", "-o", "json");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("[ ]", result.out());
 
-
-        result = executeCommand("profiles", "create", "new", "--web-service-url", "http://my.localhost:8080", "--set-current");
+        result =
+                executeCommand(
+                        "profiles",
+                        "create",
+                        "new",
+                        "--web-service-url",
+                        "http://my.localhost:8080",
+                        "--set-current");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
-        assertEquals("profile new created\n"
-                + "profile new set as current", result.out());
+        assertEquals("profile new created\n" + "profile new set as current", result.out());
 
         result = executeCommand("apps", "list", "-o", "json");
         assertEquals(1, result.exitCode());


### PR DESCRIPTION
Profiles are stored in the cli configuration yaml file.
There's a default profile which is "virtual" and uses the current cli.yaml configuration top-level entries



*Create a profile with inline values*
```
langstream profiles create my-prof --web-service-url xx --tenant xx --token xx  --api-gateway-url xx
```


*Create a profile with inline values and set it as current*
```
langstream profiles create my-prof --web-service-url xx --tenant xx --token xx  --api-gateway-url xx --set-current
```


*Update a profile with inline values*
```
langstream profiles update my-prof --web-service-url xx --tenant xx --token xx  --api-gateway-url xx
```


*Create a profile from json file*
```
langstream profiles import my-prof -f <file.json>
```

*Create a profile from inline json*
```
langstream profiles import my-prof --inline '{"webServiceUrl": "xxx"}'
```

*Create a profile from base64 json*
```
langstream profiles import my-prof --inline 'base64:xxxx'
```

*Create a profile from file and set it as current*
```
langstream profiles import my-prof -f <file.json> --set-current
```

*List profiles*
```
langstream profiles list
```

*Get profile config*
```
langstream profiles get my-prof
```

*Get profile config as yaml*
```
langstream profiles get my-prof -o yaml
```

*Get profile config as json*
```
langstream profiles get my-prof -o json
```


*Get currently used profile*
```
langstream profiles get-current
```

*Set current used profile*
```
langstream profiles set-current my-prof
```

*Delete profile*
```
langstream profiles delete my-prof
```



*Use a profile to list applications*
```
langstream -p my-prof apps list
```
