### PR TITLE
Ensure existing agents are not affected by deployer config changes

### DIFF
--- a/helm/crds/agents.langstream.ai-v1.yml
+++ b/helm/crds/agents.langstream.ai-v1.yml
@@ -45,6 +45,8 @@ spec:
             type: object
           status:
             properties:
+              lastConfigApplied:
+                type: string
               status:
                 properties:
                   status:

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/agents/AgentStatus.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/agents/AgentStatus.java
@@ -17,7 +17,6 @@ package ai.langstream.deployer.k8s.api.crds.agents;
 
 import ai.langstream.api.model.AgentLifecycleStatus;
 import ai.langstream.deployer.k8s.api.crds.BaseStatus;
-import java.util.Map;
 import lombok.Data;
 
 @Data

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/agents/AgentStatus.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/agents/AgentStatus.java
@@ -17,9 +17,11 @@ package ai.langstream.deployer.k8s.api.crds.agents;
 
 import ai.langstream.api.model.AgentLifecycleStatus;
 import ai.langstream.deployer.k8s.api.crds.BaseStatus;
+import java.util.Map;
 import lombok.Data;
 
 @Data
 public class AgentStatus extends BaseStatus {
     private AgentLifecycleStatus status;
+    private String lastConfigApplied;
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/ResolvedDeployerConfiguration.java
@@ -16,6 +16,7 @@
 package ai.langstream.deployer.k8s;
 
 import ai.langstream.deployer.k8s.agents.AgentResourceUnitConfiguration;
+import ai.langstream.deployer.k8s.util.SerializationUtil;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,8 +27,10 @@ import jakarta.inject.Singleton;
 import java.util.Map;
 import lombok.Getter;
 import lombok.SneakyThrows;
+import lombok.extern.jbosslog.JBossLog;
 
 @Singleton
+@JBossLog
 public class ResolvedDeployerConfiguration {
 
     private static final ObjectMapper yamlMapper =
@@ -65,6 +68,7 @@ public class ResolvedDeployerConfiguration {
         this.globalStorageConfiguration =
                 yamlMapper.readValue(
                         configuration.globalStorage(), GlobalStorageConfiguration.class);
+        log.infof("Deployer configuration: %s", SerializationUtil.writeAsJson(this));
     }
 
     @Getter private Map<String, Object> clusterRuntime;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/BaseController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/BaseController.java
@@ -76,7 +76,7 @@ public abstract class BaseController<T extends CustomResource<?, ? extends BaseS
             lastApplied = SerializationUtil.writeAsJson(resource.getSpec());
             baseStatus.setLastApplied(lastApplied);
             log.infof(
-                    "Reconcilied application %s, reschedule: %s, status: %s",
+                    "Reconciled application %s, reschedule: %s, status: %s",
                     resource.getMetadata().getName(),
                     String.valueOf(result.getScheduleDelay().isPresent()),
                     resource.getStatus());

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/agents/AgentController.java
@@ -88,6 +88,9 @@ public class AgentController extends BaseController<AgentCustomResource>
     }
 
     private void setLastAppliedConfig(AgentCustomResource agent) {
+        if (agent.getStatus().getLastConfigApplied() != null) {
+            return;
+        }
         final LastAppliedConfigForStatefulset lastAppliedConfigForStatefulset =
                 new LastAppliedConfigForStatefulset(
                         configuration.getAgentResources(),

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
@@ -21,9 +21,7 @@ import ai.langstream.deployer.k8s.api.crds.apps.ApplicationStatus;
 import ai.langstream.deployer.k8s.apps.AppResourcesFactory;
 import ai.langstream.deployer.k8s.controllers.BaseController;
 import ai.langstream.deployer.k8s.controllers.InfiniteRetry;
-import ai.langstream.deployer.k8s.util.JSONComparator;
 import ai.langstream.deployer.k8s.util.KubeUtil;
-import ai.langstream.deployer.k8s.util.SpecDiffer;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -145,19 +143,5 @@ public class AppController extends BaseController<ApplicationCustomResource>
                         .build();
         final Job job = AppResourcesFactory.generateJob(params);
         KubeUtil.patchJob(client, job);
-    }
-
-    protected boolean areSpecChanged(ApplicationCustomResource cr) {
-        final String lastApplied = cr.getStatus().getLastApplied();
-        if (lastApplied == null) {
-            return true;
-        }
-        final JSONComparator.Result diff = SpecDiffer.generateDiff(lastApplied, cr.getSpec());
-        if (!diff.areEquals()) {
-            log.infof("Spec changed for %s", cr.getMetadata().getName());
-            SpecDiffer.logDetailedSpecDiff(diff);
-            return true;
-        }
-        return false;
     }
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AgentControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AgentControllerIT.java
@@ -16,6 +16,7 @@
 package ai.langstream.deployer.k8s.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import ai.langstream.api.model.AgentLifecycleStatus;
 import ai.langstream.api.model.StreamingCluster;
@@ -30,7 +31,10 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.checkerframework.checker.units.qual.K;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -39,41 +43,22 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 @Testcontainers
 public class AgentControllerIT {
 
-    @RegisterExtension static final OperatorExtension deployment = new OperatorExtension();
+    static final Map<String, String> DEPLOYER_CONFIG = new HashMap<>(Map.of(
+            "DEPLOYER_RUNTIME_IMAGE", "busybox",
+            "DEPLOYER_RUNTIME_IMAGE_PULL_POLICY", "IfNotPresent"));
+
+    @RegisterExtension static final OperatorExtension deployment = new OperatorExtension(DEPLOYER_CONFIG);
 
     @Test
     void testAgentController() {
         final KubernetesClient client = deployment.getClient();
         final String namespace = "langstream-my-tenant";
-        client.resource(
-                        new NamespaceBuilder()
-                                .withNewMetadata()
-                                .withName(namespace)
-                                .endMetadata()
-                                .build())
-                .serverSideApply();
+        createNamespace(client, namespace);
 
         final String agentCustomResourceName =
                 AgentResourcesFactory.getAgentCustomResourceName("my-app", "agent-id");
 
-        client.resource(
-                        AgentResourcesFactory.generateAgentSecret(
-                                agentCustomResourceName,
-                                new RuntimePodConfiguration(
-                                        Map.of("input", Map.of("is_input", true)),
-                                        Map.of("output", Map.of("is_output", true)),
-                                        new AgentSpec(
-                                                AgentSpec.ComponentType.PROCESSOR,
-                                                "my-tenant",
-                                                "agent-id",
-                                                "my-app",
-                                                "fn-type",
-                                                Map.of("config", true),
-                                                Map.of()),
-                                        new StreamingCluster("noop", Map.of("config", true)),
-                                        null)))
-                .inNamespace(namespace)
-                .serverSideApply();
+        createAgentSecret(client, agentCustomResourceName, namespace);
 
         final AgentCustomResource resource =
                 getCr(
@@ -83,8 +68,6 @@ public class AgentControllerIT {
                 metadata:
                   name: %s
                 spec:
-                    image: busybox
-                    imagePullPolicy: IfNotPresent
                     applicationId: my-app
                     agentId: agent-id
                     agentConfigSecretRef: %s
@@ -146,4 +129,124 @@ public class AgentControllerIT {
     private AgentCustomResource getCr(String yaml) {
         return SerializationUtil.readYaml(yaml, AgentCustomResource.class);
     }
+
+    @Test
+    void testDoNotUpdateStatefulsetIfDeployerRestarted() throws InterruptedException {
+        final KubernetesClient client = deployment.getClient();
+        final String namespace = "langstream-my-tenant";
+        createNamespace(client, namespace);
+
+        final String agentCustomResourceName =
+                AgentResourcesFactory.getAgentCustomResourceName("my-app", "agent-id");
+
+        createAgentSecret(client, agentCustomResourceName, namespace);
+
+        AgentCustomResource resource =
+                getCr(
+                        """
+                apiVersion: langstream.ai/v1alpha1
+                kind: Agent
+                metadata:
+                  name: %s
+                spec:
+                    image: busybox
+                    imagePullPolicy: IfNotPresent
+                    applicationId: my-app
+                    agentId: agent-id
+                    agentConfigSecretRef: %s
+                    agentConfigSecretRefChecksum: xx
+                    tenant: my-tenant
+                """
+                                .formatted(agentCustomResourceName, agentCustomResourceName));
+
+        client.resource(resource).inNamespace(namespace).create();
+
+        Awaitility.await()
+                .untilAsserted(
+                        () -> {
+                            assertEquals(
+                                    1,
+                                    client.apps()
+                                            .statefulSets()
+                                            .inNamespace(namespace)
+                                            .list()
+                                            .getItems()
+                                            .size());
+                            assertEquals(
+                                    AgentLifecycleStatus.Status.DEPLOYING,
+                                    client.resources(AgentCustomResource.class)
+                                            .inNamespace(namespace)
+                                            .withName(agentCustomResourceName)
+                                            .get()
+                                            .getStatus()
+                                            .getStatus()
+                                            .getStatus());
+                        });
+        resource = client.resource(resource)
+                .inNamespace(namespace)
+                .get();
+        assertNotNull(resource.getStatus().getLastConfigApplied());
+
+         StatefulSet statefulSet =
+                client.apps().statefulSets().inNamespace(namespace).list().getItems().get(0);
+        assertEquals("busybox", statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+
+        DEPLOYER_CONFIG.put("DEPLOYER_RUNTIME_IMAGE", "busybox:v2");
+        deployment.restartDeployerOperator();
+
+        resource = client.resource(resource)
+                .inNamespace(namespace)
+                .get();
+        resource.getSpec().setCodeArchiveId("another");
+        client.resource(resource).inNamespace(namespace).serverSideApply();
+
+        Awaitility.await().atMost(1, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            final String archiveId =
+                                    SerializationUtil.readJson(client.resources(AgentCustomResource.class)
+                                                            .inNamespace(namespace)
+                                                            .withName(agentCustomResourceName)
+                                                            .get()
+                                                            .getStatus()
+                                                            .getLastApplied(),
+                                                    ai.langstream.deployer.k8s.api.crds.agents.AgentSpec.class)
+                                            .getCodeArchiveId();
+                            assertEquals("another", archiveId);
+                        });
+        statefulSet = client.apps().statefulSets().inNamespace(namespace).list().getItems().get(0);
+        assertEquals("busybox", statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+    }
+
+    private void createAgentSecret(KubernetesClient client, String agentCustomResourceName, String namespace) {
+        client.resource(
+                        AgentResourcesFactory.generateAgentSecret(
+                                agentCustomResourceName,
+                                new RuntimePodConfiguration(
+                                        Map.of("input", Map.of("is_input", true)),
+                                        Map.of("output", Map.of("is_output", true)),
+                                        new AgentSpec(
+                                                AgentSpec.ComponentType.PROCESSOR,
+                                                "my-tenant",
+                                                "agent-id",
+                                                "my-app",
+                                                "fn-type",
+                                                Map.of("config", true),
+                                                Map.of()),
+                                        new StreamingCluster("noop", Map.of("config", true)),
+                                        null)))
+                .inNamespace(namespace)
+                .serverSideApply();
+    }
+
+    private void createNamespace(KubernetesClient client, String namespace) {
+        client.resource(
+                        new NamespaceBuilder()
+                                .withNewMetadata()
+                                .withName(namespace)
+                                .endMetadata()
+                                .build())
+                .serverSideApply();
+    }
+
 }

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -330,6 +330,58 @@
       <version>1.7.2</version>
       <scope>test</scope>
     </dependency> -->
+
+
+    <!--    Agents: ensure this module is dependant from agents modules-->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-kafka-runtime</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-pulsar-runtime</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-ai-agents</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agents-text-processing</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agent-s3</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-agent-webcrawler</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-vector-agents</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Currently if the deployer gets upgraded/restarted, the new config is applied to ALL the agents/statefulsets. 
That also means that every time the runtime version gets upgraded in the deployer, all the executors restart with the new runtime version.
There are problems with this policy:
1. All the executors get restarted when a system upgrade is performed. This is very bad for the user experience/performance/stability.
2. The executor should continue running that particular version of that the runtime. An agent change could break existing applications. 


For the point 2, in the future it could implemented a flag "auto-update" to get the new runtime image whenever the *application* is upgraded - not the deployer.


Changes:
* Save current configuration (only the relevant and public part) in the agent custom resource status and apply it if it's an update. If it's the statefulset creation (first deploy) it gets the current deployer configuration 
