### PR TITLE
[resources] Introduce planner side validation of resources

### DIFF
--- a/langstream-api/src/main/java/ai/langstream/api/model/Application.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Application.java
@@ -33,6 +33,10 @@ public class Application {
     private Instance instance;
     private Secrets secrets;
 
+    public Map<String, Resource> getResources() {
+        return resources;
+    }
+
     @JsonIgnore
     public Module getModule(String module) {
         return modules.computeIfAbsent(module, Module::new);

--- a/langstream-api/src/main/java/ai/langstream/api/model/Application.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Application.java
@@ -33,10 +33,6 @@ public class Application {
     private Instance instance;
     private Secrets secrets;
 
-    public Map<String, Resource> getResources() {
-        return resources;
-    }
-
     @JsonIgnore
     public Module getModule(String module) {
         return modules.computeIfAbsent(module, Module::new);

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/ComputeClusterRuntime.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/ComputeClusterRuntime.java
@@ -20,6 +20,8 @@ import ai.langstream.api.model.Application;
 import ai.langstream.api.model.Connection;
 import ai.langstream.api.model.Module;
 import ai.langstream.api.model.Pipeline;
+import ai.langstream.api.model.Resource;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -82,6 +84,11 @@ public interface ComputeClusterRuntime extends AutoCloseable {
             ExecutionPlan physicalApplicationInstance,
             StreamingClusterRuntime streamingClusterRuntime) {
         return null;
+    }
+
+    default Map<String, Object> getResourceImplementation(
+            Resource resource, PluginsRegistry pluginsRegistry) {
+        return new HashMap<>(resource.configuration());
     }
 
     default void close() {}

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/PluginsRegistry.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/PluginsRegistry.java
@@ -69,4 +69,29 @@ public class PluginsRegistry {
                                                         + clusterRuntime.getClusterType()));
         return assetRuntimeProviderProvider.get();
     }
+
+    public ResourceNodeProvider lookupResourceImplementation(
+            String type, ComputeClusterRuntime clusterRuntime) {
+        log.info(
+                "Looking for an implementation of resource type {} on {}",
+                type,
+                clusterRuntime.getClusterType());
+        ServiceLoader<ResourceNodeProvider> loader = ServiceLoader.load(ResourceNodeProvider.class);
+        ServiceLoader.Provider<ResourceNodeProvider> runtimeProviderProvider =
+                loader.stream()
+                        .filter(
+                                p -> {
+                                    ResourceNodeProvider nodeProvider = p.get();
+                                    return nodeProvider.supports(type, clusterRuntime);
+                                })
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new RuntimeException(
+                                                "No ResourceNodeProvider found for resource type "
+                                                        + type
+                                                        + " for cluster type "
+                                                        + clusterRuntime.getClusterType()));
+        return runtimeProviderProvider.get();
+    }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runtime/ResourceNodeProvider.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runtime/ResourceNodeProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.runtime;
+
+import ai.langstream.api.model.Module;
+import ai.langstream.api.model.Resource;
+import java.util.Map;
+
+public interface ResourceNodeProvider {
+
+    /**
+     * Create an Implementation of a Resource.
+     *
+     * @param module the module
+     * @param executionPlan the physical application instance
+     * @param clusterRuntime the cluster runtime
+     * @param pluginsRegistry the plugins registry
+     * @return the Agent
+     */
+    Map<String, Object> createImplementation(
+            Resource resource,
+            Module module,
+            ExecutionPlan executionPlan,
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry);
+
+    /**
+     * Returns the ability of a Resource to be deployed on the give runtimes.
+     *
+     * @param type the type of implementation
+     * @param clusterRuntime the compute cluster runtime
+     * @return true if this provider can create the implementation
+     */
+    boolean supports(String type, ComputeClusterRuntime clusterRuntime);
+}

--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAgentProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAgentProvider.java
@@ -121,7 +121,8 @@ public abstract class AbstractAgentProvider implements AgentNodeProvider {
             Module module,
             Pipeline pipeline,
             ExecutionPlan executionPlan,
-            ComputeClusterRuntime clusterRuntime) {
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
         return new HashMap<>(agentConfiguration.getConfiguration());
     }
 
@@ -141,7 +142,12 @@ public abstract class AbstractAgentProvider implements AgentNodeProvider {
         ComponentType componentType = getComponentType(agentConfiguration);
         Map<String, Object> configuration =
                 computeAgentConfiguration(
-                        agentConfiguration, module, pipeline, executionPlan, clusterRuntime);
+                        agentConfiguration,
+                        module,
+                        pipeline,
+                        executionPlan,
+                        clusterRuntime,
+                        pluginsRegistry);
         // we create the output connection first to make sure that the topic is created
         ConnectionImplementation output =
                 computeOutput(

--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
@@ -45,7 +45,12 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
             ExecutionPlan executionPlan,
             ComputeClusterRuntime clusterRuntime,
             PluginsRegistry pluginsRegistry) {
-        Map<String, Object> asset = planAsset(assetDefinition, executionPlan.getApplication());
+        Map<String, Object> asset =
+                planAsset(
+                        assetDefinition,
+                        executionPlan.getApplication(),
+                        clusterRuntime,
+                        pluginsRegistry);
         validateAsset(assetDefinition, asset);
         return new AssetNode(asset);
     }
@@ -54,7 +59,10 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
             AssetDefinition assetDefinition, Map<String, Object> asset);
 
     private Map<String, Object> planAsset(
-            AssetDefinition assetDefinition, Application application) {
+            AssetDefinition assetDefinition,
+            Application application,
+            ComputeClusterRuntime computeClusterRuntime,
+            PluginsRegistry pluginsRegistry) {
 
         if (!supportedType.contains(assetDefinition.getAssetType())) {
             throw new IllegalStateException();
@@ -81,7 +89,10 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
                                                     key);
                                     Resource resource = resources.get(resourceId);
                                     if (resource != null) {
-                                        value = Map.of("configuration", resource.configuration());
+                                        Map<String, Object> resourceImplementation =
+                                                computeClusterRuntime.getResourceImplementation(
+                                                        resource, pluginsRegistry);
+                                        value = Map.of("configuration", resourceImplementation);
                                     } else {
                                         throw new IllegalArgumentException(
                                                 "Resource with name="

--- a/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
@@ -21,6 +21,7 @@ import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.model.Connection;
 import ai.langstream.api.model.Module;
 import ai.langstream.api.model.Pipeline;
+import ai.langstream.api.model.Resource;
 import ai.langstream.api.model.TopicDefinition;
 import ai.langstream.api.runtime.AgentNode;
 import ai.langstream.api.runtime.AgentNodeProvider;
@@ -32,8 +33,10 @@ import ai.langstream.api.runtime.DeployContext;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.runtime.ExecutionPlanOptimiser;
 import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.api.runtime.ResourceNodeProvider;
 import ai.langstream.api.runtime.StreamingClusterRuntime;
 import ai.langstream.api.runtime.Topic;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -141,6 +144,15 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
                 }
             }
         }
