### PR TITLE
Cli: use global config file by default

### DIFF
--- a/bin/langstream
+++ b/bin/langstream
@@ -36,13 +36,8 @@ if [ ! -d langstream-cli/target/cli ]; then
   ./mvnw clean install -DskipTests -pl langstream-cli -am
 fi
 popd > /dev/null
-LANGSTREAM_CLI_CONFIG=${LANGSTREAM_CLI_CONFIG:-""}
-
-if [ -z "$LANGSTREAM_CLI_CONFIG" ]; then
-  echo "Using global CLI config file. To use the dev config file, set LANGSTREAM_CLI_CONFIG=conf/cli.yaml"
-else
-  LANGSTREAM_CLI_CONFIG="--conf $LANGSTREAM_CLI_CONFIG"
-fi
+LANGSTREAM_CLI_CONFIG=${LANGSTREAM_CLI_CONFIG:-"conf/cli.yaml"}
+echo "Using development CLI config file $(realpath $LANGSTREAM_CLI_CONFIG). To use the global config file, set LANGSTREAM_CLI_CONFIG=\$HOME/.langstream/config"
 
 "$ROOT_DIR/langstream-cli/target/cli/bin/langstream" $LANGSTREAM_CLI_CONFIG "$@"
 

--- a/bin/langstream
+++ b/bin/langstream
@@ -36,15 +36,11 @@ if [ ! -d langstream-cli/target/cli ]; then
   ./mvnw clean install -DskipTests -pl langstream-cli -am
 fi
 popd > /dev/null
-LANGSTREAM_CLI_CONFIG=${LANGSTREAM_CLI_CONFIG:-"conf/cli.yaml"}
-if [ -n "$LANGSTREAM_CLI_CONFIG" ]; then
-  if [ ! -f "$LANGSTREAM_CLI_CONFIG" ]; then
-    echo "ERROR: CLI config file not found: $LANGSTREAM_CLI_CONFIG"
-    exit 1
-  fi
-  if [ $LANGSTREAM_CLI_CONFIG != "conf/cli.yaml" ]; then
-    echo "Using CLI config file from ENV variable LANGSTREAM_CLI_CONFIG: $LANGSTREAM_CLI_CONFIG"
-  fi
+LANGSTREAM_CLI_CONFIG=${LANGSTREAM_CLI_CONFIG:-""}
+
+if [ -z "$LANGSTREAM_CLI_CONFIG" ]; then
+  echo "Using global CLI config file. To use the dev config file, set LANGSTREAM_CLI_CONFIG=conf/cli.yaml"
+else
   LANGSTREAM_CLI_CONFIG="--conf $LANGSTREAM_CLI_CONFIG"
 fi
 

--- a/langstream-cli/pom.xml
+++ b/langstream-cli/pom.xml
@@ -122,10 +122,6 @@
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>${appassembler-maven-plugin.version}</version>
         <configuration>
-          <configurationSourceDirectory>../conf</configurationSourceDirectory>
-          <configurationDirectory>conf</configurationDirectory>
-          <copyConfigurationDirectory>true</copyConfigurationDirectory>
-          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <assembleDirectory>${project.build.directory}/cli</assembleDirectory>
           <platforms>
             <platform>windows</platform>

--- a/langstream-cli/src/main/docker/Dockerfile
+++ b/langstream-cli/src/main/docker/Dockerfile
@@ -48,7 +48,6 @@ RUN mkdir /app && chmod g+w /app
 ADD maven /app
 WORKDIR /app
 
-RUN chown -R 10000:10000 /app/conf
 RUN echo "export PATH=$PATH:/app/bin" >> /.bashrc
 
 # The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -108,7 +108,7 @@ public abstract class BaseCmd implements Runnable {
         if (config.getApiGatewayUrl() == null) {
             defaultProfile.setApiGatewayUrl("ws://localhost:8091");
         } else {
-            defaultProfile.setApiGatewayUrl(config.getWebServiceUrl());
+            defaultProfile.setApiGatewayUrl(config.getApiGatewayUrl());
         }
         if (config.getTenant() == null) {
             defaultProfile.setTenant("default");


### PR DESCRIPTION
* By default, it uses the config file at `$HOME/.langstream/config`. If it doesn't exist, it gets created.
* User can still pass `--conf` to use a different config file
* conf/cli.yaml is anymore included in the zip/docker since it's not necessary
* default values are now set by the cli directly instead of being retrieved by the file 

This is breaking change since the current config file will be ignored and new one will be used. 

Note that the command ´bin/langstream´ is a bit different from the one that you install. The former injects the --conf parameter by using the env LANGSTREAM_CLI_CONF. Now it defaults to the global one as well.
Since that command is likely to be used during development, I added a info at the cli startup

```
Using global CLI config file. To use the dev config file, set LANGSTREAM_CLI_CONFIG=conf/cli.yaml
```