### PR TITLE
Resource: add static validation for all the known resource types

### DIFF
--- a/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/ConfigurationUtils.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -154,5 +155,101 @@ public class ConfigurationUtils {
                         + key
                         + ", expecting a Map, got got a "
                         + value.getClass().getName());
+    }
+
+    public static <T> T requiredField(
+            Map<String, Object> configuration, String name, Supplier<String> definition) {
+        Object value = configuration.get(name);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "Missing required field '" + name + "' in " + definition.get());
+        }
+        return (T) value;
+    }
+
+    public static String requiredNonEmptyField(
+            Map<String, Object> configuration, String name, Supplier<String> definition) {
+        Object value = configuration.get(name);
+        if (value == null || value.toString().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required field '" + name + "' in " + definition.get());
+        }
+        return value.toString();
+    }
+
+    public static void validateEnumField(
+            Map<String, Object> configuration,
+            String name,
+            Set<String> values,
+            Supplier<String> definition) {
+        Object value = configuration.get(name);
+        if (value == null || value.toString().isEmpty()) {
+            return;
+        }
+        if (!values.contains(value.toString())) {
+            throw new IllegalArgumentException(
+                    "Value "
+                            + value
+                            + " is not allowed for field '"
+                            + name
+                            + ", only "
+                            + values
+                            + " are allowed', in "
+                            + definition.get());
+        }
+    }
+
+    public static void validateInteger(
+            Map<String, Object> configuration,
+            String name,
+            int min,
+            int max,
+            Supplier<String> definition) {
+        Object value = configuration.get(name);
+        if (value == null || value.toString().isEmpty()) {
+            return;
+        }
+        int number;
+        if (value instanceof Number) {
+            number = ((Number) value).intValue();
+        } else {
+            number = Integer.parseInt(value.toString());
+        }
+        if (number < min) {
+            throw new IllegalArgumentException(
+                    "Integer field '"
+                            + name
+                            + "' is "
+                            + number
+                            + ", but it must be greater or equals to "
+                            + min
+                            + ", in "
+                            + definition.get());
+        }
+        if (number > max) {
+            throw new IllegalArgumentException(
+                    "Integer field '"
+                            + name
+                            + "' is "
+                            + number
+                            + ", but it must be less or equals to "
+                            + max
+                            + ", in "
+                            + definition.get());
+        }
+    }
+
+    public static void requiredListField(
+            Map<String, Object> configuration, String name, Supplier<String> definition) {
+        Object value = configuration.get(name);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "Missing required field '" + name + "' in " + definition.get());
+        }
+
+        if (!(value instanceof List)) {
+            throw new IllegalArgumentException(
+                    "Expecting a list in the field '" + name + "' in " + definition.get());
+        }
     }
 }

--- a/langstream-core/src/main/java/ai/langstream/impl/assets/CassandraAssetsProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/assets/CassandraAssetsProvider.java
@@ -15,6 +15,10 @@
  */
 package ai.langstream.impl.assets;
 
+import static ai.langstream.api.util.ConfigurationUtils.requiredField;
+import static ai.langstream.api.util.ConfigurationUtils.requiredListField;
+import static ai.langstream.api.util.ConfigurationUtils.requiredNonEmptyField;
+
 import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.util.ConfigurationUtils;
 import ai.langstream.impl.common.AbstractAssetProvider;
