### PR TITLE
[cli] Add a tool to run locally an application on docker

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -41,6 +41,8 @@ elif [ "$only_image" == "operator" ] || [ "$only_image" == "deployer" ]; then
   build_docker_image langstream-k8s-deployer/langstream-k8s-deployer-operator
 elif [ "$only_image" == "runtime" ]; then
   build_docker_image langstream-runtime/langstream-runtime-impl
+elif [ "$only_image" == "runtime-tester" ]; then
+  build_docker_image langstream-runtime/langstream-runtime-tester
 elif [ "$only_image" == "cli" ]; then
   build_docker_image langstream-cli
 elif [ "$only_image" == "api-gateway" ]; then

--- a/examples/instances/astra.yaml
+++ b/examples/instances/astra.yaml
@@ -23,7 +23,7 @@ instance:
     type: "kafka"
     configuration:
       admin:
-        bootstrap.servers: "{{{ secrets.kafka.bootstrap.servers }}}"
+        bootstrap.servers: "{{{ secrets.kafka.bootstrap-servers }}}"
         security.protocol: SASL_SSL
         sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username='{{{ secrets.kafka.username }}}' password='{{{ secrets.kafka.password }}}';"
         sasl.mechanism: PLAIN

--- a/examples/instances/kafka-docker.yaml
+++ b/examples/instances/kafka-docker.yaml
@@ -1,4 +1,4 @@
-#!/bin/bash
+#
 #
 # Copyright DataStax, Inc.
 #
@@ -15,16 +15,9 @@
 # limitations under the License.
 #
 
-START_KAFKA=${START_BROKER:-true}
-if [ "START_BROKER" = "true" ]; then
-  echo "Starting Broker"
-  /kafka/kafka/bin/kafka-server-start.sh -daemon /kafka/kafka/config/kraft/server.properties
-fi
-
-START_MINIO=${START_MINIO:-true}
-if [ "$START_MINIO" = "true" ]; then
-  echo "Starting Minio"
-  /minio/minio server /tmp &
-fi
-
-exec java ${JAVA_OPTS} -Djdk.lang.Process.launchMechanism=vfork -cp "/app/lib/*:/app/tester/lib/*" "ai.langstream.runtime.tester.Main"
+instance:
+  streamingCluster:
+    type: "kafka"
+    configuration:
+      admin:
+        bootstrap.servers: localhost:9092

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -21,7 +21,7 @@ secrets:
       username: "${KAFKA_USERNAME:-}"
       password: "${KAFKA_PASSWORD:-}"
       tenant: "${KAFKA_TENANT:-}"