+    }
+
+    @Override
+    public Map<String, Object> getResourceImplementation(
+            Resource resource, PluginsRegistry pluginsRegistry) {
+        ResourceNodeProvider nodeProvider =
+                pluginsRegistry.lookupResourceImplementation(resource.type(), this);
+        // TODO: validate resource
+        return new HashMap<>(resource.configuration());
     }
 
     protected AgentNode buildAgent(

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public class AIProvidersResourceProvider implements ResourceNodeProvider {
 
     private static final Set<String> SUPPORTED_TYPES =
-            Set.of("open-ai", "hugging-face", "vertex-ai");
+            Set.of("open-ai-configuration", "hugging-face-configuration", "vertex-configuration");
 
     @Override
     public Map<String, Object> createImplementation(

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.impl.resources;
+
+import ai.langstream.api.model.Module;
+import ai.langstream.api.model.Resource;
+import ai.langstream.api.runtime.ComputeClusterRuntime;
+import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.api.runtime.ResourceNodeProvider;
+import java.util.Map;
+import java.util.Set;
+
+public class AIProvidersResourceProvider implements ResourceNodeProvider {
+
+    private static final Set<String> SUPPORTED_TYPES =
+            Set.of("open-ai", "hugging-face", "vertex-ai");
+
+    @Override
+    public Map<String, Object> createImplementation(
+            Resource resource,
+            Module module,
+            ExecutionPlan executionPlan,
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
+        Map<String, Object> configuration = resource.configuration();
+        return resource.configuration();
+    }
+
+    @Override
+    public boolean supports(String type, ComputeClusterRuntime clusterRuntime) {
+        return SUPPORTED_TYPES.contains(type);
+    }
+}

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/DataSourceResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/DataSourceResourceProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.impl.resources;
+
+import ai.langstream.api.model.Module;
+import ai.langstream.api.model.Resource;
+import ai.langstream.api.runtime.ComputeClusterRuntime;
+import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.api.runtime.ResourceNodeProvider;
+import ai.langstream.api.util.ConfigurationUtils;
+import java.util.Map;
+
+public class DataSourceResourceProvider implements ResourceNodeProvider {
+    @Override
+    public Map<String, Object> createImplementation(
+            Resource resource,
+            Module module,
+            ExecutionPlan executionPlan,
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
+        Map<String, Object> configuration = resource.configuration();
+        String service = ConfigurationUtils.getString("service", "", configuration);
+        if (service.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required field 'service' in a datasource resource definition");
+        }
+        return resource.configuration();
+    }
+
+    @Override
+    public boolean supports(String type, ComputeClusterRuntime clusterRuntime) {
+        return "datasource".equals(type);
+    }
+}

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/VectorDatabaseResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/VectorDatabaseResourceProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.impl.resources;
+
+import ai.langstream.api.model.Module;
+import ai.langstream.api.model.Resource;
+import ai.langstream.api.runtime.ComputeClusterRuntime;
+import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.api.runtime.ResourceNodeProvider;
+import ai.langstream.api.util.ConfigurationUtils;
+import java.util.Map;
+
+public class VectorDatabaseResourceProvider implements ResourceNodeProvider {
+    @Override
+    public Map<String, Object> createImplementation(
+            Resource resource,
+            Module module,
+            ExecutionPlan executionPlan,
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
+        Map<String, Object> configuration = resource.configuration();
+        String service = ConfigurationUtils.getString("service", "", configuration);
+        if (service.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required field 'service' in a vector-database resource definition");
+        }
+        return resource.configuration();
+    }
+
+    @Override
+    public boolean supports(String type, ComputeClusterRuntime clusterRuntime) {
+        return "vector-database".equals(type);
+    }
+}

--- a/langstream-core/src/main/resources/META-INF/services/ai.langstream.api.runtime.ResourceNodeProvider
+++ b/langstream-core/src/main/resources/META-INF/services/ai.langstream.api.runtime.ResourceNodeProvider
@@ -1,0 +1,3 @@
+ai.langstream.impl.resources.VectorDatabaseResourceProvider
+ai.langstream.impl.resources.DataSourceResourceProvider
+ai.langstream.impl.resources.AIProvidersResourceProvider

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/testagents/TestGenericAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/testagents/TestGenericAgentProvider.java
@@ -21,6 +21,7 @@ import ai.langstream.api.model.Pipeline;
 import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.runtime.ComputeClusterRuntime;
 import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.impl.common.AbstractAgentProvider;
 import java.util.List;
 import java.util.Map;
@@ -38,10 +39,16 @@ public class TestGenericAgentProvider extends AbstractAgentProvider {
             Module module,
             Pipeline pipeline,
             ExecutionPlan executionPlan,
-            ComputeClusterRuntime clusterRuntime) {
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
         Map<String, Object> copy =
                 super.computeAgentConfiguration(
-                        agentConfiguration, module, pipeline, executionPlan, clusterRuntime);
+                        agentConfiguration,
+                        module,
+                        pipeline,
+                        executionPlan,
+                        clusterRuntime,
+                        pluginsRegistry);
         // TODO.....
         return copy;
     }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/testagents/TestGenericSinkAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/testagents/TestGenericSinkAgentProvider.java
@@ -22,6 +22,7 @@ import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.runtime.ComputeClusterRuntime;
 import ai.langstream.api.runtime.ConnectionImplementation;
 import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.api.runtime.Topic;
 import ai.langstream.impl.common.AbstractAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
@@ -46,10 +47,16 @@ public class TestGenericSinkAgentProvider extends AbstractAgentProvider {
             Module module,
             Pipeline pipeline,
             ExecutionPlan executionPlan,
-            ComputeClusterRuntime clusterRuntime) {
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
         Map<String, Object> copy =
                 super.computeAgentConfiguration(
-                        agentConfiguration, module, pipeline, executionPlan, clusterRuntime);
+                        agentConfiguration,
+                        module,
+                        pipeline,
+                        executionPlan,
+                        clusterRuntime,
+                        pluginsRegistry);
 
         // we can auto-wire the "topics" configuration property
         ConnectionImplementation connectionImplementation =

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/testagents/TestGenericSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/testagents/TestGenericSourceAgentProvider.java
@@ -22,6 +22,7 @@ import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.runtime.ComputeClusterRuntime;
 import ai.langstream.api.runtime.ConnectionImplementation;
 import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.api.runtime.Topic;
 import ai.langstream.impl.common.AbstractAgentProvider;
 import java.util.List;
@@ -45,10 +46,16 @@ public class TestGenericSourceAgentProvider extends AbstractAgentProvider {
             Module module,
             Pipeline pipeline,
             ExecutionPlan executionPlan,
-            ComputeClusterRuntime clusterRuntime) {
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
         Map<String, Object> copy =
                 super.computeAgentConfiguration(
-                        agentConfiguration, module, pipeline, executionPlan, clusterRuntime);
+                        agentConfiguration,
+                        module,
+                        pipeline,
+                        executionPlan,
+                        clusterRuntime,
+                        pluginsRegistry);
 
         // we can auto-wire the "topic" configuration property
         ConnectionImplementation connectionImplementation =


### PR DESCRIPTION
Summary:

This patch introduces a mechanism to implement validation of "resource", in order to make it happen on the planner side, as soon as possible, and provide feedback on wrong configuration as soon as possible.


With the basic validation introduced in this PR we validate that:
- the "type" is a well-known type
- for "datasource" and "vector-database" resources you configure a "service" property

Follow up patches will add specific validations for all the known types of resources