@@ -32,27 +36,27 @@ public class CassandraAssetsProvider extends AbstractAssetProvider {
     @Override
     protected void validateAsset(AssetDefinition assetDefinition, Map<String, Object> asset) {
         Map<String, Object> configuration = ConfigurationUtils.getMap("config", null, asset);
-        requiredField(assetDefinition, configuration, "datasource");
+        requiredField(configuration, "datasource", describe(assetDefinition));
         final Map<String, Object> datasource =
                 ConfigurationUtils.getMap("datasource", Map.of(), configuration);
         final Map<String, Object> datasourceConfiguration =
                 ConfigurationUtils.getMap("configuration", Map.of(), datasource);
         switch (assetDefinition.getAssetType()) {
             case "cassandra-table" -> {
-                requiredNonEmptyField(assetDefinition, configuration, "table-name");
-                requiredNonEmptyField(assetDefinition, configuration, "keyspace");
-                requiredListField(assetDefinition, configuration, "create-statements");
+                requiredNonEmptyField(configuration, "table-name", describe(assetDefinition));
+                requiredNonEmptyField(configuration, "keyspace", describe(assetDefinition));
+                requiredListField(configuration, "create-statements", describe(assetDefinition));
             }
             case "cassandra-keyspace" -> {
-                requiredNonEmptyField(assetDefinition, configuration, "keyspace");
-                requiredListField(assetDefinition, configuration, "create-statements");
+                requiredNonEmptyField(configuration, "keyspace", describe(assetDefinition));
+                requiredListField(configuration, "create-statements", describe(assetDefinition));
                 if (datasourceConfiguration.containsKey("secureBundle")
                         || datasourceConfiguration.containsKey("database")) {
                     throw new IllegalArgumentException("Use astra-keyspace for AstraDB services");
                 }
             }
             case "astra-keyspace" -> {
-                requiredNonEmptyField(assetDefinition, configuration, "keyspace");
+                requiredNonEmptyField(configuration, "keyspace", describe(assetDefinition));
                 if (!datasourceConfiguration.containsKey("secureBundle")
                         && !datasourceConfiguration.containsKey("database")) {
                     throw new IllegalArgumentException(
@@ -60,8 +64,9 @@ public class CassandraAssetsProvider extends AbstractAssetProvider {
                 }
                 // are we are using the AstraDB SDK we need also the AstraCS token and
                 // the name of the database
-                requiredNonEmptyField(assetDefinition, datasourceConfiguration, "token");
-                requiredNonEmptyField(assetDefinition, datasourceConfiguration, "database");
+                requiredNonEmptyField(datasourceConfiguration, "token", describe(assetDefinition));
+                requiredNonEmptyField(
+                        datasourceConfiguration, "database", describe(assetDefinition));
             }
             default -> throw new IllegalStateException(
                     "Unexpected value: " + assetDefinition.getAssetType());

--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.impl.common;
 
+import static ai.langstream.api.util.ConfigurationUtils.requiredNonEmptyField;
+
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.AssetDefinition;
 import ai.langstream.api.model.Module;
@@ -25,9 +27,9 @@ import ai.langstream.api.runtime.ComputeClusterRuntime;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.runtime.PluginsRegistry;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /** Utility method to implement an AssetNodeProvider. */
 public abstract class AbstractAssetProvider implements AssetNodeProvider {
@@ -84,9 +86,9 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
                                 if (lookupResource(key)) {
                                     String resourceId =
                                             requiredNonEmptyField(
-                                                    assetDefinition,
                                                     assetDefinition.getConfig(),
-                                                    key);
+                                                    key,
+                                                    describe(assetDefinition));
                                     Resource resource = resources.get(resourceId);
                                     if (resource != null) {
                                         Map<String, Object> resourceImplementation =
@@ -117,67 +119,13 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
         return supportedType.contains(type);
     }
 
-    protected static <T> T requiredField(
-            AssetDefinition assetDefinition, Map<String, Object> configuration, String name) {
-        Object value = configuration.get(name);
-        if (value == null) {
-            throw new IllegalArgumentException(
-                    "Missing required field '"
-                            + name
-                            + "' in assert definition, type="
-                            + assetDefinition.getAssetType()
-                            + ", name="
-                            + assetDefinition.getName()
-                            + ", id="
-                            + assetDefinition.getId());
-        }
-        return (T) value;
-    }
-
-    protected static String requiredNonEmptyField(
-            AssetDefinition assetDefinition, Map<String, Object> configuration, String name) {
-        Object value = configuration.get(name);
-        if (value == null || value.toString().isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Missing required field '"
-                            + name
-                            + "' in assert definition, type="
-                            + assetDefinition.getAssetType()
-                            + ", name="
-                            + assetDefinition.getName()
-                            + ", id="
-                            + assetDefinition.getId());
-        }
-        return value.toString();
-    }
-
-    protected static void requiredListField(
-            AssetDefinition assetDefinition, Map<String, Object> configuration, String name) {
-        Object value = configuration.get(name);
-        if (value == null) {
-            throw new IllegalArgumentException(
-                    "Missing required field '"
-                            + name
-                            + "' in assert definition, type="
-                            + assetDefinition.getAssetType()
-                            + ", name="
-                            + assetDefinition.getName()
-                            + ", id="
-                            + assetDefinition.getId());
-        }
-
-        if (!(value instanceof List)) {
-            throw new IllegalArgumentException(
-                    "Expecting a list in the field '"
-                            + name
-                            + "' in assert definition, type="
-                            + assetDefinition.getAssetType()
-                            + ", name="
-                            + assetDefinition.getName()
-                            + ", id="
-                            + assetDefinition.getId()
-                            + " but got a "
-                            + value.getClass().getName());
-        }
+    protected static Supplier<String> describe(AssetDefinition assetDefinition) {
+        return () ->
+                " assert definition, type="
+                        + assetDefinition.getAssetType()
+                        + ", name="
+                        + assetDefinition.getName()
+                        + ", id="
+                        + assetDefinition.getId();
     }
 }

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
@@ -15,14 +15,22 @@
  */
 package ai.langstream.impl.resources;
 
+import static ai.langstream.api.util.ConfigurationUtils.getMap;
+import static ai.langstream.api.util.ConfigurationUtils.getString;
+import static ai.langstream.api.util.ConfigurationUtils.requiredField;
+import static ai.langstream.api.util.ConfigurationUtils.requiredNonEmptyField;
+import static ai.langstream.api.util.ConfigurationUtils.validateEnumField;
+
 import ai.langstream.api.model.Module;
 import ai.langstream.api.model.Resource;
 import ai.langstream.api.runtime.ComputeClusterRuntime;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.api.runtime.ResourceNodeProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class AIProvidersResourceProvider implements ResourceNodeProvider {
 
@@ -36,12 +44,68 @@ public class AIProvidersResourceProvider implements ResourceNodeProvider {
             ExecutionPlan executionPlan,
             ComputeClusterRuntime clusterRuntime,
             PluginsRegistry pluginsRegistry) {
-        Map<String, Object> configuration = resource.configuration();
+        switch (resource.type()) {
+            case "open-ai-configuration" -> {
+                validateOpenAIConfigurationResource(resource);
+            }
+            case "hugging-face-configuration" -> {
+                validateHuggingFaceConfigurationResource(resource);
+            }
+            case "vertex-configuration" -> {
+                validateVertexConfigurationResource(resource);
+            }
+            default -> throw new IllegalStateException();
+        }
         return resource.configuration();
+    }
+
+    private void validateVertexConfigurationResource(Resource resource) {
+        Map<String, Object> configuration = resource.configuration();
+        requiredNonEmptyField(configuration, "url", describe(resource));
+        requiredNonEmptyField(configuration, "region", describe(resource));
+        requiredNonEmptyField(configuration, "project", describe(resource));
+
+        String token = getString("token", "", configuration);
+        if (token.isEmpty()) {
+            requiredNonEmptyField(configuration, "serviceAccountJson", describe(resource));
+        }
+
+        String serviceAccountJson = getString("serviceAccountJson", "", configuration);
+        if (!serviceAccountJson.isEmpty()) {
+            try {
+                new ObjectMapper().readValue(serviceAccountJson, Map.class);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Invalid JSON for field serviceAccountJson in " + describe(resource).get(),
+                        e);
+            }
+        }
+    }
+
+    private void validateHuggingFaceConfigurationResource(Resource resource) {
+        Map<String, Object> configuration = resource.configuration();
+        validateEnumField(configuration, "provider", Set.of("local", "api"), describe(resource));
+        requiredField(configuration, "model", describe(resource));
+        getMap("options", Map.of(), configuration);
+        getMap("arguments", Map.of(), configuration);
+    }
+
+    private void validateOpenAIConfigurationResource(Resource resource) {
+        Map<String, Object> configuration = resource.configuration();
+        validateEnumField(configuration, "provider", Set.of("azure", "openai"), describe(resource));
+        String provider = getString("provider", "openai", configuration);
+        if (provider.equals("azure")) {
+            requiredField(configuration, "url", describe(resource));
+        }
+        requiredField(configuration, "access-key", describe(resource));
     }
 
     @Override
     public boolean supports(String type, ComputeClusterRuntime clusterRuntime) {
         return SUPPORTED_TYPES.contains(type);
+    }
+
+    protected static Supplier<String> describe(Resource resource) {
+        return () -> "resource with id = " + resource.id() + " of type " + resource.type();
     }
 }

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
@@ -66,11 +66,15 @@ public class AIProvidersResourceProvider implements ResourceNodeProvider {
         requiredNonEmptyField(configuration, "project", describe(resource));
 
         String token = getString("token", "", configuration);
+        String serviceAccountJson = getString("serviceAccountJson", "", configuration);
+        if (!token.isEmpty() && !serviceAccountJson.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Only one of token and serviceAccountJson should be provided in "
+                            + describe(resource).get());
+        }
         if (token.isEmpty()) {
             requiredNonEmptyField(configuration, "serviceAccountJson", describe(resource));
         }
-
-        String serviceAccountJson = getString("serviceAccountJson", "", configuration);
         if (!serviceAccountJson.isEmpty()) {
             try {
                 new ObjectMapper().readValue(serviceAccountJson, Map.class);

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/DataSourceResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/DataSourceResourceProvider.java
@@ -53,10 +53,18 @@ public class DataSourceResourceProvider implements ResourceNodeProvider {
             case "cassandra":
                 validateCassandraDatabaseResource(resource);
                 break;
+            case "jdbc":
+                validateJDBCDatabaseResource(resource);
             default:
                 throw new IllegalStateException();
         }
         return resource.configuration();
+    }
+
+    private void validateJDBCDatabaseResource(Resource resource) {
+        Map<String, Object> configuration = resource.configuration();
+        requiredNonEmptyField(configuration, "url", describe(resource));
+        requiredNonEmptyField(configuration, "driverClass", describe(resource));
     }
 
     @Override

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/DataSourceResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/DataSourceResourceProvider.java
@@ -15,6 +15,11 @@
  */
 package ai.langstream.impl.resources;
 
+import static ai.langstream.api.util.ConfigurationUtils.requiredField;
+import static ai.langstream.api.util.ConfigurationUtils.requiredNonEmptyField;
+import static ai.langstream.api.util.ConfigurationUtils.validateEnumField;
+import static ai.langstream.api.util.ConfigurationUtils.validateInteger;
+
 import ai.langstream.api.model.Module;
 import ai.langstream.api.model.Resource;
 import ai.langstream.api.runtime.ComputeClusterRuntime;
@@ -22,7 +27,10 @@ import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.api.runtime.ResourceNodeProvider;
 import ai.langstream.api.util.ConfigurationUtils;
+import java.util.Base64;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
 
 public class DataSourceResourceProvider implements ResourceNodeProvider {
     @Override
@@ -33,10 +41,20 @@ public class DataSourceResourceProvider implements ResourceNodeProvider {
             ComputeClusterRuntime clusterRuntime,
             PluginsRegistry pluginsRegistry) {
         Map<String, Object> configuration = resource.configuration();
-        String service = ConfigurationUtils.getString("service", "", configuration);
-        if (service.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Missing required field 'service' in a datasource resource definition");
+
+        String service = requiredField(configuration, "service", describe(resource));
+        validateEnumField(
+                configuration, "service", Set.of("astra", "cassandra"), describe(resource));
+
+        switch (service) {
+            case "astra":
+                validateAstraDatabaseResource(resource);
+                break;
+            case "cassandra":
+                validateCassandraDatabaseResource(resource);
+                break;
+            default:
+                throw new IllegalStateException();
         }
         return resource.configuration();
     }
@@ -44,5 +62,65 @@ public class DataSourceResourceProvider implements ResourceNodeProvider {
     @Override
     public boolean supports(String type, ComputeClusterRuntime clusterRuntime) {
         return "datasource".equals(type);
+    }
+
+    protected void validateAstraDatabaseResource(Resource resource) {
+        Map<String, Object> configuration = resource.configuration();
+
+        String secureBundle = ConfigurationUtils.getString("secureBundle", "", configuration);
+        if (secureBundle.isEmpty()) {
+            requiredNonEmptyField(configuration, "token", describe(resource));
+            requiredNonEmptyField(configuration, "database", describe(resource));
+        } else {
+            if (secureBundle.startsWith("base64:")) {
+                secureBundle = secureBundle.substring("base64:".length());
+            }
+            try {
+                Base64.getDecoder().decode(secureBundle);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        "Invalid base64 encoding for secureBundle in " + describe(resource), e);
+            }
+        }
+
+        String username =
+                ConfigurationUtils.getString(
+                        "clientId",
+                        ConfigurationUtils.getString("username", "", configuration),
+                        configuration);
+        if (username.isEmpty()) {
+            requiredNonEmptyField(configuration, "clientId", describe(resource));
+        }
+
+        String password =
+                ConfigurationUtils.getString(
+                        "secret",
+                        ConfigurationUtils.getString("password", "", configuration),
+                        configuration);
+        if (password.isEmpty()) {
+            requiredNonEmptyField(configuration, "secret", describe(resource));
+        }
+    }
+
+    protected void validateCassandraDatabaseResource(Resource resource) {
+        Map<String, Object> configuration = resource.configuration();
+
+        String secureBundle = ConfigurationUtils.getString("secureBundle", "", configuration);
+        if (!secureBundle.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "secureBundle is not supported for Cassandra services, use service=astra instead");
+        }
+
+        // in Cassandra testes you can use a Cassandra service without authentication
+        requiredField(configuration, "username", describe(resource));
+        requiredField(configuration, "password", describe(resource));
+
+        requiredNonEmptyField(configuration, "contact-points", describe(resource));
+        requiredNonEmptyField(configuration, "loadBalancing-localDc", describe(resource));
+        validateInteger(configuration, "port", 1, 65535, describe(resource));
+    }
+
+    protected static Supplier<String> describe(Resource resource) {
+        return () -> "resource with id = " + resource.id() + " of type " + resource.type();
     }
 }

--- a/langstream-core/src/test/java/ai/langstream/impl/resources/ResourceNodeProviderTest.java
+++ b/langstream-core/src/test/java/ai/langstream/impl/resources/ResourceNodeProviderTest.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.impl.resources;
+
+import static ai.langstream.impl.resources.ResourceNodeProviderTest.Outcome.NON_VALID;
+import static ai.langstream.impl.resources.ResourceNodeProviderTest.Outcome.VALID;
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.langstream.api.model.Resource;
+import ai.langstream.api.runtime.ResourceNodeProvider;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ResourceNodeProviderTest {
+
+    enum Outcome {
+        VALID,
+        NON_VALID
+    }
+
+    private void test(
+            Outcome outcome,
+            String type,
+            Map<String, Object> configuration,
+            ResourceNodeProvider providersResourceProvider) {
+        Resource resource = new Resource("the-id", "then-name", type, configuration);
+        switch (outcome) {
+            case VALID -> {
+                assertDoesNotThrow(
+                        () ->
+                                providersResourceProvider.createImplementation(
+                                        resource, null, null, null, null));
+            }
+            case NON_VALID -> {
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                providersResourceProvider.createImplementation(
+                                        resource, null, null, null, null));
+            }
+        }
+    }
+
+    private static List<Arguments> configurationsAIProviders() {
+        return Arrays.asList(
+                Arguments.of(NON_VALID, "open-ai-configuration", Map.of()),
+                Arguments.of(NON_VALID, "vertex-configuration", Map.of()),
+                Arguments.of(NON_VALID, "hugging-face-configuration", Map.of()),
+                Arguments.of(
+                        VALID,
+                        "open-ai-configuration",
+                        Map.of("access-key", "the-api-key", "provider", "openai")),
+                Arguments.of(
+                        NON_VALID,
+                        "open-ai-configuration",
+                        Map.of("access-key", "the-api-key", "provider", "azure")),
+                Arguments.of(
+                        VALID,
+                        "open-ai-configuration",
+                        Map.of(
+                                "access-key",
+                                "the-api-key",
+                                "provider",
+                                "azure",
+                                "url",
+                                "http://some-url")),
+                Arguments.of(
+                        VALID,
+                        "hugging-face-configuration",
+                        Map.of("provider", "api", "model", "some-model")),
+                Arguments.of(
+                        VALID,
+                        "hugging-face-configuration",
+                        Map.of("model", "some-model", "options", Map.of("wait-for-model", "true"))),
+                Arguments.of(
+                        NON_VALID,
+                        "hugging-face-configuration",
+                        Map.of("model", "some-model", "options", "this-is-not-a-map")),
+                Arguments.of(
+                        VALID,
+                        "hugging-face-configuration",
+                        Map.of(
+                                "model",
+                                "some-model",
+                                "arguments",
+                                Map.of("some-argument", "true"))),
+                Arguments.of(
+                        NON_VALID,
+                        "hugging-face-configuration",
+                        Map.of("model", "some-model", "arguments", "this-is-not-a-map")),
+                Arguments.of(
+                        VALID,
+                        "hugging-face-configuration",
+                        Map.of("provider", "local", "model", "some-model")),
+                Arguments.of(
+                        NON_VALID,
+                        "hugging-face-configuration",
+                        Map.of("provider", "bad-provider", "model", "some-model")),
+                Arguments.of(
+                        VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "url",
+                                "http://some-url",
+                                "region",
+                                "us-east-1",
+                                "project",
+                                "some-project",
+                                "token",
+                                "some-token")),
+                Arguments.of(
+                        VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "url",
+                                "http://some-url",
+                                "region",
+                                "us-east-1",
+                                "project",
+                                "some-project",
+                                "serviceAccountJson",
+                                "{\"some\": \"json\"}")),
+                Arguments.of(
+                        NON_VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "url",
+                                "http://some-url",
+                                "region",
+                                "us-east-1",
+                                "project",
+                                "some-project",
+                                "serviceAccountJson",
+                                "not-a-valid-json")),
+                Arguments.of(
+                        NON_VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "url",
+                                "http://some-url",
+                                "region",
+                                "us-east-1",
+                                "project",
+                                "some-project",
+                                "token",
+                                "some-token",
+                                "serviceAccountJson",
+                                "{\"some\": \"json\"}")),
+                Arguments.of(
+                        NON_VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "url",
+                                "http://some-url",
+                                "region",
+                                "us-east-1",
+                                "project",
+                                "some-project")),
+                Arguments.of(
+                        NON_VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "url",
+                                "http://some-url",
+                                "region",
+                                "us-east-1",
+                                "token",
+                                "some-token")),
+                Arguments.of(
+                        NON_VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "url",
+                                "http://some-url",
+                                "project",
+                                "some-project",
+                                "token",
+                                "some-token")),
+                Arguments.of(
+                        NON_VALID,
+                        "vertex-configuration",
+                        Map.of(
+                                "region",
+                                "us-east-1",
+                                "project",
+                                "some-project",
+                                "token",
+                                "some-token")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("configurationsAIProviders")
+    void testAIConfigurationResource(
+            Outcome outcome, String type, Map<String, Object> configuration) {
+        test(outcome, type, configuration, new AIProvidersResourceProvider());
+    }
+
+    private static List<Arguments> configurationsDataSourceProviders() {
+        return Arrays.asList(
+                Arguments.of(NON_VALID, "cassandra", Map.of()),
+                Arguments.of(NON_VALID, "jdbc", Map.of()),
+                Arguments.of(NON_VALID, "astra", Map.of()),
+                Arguments.of(
+                        VALID,
+                        "cassandra",
+                        Map.of(
+                                "contact-points",
+                                "localhost",
+                                "loadBalancing-localDc",
+                                "dc1",
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        VALID,
+                        "cassandra",
+                        Map.of(
+                                "contact-points",
+                                "localhost",
+                                "loadBalancing-localDc",
+                                "dc1",
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        NON_VALID,
+                        "cassandra",
+                        Map.of(
+                                "contact-points",
+                                "locahost",
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        NON_VALID,
+                        "cassandra",
+                        Map.of(
+                                "loadBalancing-localDc",
+                                "dc1",
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        NON_VALID,
+                        "cassandra",
+                        Map.of(
+                                "secureBundle",
+                                "base64:" + Base64.getEncoder().encodeToString("foo".getBytes()),
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        VALID,
+                        "astra",
+                        Map.of(
+                                "secureBundle",
+                                "base64:" + Base64.getEncoder().encodeToString("foo".getBytes()),
+                                "clientId",
+                                "user",
+                                "secret",
+                                "pwd")),
+                Arguments.of(
+                        VALID,
+                        "astra",
+                        Map.of(
+                                "secureBundle",
+                                "base64:" + Base64.getEncoder().encodeToString("foo".getBytes()),
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        VALID,
+                        "astra",
+                        Map.of(
+                                "secureBundle",
+                                Base64.getEncoder().encodeToString("foo".getBytes()),
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        NON_VALID,
+                        "astra",
+                        Map.of(
+                                "secureBundle",
+                                "not-base-64",
+                                "username",
+                                "user",
+                                "password",
+                                "pwd")),
+                Arguments.of(
+                        VALID,
+                        "astra",
+                        Map.of(
+                                "token",
+                                "the-token",
+                                "database",
+                                "the-database",
+                                "clientId",
+                                "user",
+                                "secret",
+                                "pwd")),
+                Arguments.of(
+                        NON_VALID,
+                        "astra",
+                        Map.of("token", "the-token", "clientId", "user", "secret", "pwd")),
+                Arguments.of(
+                        NON_VALID,
+                        "astra",
+                        Map.of("database", "the-database", "clientId", "user", "secret", "pwd")),
+                Arguments.of(NON_VALID, "astra", Map.of("clientId", "user", "secret", "pwd")),
+                Arguments.of(NON_VALID, "jdbc", Map.of("driverClass", "some.java.Class")),
+                Arguments.of(
+                        NON_VALID,
+                        "jdbc",
+                        Map.of(
+                                "driverClass",
+                                "some.java.Class",
+                                "usermame",
+                                "user",
+                                "password",
+                                "pass")));
+    }
+
+    private static List<Arguments> configurationsVectorDatabaseProviders() {
+        List<Arguments> all = new ArrayList<>();
+        all.addAll(configurationsDataSourceProviders());
+        all.addAll(
+                (Arrays.asList(
+                        Arguments.of(NON_VALID, "pinecone", Map.of()),
+                        Arguments.of(
+                                VALID,
+                                "pinecone",
+                                Map.of(
+                                        "api-key",
+                                        "xxx",
+                                        "environment",
+                                        "xxx",
+                                        "project-name",
+                                        "xxx",
+                                        "index-name",
+                                        "xxx")),
+                        Arguments.of(
+                                VALID,
+                                "pinecone",
+                                Map.of(
+                                        "api-key",
+                                        "xxx",
+                                        "environment",
+                                        "xxx",
+                                        "project-name",
+                                        "xxx",
+                                        "index-name",
+                                        "xxx",
+                                        "server-side-timeout-sec",
+                                        10000)),
+                        Arguments.of(
+                                VALID,
+                                "pinecone",
+                                Map.of(
+                                        "api-key",
+                                        "xxx",
+                                        "environment",
+                                        "xxx",
+                                        "project-name",
+                                        "xxx",
+                                        "index-name",
+                                        "xxx",
+                                        "server-side-timeout-sec",
+                                        "10000")),
+                        Arguments.of(
+                                NON_VALID,
+                                "pinecone",
+                                Map.of(
+                                        "api-key",
+                                        "xxx",
+                                        "environment",
+                                        "xxx",
+                                        "project-name",
+                                        "xxx",
+                                        "index-name",
+                                        "xxx",
+                                        "server-side-timeout-sec",
+                                        -12)),
+                        Arguments.of(
+                                NON_VALID,
+                                "pinecone",
+                                Map.of(
+                                        "api-key",
+                                        "xxx",
+                                        "environment",
+                                        "xxx",
+                                        "project-name",
+                                        "xxx")),
+                        Arguments.of(
+                                NON_VALID,
+                                "pinecone",
+                                Map.of(
+                                        "api-key",
+                                        "xxx",
+                                        "environment",
+                                        "xxx",
+                                        "index-name",
+                                        "xxx")),
+                        Arguments.of(
+                                NON_VALID,
+                                "pinecone",
+                                Map.of(
+                                        "api-key",
+                                        "xxx",
+                                        "project-name",
+                                        "xxx",
+                                        "index-name",
+                                        "xxx")),
+                        Arguments.of(
+                                NON_VALID,
+                                "pinecone",
+                                Map.of(
+                                        "environment",
+                                        "xxx",
+                                        "project-name",
+                                        "xxx",
+                                        "index-name",
+                                        "xxx")))));
+        return all;
+    }
+
+    @ParameterizedTest
+    @MethodSource("configurationsDataSourceProviders")
+    void testDataSourceNodeResourceProvider(
+            Outcome outcome, String service, Map<String, Object> configuration) {
+        Map<String, Object> resourceConfiguration = new HashMap<>();
+        resourceConfiguration.putAll(configuration);
+        resourceConfiguration.put("service", service);
+        test(outcome, "datasource", resourceConfiguration, new DataSourceResourceProvider());
+    }
+
+    @ParameterizedTest
+    @MethodSource("configurationsVectorDatabaseProviders")
+    void testVectorDatabaseNodeResourceProvider(
+            Outcome outcome, String service, Map<String, Object> configuration) {
+        Map<String, Object> resourceConfiguration = new HashMap<>();
+        resourceConfiguration.putAll(configuration);
+        resourceConfiguration.put("service", service);
+        test(outcome, "datasource", resourceConfiguration, new VectorDatabaseResourceProvider());
+    }
+}


### PR DESCRIPTION
Summary:
- validate as much as possible all the known resource types: datasource (astra, cassandra, pinecone, generic JDBC), vector-database (astra, pinecone, cassandra), openai-configuration, vertex-configuration, hugging-face-configuration
- the intent is to fail invalid configurations at deploy time

Notes:
- we are validating resources that are actually used by agents, this allows to have some demo configuration files with empty values: they won't fail the deploy as long as they are not used
- we cannot connect to the services at deploy time, this is because the actual connection can be performed ONLY from the agent pods, and not from the Control Plane, due to security reasons (agent runners run in special security contexts) and also because the .nar files with the drivers are only available up there