### PR TITLE
Vector DB Support: download automatically the AstraDB secure bundle

### DIFF
--- a/examples/applications/astradb-sink/README.md
+++ b/examples/applications/astradb-sink/README.md
@@ -23,7 +23,13 @@ This is handled by the 'cassandra-table' assets in the pipeline.yaml file.
 
 ## Configure the pipeline
 
-Update the same file and set username, password and the other parameters.
+Update the secrets.yaml file and set the Astra credentials and the database name:
+- clientId
+- secret
+- token
+- database
+
+You can find the credentials in the Astra DB console when you create a Token.
 
 ## Deploy the LangStream application
 
@@ -38,7 +44,7 @@ Update the same file and set username, password and the other parameters.
 
 ## Verify the data on Cassandra
 
-Query Cassandra to see the results
+Query Cassandra to see the results using the Astra DB console or the cqlsh tool:
 
 ```
 SELECT * FROM products.products;

--- a/examples/applications/astradb-sink/configuration.yaml
+++ b/examples/applications/astradb-sink/configuration.yaml
@@ -23,8 +23,6 @@ configuration:
         service: "astra"
         clientId: "{{{ secrets.astra.clientId }}}"
         secret: "{{{ secrets.astra.secret }}}"
-        secureBundle: "{{{ secrets.astra.secureBundle }}}"
-        # These are optional, but if you want to use the astra-keyspace asset you need them
         token: "{{{ secrets.astra.token }}}"
         database: "{{{ secrets.astra.database }}}"
         environment: "{{{ secrets.astra.environment }}}"

--- a/langstream-core/src/main/java/ai/langstream/impl/assets/CassandraAssetsProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/assets/CassandraAssetsProvider.java
@@ -46,18 +46,17 @@ public class CassandraAssetsProvider extends AbstractAssetProvider {
             case "cassandra-keyspace" -> {
                 requiredNonEmptyField(assetDefinition, configuration, "keyspace");
                 requiredListField(assetDefinition, configuration, "create-statements");
-                if (datasourceConfiguration.containsKey("secureBundle")) {
-                    throw new IllegalArgumentException(
-                            "Use astra-keyspace for AstraDB services (not expecting a secureBundle in a Cassandra datasource).");
+                if (datasourceConfiguration.containsKey("secureBundle")
+                        || datasourceConfiguration.containsKey("database")) {
+                    throw new IllegalArgumentException("Use astra-keyspace for AstraDB services");
                 }
             }
             case "astra-keyspace" -> {
                 requiredNonEmptyField(assetDefinition, configuration, "keyspace");
-                if (!datasourceConfiguration.containsKey("secureBundle")) {
+                if (!datasourceConfiguration.containsKey("secureBundle")
+                        && !datasourceConfiguration.containsKey("database")) {
                     throw new IllegalArgumentException(
-                            "Use cassandra-keyspace for a standard Cassandra service (expecting a secureBundle, but found only "
-                                    + datasourceConfiguration.keySet()
-                                    + " .");
+                            "Use cassandra-keyspace for a standard Cassandra service (not AstraDB)");
                 }
                 // are we are using the AstraDB SDK we need also the AstraCS token and
                 // the name of the database

--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
@@ -82,6 +82,14 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
                                     Resource resource = resources.get(resourceId);
                                     if (resource != null) {
                                         value = Map.of("configuration", resource.configuration());
+                                    } else {
+                                        throw new IllegalArgumentException(
+                                                "Resource with name="
+                                                        + resourceId
+                                                        + " not found, declared as "
+                                                        + key
+                                                        + " in asset "
+                                                        + assetDefinition.getId());
                                     }
                                 }
                                 configuration.put(key, value);


### PR DESCRIPTION
Summary:
- now that we can use the Astra DevOps API it is easy to download the Secure bundle automatically
- the user must provide the "token" and the "database" in the DataSource configuration
- this works for the query-vector-db, vector-db-sink and the astra-keyspace and cassandra-table assets


configuration.yaml

```
configuration:
  resources:
    - type: "vector-database"
      name: "AstraDatasource"
      configuration:
        service: "astra"
        clientId: "{{{ secrets.astra.clientId }}}"
        secret: "{{{ secrets.astra.secret }}}"
        token: "{{{ secrets.astra.token }}}"
        database: "{{{ secrets.astra.database }}}"
        environment: "{{{ secrets.astra.environment }}}"
```

"environment" is by default PROD and it can be PROD, STAGING, DEV, this is a Datastax only thing, because we use the DEV databases.
 I would keep it because all DataStax developers are using DEV databases and so it is easier for us to change the value to DEV in our secrets.yaml files and we can set PROD by default in the examples