### PR TITLE
Cli: allow to pass remote file - Github

### DIFF
--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -20,6 +20,7 @@ import ai.langstream.admin.client.http.HttpClientProperties;
 import ai.langstream.admin.client.http.Retry;
 import ai.langstream.admin.client.model.Applications;
 import ai.langstream.admin.client.util.MultiPartBodyPublisher;
+import ai.langstream.admin.client.util.Slf4jLAdminClientLogger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -27,13 +28,18 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class AdminClient implements AutoCloseable {
 
     private final AdminClientConfiguration configuration;
     private final AdminClientLogger logger;
     private final HttpClientFacade httpClientFacade;
-    private HttpClientProperties httpClientProperties;
+
+    public AdminClient(AdminClientConfiguration adminClientConfiguration) {
+        this(adminClientConfiguration, new Slf4jLAdminClientLogger(log));
+    }
 
     public AdminClient(
             AdminClientConfiguration adminClientConfiguration, AdminClientLogger logger) {
@@ -46,7 +52,6 @@ public class AdminClient implements AutoCloseable {
             HttpClientProperties httpClientProperties) {
         this.configuration = adminClientConfiguration;
         this.logger = logger;
-        this.httpClientProperties = httpClientProperties;
         this.httpClientFacade = new HttpClientFacade(logger, httpClientProperties);
     }
 

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/HttpClientFacade.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/http/HttpClientFacade.java
@@ -17,6 +17,7 @@ package ai.langstream.admin.client.http;
 
 import ai.langstream.admin.client.AdminClientLogger;
 import ai.langstream.admin.client.HttpRequestFailedException;
+import ai.langstream.admin.client.util.Slf4jLAdminClientLogger;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.http.HttpClient;
@@ -26,13 +27,23 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class HttpClientFacade implements AutoCloseable {
 
     private final AdminClientLogger logger;
     private final HttpClientProperties httpClientProperties;
     private ExecutorService executorService;
     private HttpClient httpClient;
+
+    public HttpClientFacade() {
+        this(new HttpClientProperties());
+    }
+
+    public HttpClientFacade(HttpClientProperties httpClientProperties) {
+        this(new Slf4jLAdminClientLogger(log), httpClientProperties);
+    }
 
     public HttpClientFacade(AdminClientLogger logger, HttpClientProperties httpClientProperties) {
         this.logger = logger;

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/util/Slf4jLAdminClientLogger.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/util/Slf4jLAdminClientLogger.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.admin.client.util;
+
+import ai.langstream.admin.client.AdminClientLogger;
+import org.slf4j.Logger;
+
+public class Slf4jLAdminClientLogger implements AdminClientLogger {
+
+    private final org.slf4j.Logger log;
+
+    public Slf4jLAdminClientLogger(Logger log) {
+        this.log = log;
+    }
+
+    @Override
+    public void log(Object message) {
+        if (message != null) {
+            log.info(message.toString());
+        }
+    }
+
+    @Override
+    public void error(Object message) {
+        if (message != null) {
+            log.error(message.toString());
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(Object message) {
+        if (message != null) {
+            log.debug(message.toString());
+        }
+    }
+}

--- a/langstream-cli/pom.xml
+++ b/langstream-cli/pom.xml
@@ -69,6 +69,11 @@
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-websocket</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>6.7.0.202309050840-r</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/langstream-cli/pom.xml
+++ b/langstream-cli/pom.xml
@@ -33,6 +33,7 @@
     <appassembler-maven-plugin.version>1.10</appassembler-maven-plugin.version>
     <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
 
+    <org.eclipse.jgit.version>6.7.0.202309050840-r</org.eclipse.jgit.version>
   </properties>
   <dependencies>
     <dependency>
@@ -72,7 +73,7 @@
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>6.7.0.202309050840-r</version>
+      <version>${org.eclipse.jgit.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -360,6 +360,11 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
 
     static File downloadHttpsFile(String path, HttpClientFacade client, Consumer<String> logger)
             throws IOException, HttpRequestFailedException {
+        final URI uri = URI.create(path);
+        if ("github.com".equals(uri.getHost())) {
+            return downloadFromGithub(uri, logger);
+        }
+
         final HttpRequest request =
                 HttpRequest.newBuilder()
                         .uri(URI.create(path))
@@ -384,6 +389,10 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         final long time = (System.currentTimeMillis() - start) / 1000;
         logger.accept(String.format("downloaded remote file %s (%d s)", path, time));
         return tempFile.toFile();
+    }
+
+    private static File downloadFromGithub(URI uri, Consumer<String> logger) {
+        return GithubRepositoryDownloader.downloadGithubRepository(uri, logger);
     }
 
     public static MultiPartBodyPublisher buildMultipartContentForAppZip(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloader.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.applications;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import lombok.Data;
+import lombok.SneakyThrows;
+import org.eclipse.jgit.api.Git;
+
+public class GithubRepositoryDownloader {
+
+    @Data
+    static class RequestedDirectory {
+        private String owner;
+        private String repository;
+        private String branch;
+        private String directory;
+    }
+
+    @SneakyThrows
+    public static File downloadGithubRepository(URI uri, Consumer<String> logger) {
+        RequestedDirectory requestedDirectory = parseRequest(uri);
+
+        final Path directory = Files.createTempDirectory("langstream");
+
+        final long start = System.currentTimeMillis();
+        Git.cloneRepository()
+                .setURI(
+                        String.format(
+                                "https://github.com/%s/%s.git",
+                                requestedDirectory.getOwner(), requestedDirectory.getRepository()))
+                .setDirectory(directory.toFile())
+                .setBranch(requestedDirectory.getBranch())
+                .setDepth(1)
+                .call();
+        final long time = (System.currentTimeMillis() - start) / 1000;
+        logger.accept(String.format("downloaded GitHub directory (%d s)", time));
+        final Path result = directory.resolve(requestedDirectory.getDirectory());
+        return result.toFile();
+    }
+
+    static RequestedDirectory parseRequest(URI uri) {
+        final String path = uri.getPath();
+        final String[] paths = path.split("/", 6);
+        if (paths.length < 5) {
+            throw new IllegalArgumentException(
+                    "Invalid github url. Expected format: https://github"
+                            + ".com/<owner>/<repository>/tree|blob/<branch>[/directory]");
+        }
+        RequestedDirectory requestedDirectory = new RequestedDirectory();
+        requestedDirectory.setOwner(paths[1]);
+        requestedDirectory.setRepository(paths[2]);
+        requestedDirectory.setBranch(paths[4]);
+        if (paths.length > 5) {
+            requestedDirectory.setDirectory(paths[5]);
+        }
+        return requestedDirectory;
+    }
+}

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloaderTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.applications;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class GithubRepositoryDownloaderTest {
+
+    @Test
+    void testParseUrl() {
+        final GithubRepositoryDownloader.RequestedDirectory request =
+                GithubRepositoryDownloader.parseRequest(
+                        URI.create(
+                                "https://github.com/LangStream/langstream/tree/main/examples/applications/astradb-sink"));
+        assertEquals("LangStream", request.getOwner());
+        assertEquals("langstream", request.getRepository());
+        assertEquals("main", request.getBranch());
+        assertEquals("examples/applications/astradb-sink", request.getDirectory());
+    }
+
+    @Test
+    void testParseUrlBlob() {
+        final GithubRepositoryDownloader.RequestedDirectory request =
+                GithubRepositoryDownloader.parseRequest(
+                        URI.create(
+                                "https://github.com/LangStream/langstream/blob/v0.0.13/examples/instances/astra.yaml"));
+        assertEquals("LangStream", request.getOwner());
+        assertEquals("langstream", request.getRepository());
+        assertEquals("v0.0.13", request.getBranch());
+        assertEquals("examples/instances/astra.yaml", request.getDirectory());
+    }
+
+    @Test
+    void testParseUrlRoot() {
+        final GithubRepositoryDownloader.RequestedDirectory request =
+                GithubRepositoryDownloader.parseRequest(
+                        URI.create("https://github.com/LangStream/langstream/tree/main"));
+        assertEquals("LangStream", request.getOwner());
+        assertEquals("langstream", request.getRepository());
+        assertEquals("main", request.getBranch());
+        assertNull(request.getDirectory());
+    }
+}


### PR DESCRIPTION
* Accepts Github UI links to directory or files. The expected flow is that the user copy the url from the github UI and put it in the input

*Get example application from this repo*
```
langstream apps deploy test -app https://github.com/LangStream/langstream/tree/main/examples/applications/astradb-sink
```

*Get example application from this repo of a specific tag*
```
langstream apps deploy test -app https://github.com/LangStream/langstream/tree/v0.0.13/examples/applications/astradb-sink
```