-      bootstrap.servers: "${KAFKA_BOOTSTRAP_SERVERS:-}"
+      bootstrap-servers: "${KAFKA_BOOTSTRAP_SERVERS:-}"
   - id: open-ai
     data:
       access-key: "${OPEN_AI_ACCESS_KEY:-}"

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
@@ -30,6 +30,7 @@ import picocli.CommandLine;
         subcommands = {
             AbstractDeployApplicationCmd.DeployApplicationCmd.class,
             AbstractDeployApplicationCmd.UpdateApplicationCmd.class,
+            AbstractDeployApplicationCmd.LocalRun.class,
             ListApplicationCmd.class,
             DeleteApplicationCmd.class,
             GetApplicationCmd.class,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootAppCmd.java
@@ -30,7 +30,6 @@ import picocli.CommandLine;
         subcommands = {
             AbstractDeployApplicationCmd.DeployApplicationCmd.class,
             AbstractDeployApplicationCmd.UpdateApplicationCmd.class,
-            AbstractDeployApplicationCmd.LocalRun.class,
             ListApplicationCmd.class,
             DeleteApplicationCmd.class,
             GetApplicationCmd.class,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
@@ -32,6 +32,7 @@ import picocli.CommandLine;
             RootTenantCmd.class,
             RootGatewayCmd.class,
             RootProfileCmd.class,
+            RootDockerCmd.class,
             AutoComplete.GenerateCompletion.class
         })
 public class RootCmd {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootDockerCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootDockerCmd.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands;
+
+import ai.langstream.cli.commands.docker.LocalRunApplicationCmd;
+import lombok.Getter;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "docker",
+        header = "Run LangStream locally",
+        subcommands = {LocalRunApplicationCmd.class})
+@Getter
+public class RootDockerCmd {
+    @CommandLine.ParentCommand private RootCmd rootCmd;
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -159,9 +159,6 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
             header = "Run on a docker container a LangStream application")
     public static class LocalRun extends AbstractDeployApplicationCmd {
 
-        @CommandLine.Parameters(description = "Name of the application")
-        private String name;
-
         @CommandLine.Option(
                 names = {"-app", "--application"},
                 description = "Application directory path",
@@ -181,7 +178,7 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
 
         @Override
         String applicationId() {
-            return name;
+            return "app";
         }
 
         @Override

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.docker;
+
+import ai.langstream.cli.commands.BaseCmd;
+import ai.langstream.cli.commands.RootCmd;
+import ai.langstream.cli.commands.RootDockerCmd;
+import picocli.CommandLine;
+
+public abstract class BaseDockerCmd extends BaseCmd {
+
+    @CommandLine.ParentCommand private RootDockerCmd rootDockerCmd;
+
+    @Override
+    protected RootCmd getRootCmd() {
+        return rootDockerCmd.getRootCmd();
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.docker;
+
+import ai.langstream.cli.util.LocalFileReferenceResolver;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.SneakyThrows;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "run", header = "Run on a docker container a LangStream application")
+public class LocalRunApplicationCmd extends BaseDockerCmd {
+
+    @CommandLine.Option(
+            names = {"-app", "--application"},
+            description = "Application directory path",
+            required = true)
+    private String appPath;
+
+    @CommandLine.Option(
+            names = {"-i", "--instance"},
+            description = "Instance file path",
+            required = true)
+    private String instanceFilePath;
+
+    @CommandLine.Option(
+            names = {"--start-broker"},
+            description = "Start the broker")
+    private boolean startBroker = true;
+
+    @CommandLine.Option(
+            names = {"--start-s3"},
+            description = "Start the S3 service")
+    private boolean startS3 = true;
+
+    @CommandLine.Option(
+            names = {"-s", "--secrets"},
+            description = "Secrets file path")
+    private String secretFilePath;
+
+    String appPath() {
+        return appPath;
+    }
+
+    String instanceFilePath() {
+        return instanceFilePath;
+    }
+
+    String secretFilePath() {
+        return secretFilePath;
+    }
+
+    @Override
+    @SneakyThrows
+    public void run() {
+        final File appDirectory = checkFileExistsOrDownload(appPath());
+        final File instanceFile = checkFileExistsOrDownload(instanceFilePath());
+        final File secretsFile = checkFileExistsOrDownload(secretFilePath());
+
+        log("Application directory: " + appDirectory.getAbsolutePath());
+        log("Instance file: " + instanceFile.getAbsolutePath());
+        log("Secrets file: " + secretsFile.getAbsolutePath());
+        log("Start broker: " + startBroker);
+        log("Start S3: " + startS3);
+
+        if ((appDirectory == null || instanceFile == null)) {
+            throw new IllegalArgumentException("application and instance files are required");
+        }
+
+        downloadDependencies(appDirectory.toPath());
+
+        String secretsContents;
+        String instanceContents;
+
+        try {
+
+            instanceContents =
+                    LocalFileReferenceResolver.resolveFileReferencesInYAMLFile(
+                            instanceFile.toPath());
+        } catch (Exception e) {
+            log(
+                    "Failed to resolve instance file references. Please double check the file path: "
+                            + instanceFile.toPath());
+            e.printStackTrace();
+            throw e;
+        }
+
+        try {
+
+            secretsContents =
+                    LocalFileReferenceResolver.resolveFileReferencesInYAMLFile(
+                            secretsFile.toPath());
+        } catch (Exception e) {
+            log(
+                    "Failed to resolve secrets file references. Please double check the file path: "
+                            + secretsFile.toPath());
+            throw e;
+        }
+
+        executeOnDocker(appDirectory, instanceContents, secretsContents, startBroker, startS3);
+    }
+
+    private void executeOnDocker(
+            File appDirectory,
+            String instanceContents,
+            String secretsContents,
+            boolean startBroker,
+            boolean startS3)
+            throws Exception {
+        File tmpInstanceFile = Files.createTempFile("instance", ".yaml").toFile();
+        Files.write(tmpInstanceFile.toPath(), instanceContents.getBytes(StandardCharsets.UTF_8));
+        File tmpSecretsFile = Files.createTempFile("secrets", ".yaml").toFile();
+        Files.write(tmpSecretsFile.toPath(), secretsContents.getBytes(StandardCharsets.UTF_8));
+        String imageName = "langstream/langstream-runtime-tester:latest-dev";
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add("docker");
+        commandLine.add("run");
+        commandLine.add("--rm");
+        commandLine.add("-it");
+        commandLine.add("-e");
+        commandLine.add("START_BROKER=" + startBroker);
+        commandLine.add("-e");
+        commandLine.add("START_S3=" + startS3);
+        commandLine.add("-v");
+        commandLine.add(appDirectory.getAbsolutePath() + ":/code/application");
+        commandLine.add("-v");
+        commandLine.add(tmpInstanceFile.getAbsolutePath() + ":/code/instance.yaml");
+        commandLine.add("-v");
+        commandLine.add(tmpSecretsFile.getAbsolutePath() + ":/code/secrets.yaml");
+        commandLine.add(imageName);
+        ProcessBuilder processBuilder = new ProcessBuilder(commandLine).inheritIO();
+        Process process = processBuilder.start();
+        process.waitFor();
+    }
+}

--- a/langstream-runtime/langstream-runtime-tester/pom.xml
+++ b/langstream-runtime/langstream-runtime-tester/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>langstream-runtime</artifactId>
+    <groupId>ai.langstream</groupId>
+    <version>0.0.16-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>langstream-runtime-tester</artifactId>
+
+  <properties>
+    <docker.platforms>linux/amd64</docker.platforms>
+  </properties>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-runtime-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-k8s-common</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-k8s-deployer-api</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ai.langstream</groupId>
+      <artifactId>langstream-k8s-deployer-core</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+  </dependencies>
+  <build>
+    <plugins>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <activation>
+        <property>
+          <name>docker</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <verbose>true</verbose>
+              <images>
+                <image>
+                  <name>langstream-runtime-tester:latest-dev</name>
+                  <build>
+                    <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                    <assembly>
+                      <descriptor>${project.basedir}/src/main/assemble/langstream-runtime-tester.xml</descriptor>
+                    </assembly>
+                    <buildx>
+                      <platforms>
+                        <!-- <platform>${docker.platforms}</platform>-->
+                      </platforms>
+                    </buildx>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/langstream-runtime/langstream-runtime-tester/pom.xml
+++ b/langstream-runtime/langstream-runtime-tester/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
     </dependency>
@@ -100,7 +104,7 @@
               <verbose>true</verbose>
               <images>
                 <image>
-                  <name>langstream-runtime-tester:latest-dev</name>
+                  <name>langstream/langstream-runtime-tester:latest-dev</name>
                   <build>
                     <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
                     <assembly>

--- a/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
+++ b/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-exec java ${JAVA_OPTS} -cp "/app/lib/*" "ai.langstream.runtime.tester.Main" "$@"
+exec java ${JAVA_OPTS} -Djdk.lang.Process.launchMechanism=vfork -cp "/app/lib/*:/app/tester/lib/*" "ai.langstream.runtime.tester.Main"

--- a/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
+++ b/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-#
 # Copyright DataStax, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
+++ b/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+exec java ${JAVA_OPTS} -cp "/app/lib/*" "ai.langstream.runtime.tester.Main" "$@"

--- a/langstream-runtime/langstream-runtime-tester/src/main/assemble/langstream-runtime-tester.xml
+++ b/langstream-runtime/langstream-runtime-tester/src/main/assemble/langstream-runtime-tester.xml
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>runtime</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/assemble/</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>*.sh</include>
+      </includes>
+      <lineEnding>unix</lineEnding>
+      <fileMode>755</fileMode>
+    </fileSet>
+  </fileSets>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>lib</outputDirectory>
+      <unpack>false</unpack>
+      <scope>runtime</scope>
+      <useProjectArtifact>true</useProjectArtifact>
+      <outputFileNameMapping>${artifact.groupId}-${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
@@ -18,6 +18,23 @@
 FROM langstream/langstream-runtime:latest-dev
 
 ARG DEBIAN_FRONTEND=noninteractive
+USER 0
+RUN mkdir /kafka \
+       && curl -o /kafka/kafka.tgz https://downloads.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz \
+       && cd /kafka \
+       && tar -xzf kafka.tgz \
+       && rm kafka.tgz \
+       && mv kafka_2.13-3.5.1 kafka \
+       && chmod -R g+w /kafka \
+       && cd /kafka/kafka \
+       && export UUID=$(bin/kafka-storage.sh random-uuid) \
+       && bin/kafka-storage.sh format -t $UUID -c config/kraft/server.properties \
+       && mkdir -p /tmp/kraft-combined-logs \
+       && chmod a+rwx /tmp/kraft-combined-logs
+
+RUN mkdir /minio \
+    && wget https://dl.min.io/server/minio/release/linux-amd64/minio -O /minio/minio \
+    && chmod a+x /minio/minio
 
 # Add the runtime code at the end. This optimizes docker layers to not depend on artifacts-specific changes.
 ADD maven/lib /app/tester/lib

--- a/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
@@ -1,0 +1,33 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM langstream/langstream-runtime:latest-dev
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Add the runtime code at the end. This optimizes docker layers to not depend on artifacts-specific changes.
+ADD maven/lib /app/tester/lib
+ADD maven/entrypoint.sh /app/entrypoint.sh
+
+WORKDIR /app
+
+# The UID must be non-zero. Otherwise, it is arbitrary. No logic should rely on its specific value.
+USER 10000
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+LABEL org.opencontainers.image.source=https://github.com/LangStream/langstream
+LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/KubeTestServer.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/KubeTestServer.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.tester;
+
+import static org.mockito.ArgumentMatchers.isNull;
+
+import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import ai.langstream.impl.k8s.KubernetesClientFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+@Slf4j
+public class KubeTestServer implements AutoCloseable {
+
+    public static class Server extends KubernetesMockServer {
+
+        MockedStatic<KubernetesClientFactory> mocked;
+        NamespacedKubernetesClient client;
+
+        @Override
+        @SneakyThrows
+        public void init() {
+            super.init();
+
+            mocked = Mockito.mockStatic(KubernetesClientFactory.class);
+            client = createClient();
+
+            mocked.when(() -> KubernetesClientFactory.get(isNull())).thenReturn(client);
+            mocked.when(() -> KubernetesClientFactory.create(isNull())).thenReturn(client);
+        }
+
+        @Override
+        public void destroy() {
+            super.destroy();
+            if (mocked != null) {
+                mocked.close();
+            }
+            if (client != null) {
+                client.close();
+            }
+        }
+    }
+
+    @Getter private Server server;
+
+    @SneakyThrows
+    public void start() {
+        server = new Server();
+        server.init();
+
+        server.reset();
+        currentAgents.clear();
+        currentAgentsSecrets.clear();
+        currentApplications.clear();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (server != null) {
+            server.destroy();
+            server = null;
+        }
+    }
+
+    private final Map<String, AgentCustomResource> currentAgents = new HashMap<>();
+    private final Map<String, ApplicationCustomResource> currentApplications = new HashMap<>();
+    private final Map<String, Secret> currentAgentsSecrets = new HashMap<>();
+
+    public Map<String, AgentCustomResource> spyAgentCustomResources(
+            final String namespace, String... expectedAgents) {
+        for (String agentId : expectedAgents) {
+            final String fullPath =
+                    "/apis/langstream.ai/v1alpha1/namespaces/%s/agents/%s"
+                            .formatted(namespace, agentId);
+            server.expect()
+                    .patch()
+                    .withPath(fullPath + "?fieldManager=fabric8")
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                try {
+                                    final ByteArrayOutputStream byteArrayOutputStream =
+                                            new ByteArrayOutputStream();
+                                    recordedRequest.getBody().copyTo(byteArrayOutputStream);
+                                    final ObjectMapper mapper =
+                                            new ObjectMapper()
+                                                    .enable(
+                                                            SerializationFeature
+                                                                    .ORDER_MAP_ENTRIES_BY_KEYS);
+                                    final AgentCustomResource agent =
+                                            mapper.readValue(
+                                                    byteArrayOutputStream.toByteArray(),
+                                                    AgentCustomResource.class);
+                                    log.info("received patch request for agent {}", agentId);
+                                    currentAgents.put(agentId, agent);
+                                    return agent;
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                    .always();
+
+            server.expect()
+                    .get()
+                    .withPath(fullPath)
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                log.info("received get request for agent {}", agentId);
+                                return currentAgents.get(agentId);
+                            })
+                    .always();
+
+            server.expect()
+                    .delete()
+                    .withPath(fullPath)
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                log.info("received delete request for agent {}", agentId);
+                                currentAgents.remove(agentId);
+                                return List.of();
+                            })
+                    .always();
+        }
+        return currentAgents;
+    }
+
+    public Map<String, Secret> spyAgentCustomResourcesSecrets(
+            final String namespace, String... expectedAgents) {
+        for (String agentId : expectedAgents) {
+            final String fullPath =
+                    "/api/v1/namespaces/%s/secrets/%s".formatted(namespace, agentId);
+            server.expect()
+                    .patch()
+                    .withPath(fullPath + "?fieldManager=fabric8")
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                try {
+                                    final ByteArrayOutputStream byteArrayOutputStream =
+                                            new ByteArrayOutputStream();
+                                    recordedRequest.getBody().copyTo(byteArrayOutputStream);
+                                    final ObjectMapper mapper = new ObjectMapper();
+                                    final Secret secret =
+                                            mapper.readValue(
+                                                    byteArrayOutputStream.toByteArray(),
+                                                    Secret.class);
+                                    log.info(
+                                            "received patch request secret for agent {}: {}",
+                                            agentId,
+                                            secret);
+                                    currentAgentsSecrets.put(agentId, secret);
+                                    return secret;
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                    .always();
+
+            server.expect()
+                    .delete()
+                    .withPath(fullPath)
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                log.info("received delete request for secret agent {}", agentId);
+                                currentAgentsSecrets.remove(agentId);
+                                return List.of();
+                            })
+                    .always();
+        }
+        return currentAgentsSecrets;
+    }
+
+    public void expectTenantCreated(String tenant) {
+        final String namespace = "langstream-" + tenant;
+
+        server.expect()
+                .patch()
+                .withPath("/api/v1/namespaces/%s?fieldManager=fabric8".formatted(namespace))
+                .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> null)
+                .always();
+
+        server.expect()
+                .get()
+                .withPath("/api/v1/namespaces/%s".formatted(namespace))
+                .andReply(
+                        HttpURLConnection.HTTP_OK,
+                        recordedRequest ->
+                                new NamespaceBuilder()
+                                        .withNewMetadata()
+                                        .withName(namespace)
+                                        .endMetadata()
+                                        .build())
+                .always();
+
+        server.expect()
+                .patch()
+                .withPath(
+                        "/api/v1/namespaces/%s/serviceaccounts/%s?fieldManager=fabric8"
+                                .formatted(namespace, tenant))
+                .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> null)
+                .always();
+        server.expect()
+                .patch()
+                .withPath(
+                        "/apis/rbac.authorization.k8s.io/v1/namespaces/%s/roles/%s?fieldManager=fabric8"
+                                .formatted(namespace, tenant))
+                .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> null)
+                .always();
+
+        server.expect()
+                .patch()
+                .withPath(
+                        "/apis/rbac.authorization.k8s.io/v1/namespaces/%s/rolebindings/%s?fieldManager=fabric8"
+                                .formatted(namespace, tenant))
+                .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> null)
+                .always();
+
+        server.expect()
+                .patch()
+                .withPath(
+                        "/api/v1/namespaces/%s/secrets/langstream-cluster-config?fieldManager=fabric8"
+                                .formatted(namespace))
+                .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> null)
+                .always();
+    }
+
+    public Map<String, ApplicationCustomResource> spyApplicationCustomResources(
+            String namespace, String... applicationIds) {
+        for (String appId : applicationIds) {
+            final String fullPath =
+                    "/apis/langstream.ai/v1alpha1/namespaces/%s/applications/%s"
+                            .formatted(namespace, appId);
+            server.expect()
+                    .patch()
+                    .withPath(fullPath + "?fieldManager=fabric8")
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                try {
+                                    final ByteArrayOutputStream byteArrayOutputStream =
+                                            new ByteArrayOutputStream();
+                                    recordedRequest.getBody().copyTo(byteArrayOutputStream);
+                                    final ObjectMapper mapper =
+                                            new ObjectMapper()
+                                                    .enable(
+                                                            SerializationFeature
+                                                                    .ORDER_MAP_ENTRIES_BY_KEYS);
+                                    final ApplicationCustomResource app =
+                                            mapper.readValue(
+                                                    byteArrayOutputStream.toByteArray(),
+                                                    ApplicationCustomResource.class);
+                                    log.info("received patch request for app {}", appId);
+                                    currentApplications.put(appId, app);
+                                    return app;
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                    .always();
+
+            server.expect()
+                    .patch()
+                    .withPath(
+                            "/api/v1/namespaces/%s/secrets/%s?fieldManager=fabric8"
+                                    .formatted(namespace, appId))
+                    .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> null)
+                    .always();
+
+            server.expect()
+                    .get()
+                    .withPath(fullPath)
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                return currentApplications.get(appId);
+                            })
+                    .always();
+
+            server.expect()
+                    .delete()
+                    .withPath(fullPath)
+                    .andReply(
+                            HttpURLConnection.HTTP_OK,
+                            recordedRequest -> {
+                                log.info("received delete request for app {}", appId);
+                                currentApplications.remove(appId);
+                                return List.of();
+                            })
+                    .always();
+        }
+        return currentApplications;
+    }
+}

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/LocalApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/LocalApplicationRunner.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.tester;
+
+import ai.langstream.api.model.Application;
+import ai.langstream.api.runtime.ClusterRuntimeRegistry;
+import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.deployer.k8s.agents.AgentResourcesFactory;
+import ai.langstream.impl.deploy.ApplicationDeployer;
+import ai.langstream.impl.parser.ModelBuilder;
+import ai.langstream.runtime.agent.AgentRunner;
+import ai.langstream.runtime.agent.api.AgentInfo;
+import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
+import io.fabric8.kubernetes.api.model.Secret;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LocalApplicationRunner implements AutoCloseable {
+
+    final KubeTestServer kubeServer = new KubeTestServer();
+    final ApplicationDeployer applicationDeployer;
+
+    final Path agentsDirectory;
+    final Path instanceFile;
+    final Path secretsfile;
+
+    final AtomicBoolean continueLoop = new AtomicBoolean(true);
+
+    final CountDownLatch exited = new CountDownLatch(1);
+
+    public LocalApplicationRunner(Path agentsDirectory, Path instanceFile, Path secretsfile) {
+        this.agentsDirectory = agentsDirectory;
+        this.instanceFile = instanceFile;
+        this.secretsfile = secretsfile;
+        this.applicationDeployer =
+                ApplicationDeployer.builder()
+                        .registry(new ClusterRuntimeRegistry())
+                        .pluginsRegistry(new PluginsRegistry())
+                        .build();
+    }
+
+    protected record ApplicationRuntime(
+            String tenant,
+            String applicationId,
+            Application applicationInstance,
+            ExecutionPlan implementation,
+            Map<String, Secret> secrets,
+            ApplicationDeployer applicationDeployer)
+            implements AutoCloseable {
+
+        public <T> T getGlobal(String key) {
+            return (T) implementation.getApplication().getInstance().globals().get(key);
+        }
+
+        public void close() {
+            applicationDeployer.delete(tenant, implementation, null);
+        }
+    }
+
+    public ApplicationRuntime deployApplicationWithSecrets(
+            String tenant,
+            String appId,
+            Map<String, String> application,
+            String instance,
+            String secretsContents,
+            String... expectedAgents)
+            throws Exception {
+
+        kubeServer.spyAgentCustomResources(tenant, expectedAgents);
+        final Map<String, Secret> secrets =
+                kubeServer.spyAgentCustomResourcesSecrets(tenant, expectedAgents);
+
+        Application applicationInstance =
+                ModelBuilder.buildApplicationInstance(application, instance, secretsContents)
+                        .getApplication();
+
+        ExecutionPlan implementation =
+                applicationDeployer.createImplementation(appId, applicationInstance);
+
+        applicationDeployer.deploy(tenant, implementation, null);
+
+        return new ApplicationRuntime(
+                tenant, appId, applicationInstance, implementation, secrets, applicationDeployer);
+    }
+
+    public record AgentRunResult(Map<String, AgentInfo> info) {}
+
+    protected AgentRunResult executeAgentRunners(ApplicationRuntime runtime) throws Exception {
+        String runnerExecutionId = UUID.randomUUID().toString();
+        log.info(
+                "{} Starting Agent Runners. Running {} pods",
+                runnerExecutionId,
+                runtime.secrets.size());
+        Map<String, AgentInfo> allAgentsInfo = new ConcurrentHashMap<>();
+        try {
+            List<RuntimePodConfiguration> pods = new ArrayList<>();
+            runtime.secrets()
+                    .forEach(
+                            (key, secret) -> {
+                                RuntimePodConfiguration runtimePodConfiguration =
+                                        AgentResourcesFactory.readRuntimePodConfigurationFromSecret(
+                                                secret);
+                                log.info(
+                                        "{} Pod configuration {} = {}",
+                                        runnerExecutionId,
+                                        key,
+                                        runtimePodConfiguration);
+                                pods.add(runtimePodConfiguration);
+                            });
+            // execute all the pods
+            ExecutorService executorService = Executors.newCachedThreadPool();
+            List<CompletableFuture> futures = new ArrayList<>();
+            for (RuntimePodConfiguration podConfiguration : pods) {
+                CompletableFuture<?> handle = new CompletableFuture<>();
+                futures.add(handle);
+                executorService.submit(
+                        () -> {
+                            String originalName = Thread.currentThread().getName();
+                            Thread.currentThread()
+                                    .setName(
+                                            podConfiguration.agent().agentId()
+                                                    + "runner-tid-"
+                                                    + runnerExecutionId);
+                            try {
+                                log.info(
+                                        "{} AgentPod {} Started",
+                                        runnerExecutionId,
+                                        podConfiguration.agent().agentId());
+                                AgentInfo agentInfo = new AgentInfo();
+                                allAgentsInfo.put(podConfiguration.agent().agentId(), agentInfo);
+                                AtomicInteger numLoops = new AtomicInteger();
+                                AgentRunner.runAgent(
+                                        podConfiguration,
+                                        null,
+                                        null,
+                                        agentsDirectory,
+                                        agentInfo,
+                                        continueLoop::get,
+                                        () -> {},
+                                        false);
+                                List<?> infos = agentInfo.serveWorkerStatus();
+                                log.info(
+                                        "{} AgentPod {} AgentInfo {}",
+                                        runnerExecutionId,
+                                        podConfiguration.agent().agentId(),
+                                        infos);
+                                handle.complete(null);
+                            } catch (Throwable error) {
+                                log.error(
+                                        "{} Error on AgentPod {}",
+                                        runnerExecutionId,
+                                        podConfiguration.agent().agentId(),
+                                        error);
+                                handle.completeExceptionally(error);
+                            } finally {
+                                log.info(
+                                        "{} AgentPod {} finished",
+                                        runnerExecutionId,
+                                        podConfiguration.agent().agentId());
+                                Thread.currentThread().setName(originalName);
+                            }
+                        });
+            }
+            try {
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+            } catch (ExecutionException executionException) {
+                log.error(
+                        "Some error occurred while executing the agent",
+                        executionException.getCause());
+                // unwrap the exception in order to easily perform assertions
+                if (executionException.getCause() instanceof Exception) {
+                    throw (Exception) executionException.getCause();
+                } else {
+                    throw executionException;
+                }
+            }
+            executorService.shutdown();
+            executorService.awaitTermination(1, TimeUnit.MINUTES);
+        } finally {
+            log.info("{} Agent Runners Stopped", runnerExecutionId);
+            exited.countDown();
+        }
+        return new AgentRunResult(allAgentsInfo);
+    }
+
+    public void close() throws Exception {
+        continueLoop.set(false);
+
+        exited.await(1, TimeUnit.MINUTES);
+
+        if (applicationDeployer != null) {
+            // this closes the kubernetes client
+            applicationDeployer.close();
+        }
+    }
+}

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.tester;
+
+import ai.langstream.impl.parser.ModelBuilder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Main {
+    public static void main(String... args) {
+        try {
+            String applicationPath = "/code/application";
+            String instanceFile = "/code/instance.yaml";
+            String secretsFile = "/code/secrets.yaml";
+            String agentsDirectory = "/app/agents";
+
+            String tenant = "tenant";
+
+            String secrets = Files.readString(Paths.get(secretsFile));
+            String instance = Files.readString(Paths.get(instanceFile));
+
+            List<Path> applicationDirectories = List.of(Paths.get(applicationPath));
+            ModelBuilder.ApplicationWithPackageInfo applicationWithPackageInfo =
+                    ModelBuilder.buildApplicationInstance(
+                            applicationDirectories, instance, secrets);
+
+            String applicationId = "app";
+
+            List<String> expectedAgents = new ArrayList<>();
+            applicationWithPackageInfo
+                    .getApplication()
+                    .getModules()
+                    .values()
+                    .forEach(
+                            module -> {
+                                module.getPipelines()
+                                        .values()
+                                        .forEach(
+                                                p -> {
+                                                    p.getAgents()
+                                                            .forEach(
+                                                                    agentConfiguration -> {
+                                                                        expectedAgents.add(
+                                                                                applicationId
+                                                                                        + "-"
+                                                                                        + agentConfiguration
+                                                                                                .getId());
+                                                                    });
+                                                });
+                            });
+            log.info("expectedAgents {}", expectedAgents);
+
+            try (LocalApplicationRunner runner =
+                    new LocalApplicationRunner(Paths.get(agentsDirectory)); ) {
+
+                runner.start();
+                try (LocalApplicationRunner.ApplicationRuntime applicationRuntime =
+                        runner.deployApplicationWithSecrets(
+                                tenant,
+                                applicationId,
+                                applicationWithPackageInfo,
+                                expectedAgents.toArray(new String[0]))) {
+
+                    Runtime.getRuntime()
+                            .addShutdownHook(
+                                    new Thread(
+                                            () -> {
+                                                log.info("Shutdown hook");
+                                                runner.close();
+                                            }));
+
+                    runner.executeAgentRunners(applicationRuntime);
+                }
+            }
+        } catch (Throwable error) {
+            error.printStackTrace();
+        }
+    }
+}

--- a/langstream-runtime/pom.xml
+++ b/langstream-runtime/pom.xml
@@ -29,5 +29,6 @@
   <modules>
     <module>langstream-runtime-api</module>
     <module>langstream-runtime-impl</module>
+    <module>langstream-runtime-tester</module>
   </modules>
 </project>


### PR DESCRIPTION
Goals:
allow users to quickly iterate over the configurations without needing to deploy the application to a kubernetes cluster

Summary:
- new docker image langstream-runtime-tester that allows you to run a single LangStream application on the local enviroment, on a single docker container

How to run the tool:

`bin/langstream docker run -app /path/to/app -i /path/to/instance -s /path/to-secrets --start-broker=true|false --start-s3=true|false`

it is the same command as "apps deploy" but you use "local-run" instead of "deploy".
As the environment is ephemeral you must always pass the instance.yaml and the secrets.yaml files

By default we also start Kafka and Minio, you can control them by using --start-broker and --start-s3


Limitations of the "local mode":
- this is not for production, only for quick iterations
- all the pipelines and agents executors run in the same Java process
- no parallelism
- you always have to pass the "secrets" and the "instance file"
- the system is almost stateless, each time you run you deploy the application from scratch
