### PR TITLE
Internal refactor for Gateway

### DIFF
--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
@@ -124,7 +124,7 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
             throws AuthFailedException {
 
         final Gateway.Authentication authentication =
-                gatewayRequestContext.gateway().authentication();
+                gatewayRequestContext.gateway().getAuthentication();
 
         if (authentication == null) {
             return Map.of();
@@ -135,7 +135,7 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
             if (!authentication.isAllowTestMode()) {
                 throw new AuthFailedException(
                         "Gateway "
-                                + gatewayRequestContext.gateway().id()
+                                + gatewayRequestContext.gateway().getId()
                                 + " of tenant "
                                 + gatewayRequestContext.tenant()
                                 + " does not allow test mode.");

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -174,7 +174,7 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         Gateway selectedGateway = null;
 
         for (Gateway gateway : gateways) {
-            if (gateway.id().equals(gatewayId) && type == gateway.type()) {
+            if (gateway.getId().equals(gatewayId) && type == gateway.getType()) {
                 selectedGateway = gateway;
                 break;
             }
@@ -223,7 +223,7 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         final Gateway.GatewayType type = gatewayType();
         final Gateway gateway = extractGateway(gatewayId, application, type);
 
-        final List<String> requiredParameters = gateway.parameters();
+        final List<String> requiredParameters = gateway.getParameters();
         Set<String> allUserParameterKeys = new HashSet<>(userParameters.keySet());
         if (requiredParameters != null) {
             for (String requiredParameter : requiredParameters) {
@@ -298,7 +298,7 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
     @SneakyThrows
     protected void sendEvent(EventRecord.Types type, AuthenticatedGatewayRequestContext context) {
         final Gateway gateway = context.gateway();
-        if (gateway.eventsTopic() == null) {
+        if (gateway.getEventsTopic() == null) {
             return;
         }
         final StreamingCluster streamingCluster =
@@ -310,7 +310,7 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
                 topicConnectionsRuntime.createProducer(
                         "langstream-events",
                         streamingCluster,
-                        Map.of("topic", gateway.eventsTopic())); ) {
+                        Map.of("topic", gateway.getEventsTopic())); ) {
             producer.start();
 
             final EventSources.GatewaySource source =

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
@@ -99,7 +99,7 @@ public class ConsumeHandler extends AbstractHandler {
         final TopicConnectionsRuntime topicConnectionsRuntime =
                 TOPIC_CONNECTIONS_REGISTRY.getTopicConnectionsRuntime(streamingCluster);
 
-        final String topicName = gateway.topic();
+        final String topicName = gateway.getTopic();
 
         final String positionParameter = context.options().getOrDefault("position", "latest");
         TopicOffsetPosition position =
@@ -128,7 +128,7 @@ public class ConsumeHandler extends AbstractHandler {
                             final Map<String, Object> attributes = session.getAttributes();
                             TopicReader reader = (TopicReader) attributes.get("topicReader");
                             final String tenant = context.tenant();
-                            final String gatewayId = context.gateway().id();
+                            final String gatewayId = context.gateway().getId();
                             final String applicationId = context.applicationId();
                             try {
                                 log.info(
@@ -262,8 +262,8 @@ public class ConsumeHandler extends AbstractHandler {
             Map<String, String> principalValues) {
         List<Function<Record, Boolean>> filters = new ArrayList<>();
 
-        if (selectedGateway.consumeOptions() != null) {
-            final Gateway.ConsumeOptions consumeOptions = selectedGateway.consumeOptions();
+        if (selectedGateway.getConsumeOptions() != null) {
+            final Gateway.ConsumeOptions consumeOptions = selectedGateway.getConsumeOptions();
             if (consumeOptions.filters() != null) {
                 if (consumeOptions.filters().headers() != null) {
                     for (Gateway.KeyValueComparison comparison :

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
@@ -87,7 +87,7 @@ public class ProduceHandler extends AbstractHandler {
         final TopicConnectionsRuntime topicConnectionsRuntime =
                 TOPIC_CONNECTIONS_REGISTRY.getTopicConnectionsRuntime(streamingCluster);
 
-        final String topicName = gateway.topic();
+        final String topicName = gateway.getTopic();
         final TopicProducer producer =
                 topicConnectionsRuntime.createProducer(
                         null, streamingCluster, Map.of("topic", topicName));
@@ -100,7 +100,7 @@ public class ProduceHandler extends AbstractHandler {
                 "Started produced for gateway {}/{}/{} on topic {}",
                 context.tenant(),
                 context.applicationId(),
-                context.gateway().id(),
+                context.gateway().getId(),
                 topicName);
         sendClientConnectedEvent(context);
     }
@@ -212,10 +212,10 @@ public class ProduceHandler extends AbstractHandler {
             Map<String, String> passedParameters,
             Map<String, String> principalValues) {
         final List<Header> headers = new ArrayList<>();
-        if (selectedGateway.produceOptions() != null
-                && selectedGateway.produceOptions().headers() != null) {
+        if (selectedGateway.getProduceOptions() != null
+                && selectedGateway.getProduceOptions().headers() != null) {
             final List<Gateway.KeyValueComparison> headersConfig =
-                    selectedGateway.produceOptions().headers();
+                    selectedGateway.getProduceOptions().headers();
             for (Gateway.KeyValueComparison mapping : headersConfig) {
                 if (mapping.key() == null || mapping.key().isEmpty()) {
                     throw new IllegalArgumentException("Header key cannot be empty");

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
@@ -83,7 +83,7 @@ import org.springframework.context.annotation.Primary;
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {
-                "spring.main.allow-bean-definition-overriding=true",
+            "spring.main.allow-bean-definition-overriding=true",
         })
 @WireMockTest
 class ProduceConsumeHandlerTest {
@@ -104,12 +104,12 @@ class ProduceConsumeHandlerTest {
         public ApplicationStore store() {
             final ApplicationStore mock = Mockito.mock(ApplicationStore.class);
             doAnswer(
-                    invocationOnMock -> {
-                        final StoredApplication storedApplication = new StoredApplication();
-                        final Application application = buildApp();
-                        storedApplication.setInstance(application);
-                        return storedApplication;
-                    })
+                            invocationOnMock -> {
+                                final StoredApplication storedApplication = new StoredApplication();
+                                final Application application = buildApp();
+                                storedApplication.setInstance(application);
+                                return storedApplication;
+                            })
                     .when(mock)
                     .get(anyString(), anyString(), anyBoolean());
             doAnswer(invocationOnMock -> ApplicationSpecs.builder().application(buildApp()).build())
@@ -179,11 +179,9 @@ class ProduceConsumeHandlerTest {
         return application;
     }
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
-    @Autowired
-    ApplicationStore store;
+    @Autowired ApplicationStore store;
 
     static WireMock wireMock;
     static String wireMockBaseUrl;
@@ -227,34 +225,34 @@ class ProduceConsumeHandlerTest {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         List<String> messages = new ArrayList<>();
         try (final TestWebSocketClient ignored =
-                     new TestWebSocketClient(
-                             new TestWebSocketClient.Handler() {
-                                 @Override
-                                 public void onMessage(String msg) {
-                                     messages.add(msg);
-                                     countDownLatch.countDown();
-                                 }
+                new TestWebSocketClient(
+                                new TestWebSocketClient.Handler() {
+                                    @Override
+                                    public void onMessage(String msg) {
+                                        messages.add(msg);
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onClose(CloseReason closeReason) {
-                                     countDownLatch.countDown();
-                                 }
+                                    @Override
+                                    public void onClose(CloseReason closeReason) {
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onError(Throwable throwable) {
-                                     countDownLatch.countDown();
-                                 }
-                             })
-                             .connect(
-                                     URI.create(
-                                             "ws://localhost:%d/v1/consume/tenant1/application1/consume"
-                                                     .formatted(port)))) {
+                                    @Override
+                                    public void onError(Throwable throwable) {
+                                        countDownLatch.countDown();
+                                    }
+                                })
+                        .connect(
+                                URI.create(
+                                        "ws://localhost:%d/v1/consume/tenant1/application1/consume"
+                                                .formatted(port)))) {
             try (final TestWebSocketClient producer =
-                         new TestWebSocketClient(TestWebSocketClient.NOOP)
-                                 .connect(
-                                         URI.create(
-                                                 "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                                         .formatted(port)))) {
+                    new TestWebSocketClient(TestWebSocketClient.NOOP)
+                            .connect(
+                                    URI.create(
+                                            "ws://localhost:%d/v1/produce/tenant1/application1/produce"
+                                                    .formatted(port)))) {
                 final ProduceRequest produceRequest =
                         new ProduceRequest(null, "this is a message", null);
                 produce(produceRequest, producer);
@@ -302,7 +300,8 @@ class ProduceConsumeHandlerTest {
                                         .id("gw")
                                         .type(Gateway.GatewayType.valueOf(type))
                                         .topic(topic)
-                                        .parameters(List.of("session-id")).build()));
+                                        .parameters(List.of("session-id"))
+                                        .build()));
         connectAndExpectClose(
                 URI.create("ws://localhost:%d/v1/%s/tenant1/application1/gw".formatted(port, type)),
                 new CloseReason(
@@ -326,7 +325,7 @@ class ProduceConsumeHandlerTest {
         connectAndExpectClose(
                 URI.create(
                         ("ws://localhost:%d/v1/%s/tenant1/application1/gw?param:session-id=ok&param:another-non"
-                         + "-declared=y")
+                                        + "-declared=y")
                                 .formatted(port, type)),
                 new CloseReason(
                         CloseReason.CloseCodes.VIOLATED_POLICY,
@@ -354,43 +353,45 @@ class ProduceConsumeHandlerTest {
                                         .type(Gateway.GatewayType.produce)
                                         .topic(topic)
                                         .parameters(List.of("session-id"))
-                                        .produceOptions(new Gateway.ProduceOptions(
-                                                List.of(
-                                                        Gateway.KeyValueComparison.value(
-                                                                "header1", "langstream"))))
+                                        .produceOptions(
+                                                new Gateway.ProduceOptions(
+                                                        List.of(
+                                                                Gateway.KeyValueComparison.value(
+                                                                        "header1", "langstream"))))
                                         .build(),
                                 Gateway.builder()
                                         .id("produce-non-langstream")
                                         .type(Gateway.GatewayType.produce)
                                         .topic(topic)
                                         .parameters(List.of("session-id"))
-                                        .build()
-                                ,
+                                        .build(),
                                 Gateway.builder()
                                         .id("consume")
                                         .type(Gateway.GatewayType.consume)
                                         .topic(topic)
                                         .parameters(List.of("session-id"))
-                                        .consumeOptions(new Gateway.ConsumeOptions(
-                                                new Gateway.ConsumeOptionsFilters(
-                                                        List.of(
-                                                                Gateway.KeyValueComparison.value(
-                                                                        "header1",
-                                                                        "langstream")))))
-                                        .build()
-                        )
-                );
+                                        .consumeOptions(
+                                                new Gateway.ConsumeOptions(
+                                                        new Gateway.ConsumeOptionsFilters(
+                                                                List.of(
+                                                                        Gateway.KeyValueComparison
+                                                                                .value(
+                                                                                        "header1",
+                                                                                        "langstream")))))
+                                        .build()));
 
         List<String> user1Messages = new ArrayList<>();
         List<String> user2Messages = new ArrayList<>();
 
-        @Cleanup final ClientSession client1 =
+        @Cleanup
+        final ClientSession client1 =
                 connectAndCollectMessages(
                         URI.create(
                                 "ws://localhost:%d/v1/consume/tenant1/application1/consume?param:session-id=user1"
                                         .formatted(port)),
                         user1Messages);
-        @Cleanup final ClientSession client2 =
+        @Cleanup
+        final ClientSession client2 =
                 connectAndCollectMessages(
                         URI.create(
                                 "ws://localhost:%d/v1/consume/tenant1/application1/consume?param:session-id=user2"
@@ -398,25 +399,25 @@ class ProduceConsumeHandlerTest {
                         user2Messages);
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             ("ws://localhost:%d/v1/produce/tenant1/application1/produce-non"
-                                              + "-langstream?param:session-id"
-                                              + "=user1")
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        ("ws://localhost:%d/v1/produce/tenant1/application1/produce-non"
+                                                        + "-langstream?param:session-id"
+                                                        + "=user1")
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest =
                     new ProduceRequest(null, "this is a message non from langstream", null);
             produce(produceRequest, producer);
         }
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
-                                              + "-id=user1")
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
+                                                        + "-id=user1")
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest =
                     new ProduceRequest(null, "this is a message for everyone", null);
             produce(produceRequest, producer);
@@ -513,18 +514,20 @@ class ProduceConsumeHandlerTest {
         List<String> user1Messages = new ArrayList<>();
         List<String> user2Messages = new ArrayList<>();
 
-        @Cleanup final ClientSession client1 =
+        @Cleanup
+        final ClientSession client1 =
                 connectAndCollectMessages(
                         URI.create(
                                 ("ws://localhost:%d/v1/consume/tenant1/application1/consume?credentials=test-user"
-                                 + "-password&option:position=earliest")
+                                                + "-password&option:position=earliest")
                                         .formatted(port)),
                         user1Messages);
-        @Cleanup final ClientSession client2 =
+        @Cleanup
+        final ClientSession client2 =
                 connectAndCollectMessages(
                         URI.create(
                                 ("ws://localhost:%d/v1/consume/tenant1/application1/consume?credentials=test-user"
-                                 + "-password-2&option:position=earliest")
+                                                + "-password-2&option:position=earliest")
                                         .formatted(port)),
                         user2Messages);
 
@@ -566,35 +569,48 @@ class ProduceConsumeHandlerTest {
                                         .id("produce")
                                         .type(Gateway.GatewayType.produce)
                                         .topic(topic)
-                                        .authentication(new Gateway.Authentication("test-auth", Map.of(), true))
-                                        .produceOptions(new Gateway.ProduceOptions(List.of(
-                                                Gateway.KeyValueComparison
-                                                        .valueFromAuthentication(
-                                                                "header1", "login"))))
+                                        .authentication(
+                                                new Gateway.Authentication(
+                                                        "test-auth", Map.of(), true))
+                                        .produceOptions(
+                                                new Gateway.ProduceOptions(
+                                                        List.of(
+                                                                Gateway.KeyValueComparison
+                                                                        .valueFromAuthentication(
+                                                                                "header1",
+                                                                                "login"))))
                                         .build(),
                                 Gateway.builder()
                                         .id("consume")
                                         .type(Gateway.GatewayType.consume)
                                         .topic(topic)
-                                        .authentication(new Gateway.Authentication("test-auth", Map.of(), true))
-                                        .consumeOptions(new Gateway.ConsumeOptions(
-                                                new Gateway.ConsumeOptionsFilters(List.of(
-                                                        Gateway.KeyValueComparison
-                                                                .valueFromAuthentication(
-                                                                        "header1", "login")))))
+                                        .authentication(
+                                                new Gateway.Authentication(
+                                                        "test-auth", Map.of(), true))
+                                        .consumeOptions(
+                                                new Gateway.ConsumeOptions(
+                                                        new Gateway.ConsumeOptionsFilters(
+                                                                List.of(
+                                                                        Gateway.KeyValueComparison
+                                                                                .valueFromAuthentication(
+                                                                                        "header1",
+                                                                                        "login")))))
                                         .build(),
                                 Gateway.builder()
                                         .id("consume-no-test")
                                         .type(Gateway.GatewayType.consume)
                                         .topic(topic)
-                                        .authentication(new Gateway.Authentication("test-auth", Map.of(), false))
+                                        .authentication(
+                                                new Gateway.Authentication(
+                                                        "test-auth", Map.of(), false))
                                         .build()));
 
-        @Cleanup final ClientSession client1 =
+        @Cleanup
+        final ClientSession client1 =
                 connectAndCollectMessages(
                         URI.create(
                                 ("ws://localhost:%d/v1/consume/tenant1/application1/consume?test-credentials=test-user"
-                                 + "-password")
+                                                + "-password")
                                         .formatted(port)),
                         user1Messages);
 
@@ -620,7 +636,7 @@ class ProduceConsumeHandlerTest {
         connectAndExpectClose(
                 URI.create(
                         ("ws://localhost:%d/v1/consume/tenant1/application1/consume-no-admin?test-credentials=test"
-                         + "-user-password")
+                                        + "-user-password")
                                 .formatted(port)),
                 new CloseReason(
                         CloseReason.CloseCodes.VIOLATED_POLICY,
@@ -629,13 +645,12 @@ class ProduceConsumeHandlerTest {
         connectAndExpectClose(
                 URI.create(
                         ("ws://localhost:%d/v1/produce/tenant1/application1/produce?test-credentials=test-user"
-                         + "-password-but-wrong")
+                                        + "-password-but-wrong")
                                 .formatted(port)),
                 new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "Invalid credentials"));
     }
 
-    private record MsgRecord(Object key, Object value, Map<String, String> headers) {
-    }
+    private record MsgRecord(Object key, Object value, Map<String, String> headers) {}
 
     private void assertMessagesContent(List<MsgRecord> expected, List<String> actual) {
         assertEquals(
@@ -675,34 +690,42 @@ class ProduceConsumeHandlerTest {
                                         .type(Gateway.GatewayType.produce)
                                         .topic(topic)
                                         .parameters(List.of("session-id"))
-                                        .produceOptions(new Gateway.ProduceOptions(List.of(
-                                                Gateway.KeyValueComparison
-                                                        .valueFromParameters(
-                                                                "header1", "session-id"))))
+                                        .produceOptions(
+                                                new Gateway.ProduceOptions(
+                                                        List.of(
+                                                                Gateway.KeyValueComparison
+                                                                        .valueFromParameters(
+                                                                                "header1",
+                                                                                "session-id"))))
                                         .build(),
                                 Gateway.builder()
                                         .id("consume")
                                         .type(Gateway.GatewayType.consume)
                                         .topic(topic)
                                         .parameters(List.of("session-id"))
-                                        .consumeOptions(new Gateway.ConsumeOptions(
-                                                new Gateway.ConsumeOptionsFilters(List.of(
-                                                        Gateway.KeyValueComparison
-                                                                .valueFromParameters(
-                                                                        "header1", "session-id")))))
+                                        .consumeOptions(
+                                                new Gateway.ConsumeOptions(
+                                                        new Gateway.ConsumeOptionsFilters(
+                                                                List.of(
+                                                                        Gateway.KeyValueComparison
+                                                                                .valueFromParameters(
+                                                                                        "header1",
+                                                                                        "session-id")))))
                                         .build()));
 
         List<String> user1Messages = new ArrayList<>();
         List<String> user2Messages = new ArrayList<>();
 
-        @Cleanup final ClientSession client1 =
+        @Cleanup
+        final ClientSession client1 =
                 connectAndCollectMessages(
                         URI.create(
                                 ("ws://localhost:%d/v1/consume/tenant1/application1/consume?param:session-id=user1"
-                                 + "&option:position=earliest")
+                                                + "&option:position=earliest")
                                         .formatted(port)),
                         user1Messages);
-        @Cleanup final ClientSession client2 =
+        @Cleanup
+        final ClientSession client2 =
                 connectAndCollectMessages(
                         URI.create(
                                 "ws://localhost:%d/v1/consume/tenant1/application1/consume?param:session-id=user2"
@@ -710,12 +733,12 @@ class ProduceConsumeHandlerTest {
                         user2Messages);
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
-                                              + "-id=user1")
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
+                                                        + "-id=user1")
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest =
                     new ProduceRequest(null, "this is a message for user1", null);
             produce(produceRequest, producer);
@@ -735,12 +758,12 @@ class ProduceConsumeHandlerTest {
         assertEquals(List.of(), user2Messages);
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
-                                              + "-id=user1")
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
+                                                        + "-id=user1")
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest =
                     new ProduceRequest(null, "this is a message for user1, again", null);
             produce(produceRequest, producer);
@@ -762,12 +785,12 @@ class ProduceConsumeHandlerTest {
         assertEquals(List.of(), user2Messages);
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
-                                              + "-id=user2")
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:session"
+                                                        + "-id=user2")
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest =
                     new ProduceRequest(null, "this is a message for user2", null);
             produce(produceRequest, producer);
@@ -813,10 +836,13 @@ class ProduceConsumeHandlerTest {
                                         .type(Gateway.GatewayType.produce)
                                         .topic(topic)
                                         .parameters(List.of("session-id"))
-                                        .produceOptions(new Gateway.ProduceOptions(List.of(
-                                                Gateway.KeyValueComparison
-                                                        .valueFromParameters(
-                                                                "header1", "session-id"))))
+                                        .produceOptions(
+                                                new Gateway.ProduceOptions(
+                                                        List.of(
+                                                                Gateway.KeyValueComparison
+                                                                        .valueFromParameters(
+                                                                                "header1",
+                                                                                "session-id"))))
                                         .build()));
         ProduceResponse response =
                 connectAndProduce(
@@ -858,8 +884,8 @@ class ProduceConsumeHandlerTest {
         assertEquals(ProduceResponse.Status.BAD_REQUEST, response.status());
         assertEquals(
                 "Unrecognized token 'invalid': was expecting (JSON String, Number, Array, Object or token "
-                + "'null', 'true' or 'false')\n"
-                + " at [Source: (String)\"invalid-json\"; line: 1, column: 8]",
+                        + "'null', 'true' or 'false')\n"
+                        + " at [Source: (String)\"invalid-json\"; line: 1, column: 8]",
                 response.reason());
     }
 
@@ -883,7 +909,8 @@ class ProduceConsumeHandlerTest {
 
         List<String> messages = new ArrayList<>();
 
-        @Cleanup final ClientSession client1 =
+        @Cleanup
+        final ClientSession client1 =
                 connectAndCollectMessages(
                         URI.create(
                                 "ws://localhost:%d/v1/consume/tenant1/application1/consume"
@@ -891,11 +918,11 @@ class ProduceConsumeHandlerTest {
                         messages);
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        "ws://localhost:%d/v1/produce/tenant1/application1/produce"
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest = new ProduceRequest(null, "msg1", null);
             produce(produceRequest, producer);
         }
@@ -909,17 +936,18 @@ class ProduceConsumeHandlerTest {
                 MAPPER.readValue(messages.get(0), ConsumePushMessage.class).offset();
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        "ws://localhost:%d/v1/produce/tenant1/application1/produce"
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest = new ProduceRequest(null, "msg2", null);
             produce(produceRequest, producer);
         }
 
         List<String> messagesFromOffset = new ArrayList<>();
-        @Cleanup final ClientSession client1Offset =
+        @Cleanup
+        final ClientSession client1Offset =
                 connectAndCollectMessages(
                         URI.create(
                                 "ws://localhost:%d/v1/consume/tenant1/application1/consume?option:position=%s"
@@ -934,7 +962,8 @@ class ProduceConsumeHandlerTest {
                                         messagesFromOffset));
 
         List<String> messagesFromEarliest = new ArrayList<>();
-        @Cleanup final ClientSession clientFromEarliest =
+        @Cleanup
+        final ClientSession clientFromEarliest =
                 connectAndCollectMessages(
                         URI.create(
                                 "ws://localhost:%d/v1/consume/tenant1/application1/consume?option:position=earliest"
@@ -951,7 +980,8 @@ class ProduceConsumeHandlerTest {
                                         messagesFromEarliest));
 
         List<String> messagesFromLatest = new ArrayList<>();
-        @Cleanup final ClientSession clientFromLatest =
+        @Cleanup
+        final ClientSession clientFromLatest =
                 connectAndCollectMessages(
                         URI.create(
                                 "ws://localhost:%d/v1/consume/tenant1/application1/consume?option:position=latest"
@@ -959,11 +989,11 @@ class ProduceConsumeHandlerTest {
                         messagesFromLatest);
 
         try (final TestWebSocketClient producer =
-                     new TestWebSocketClient(TestWebSocketClient.NOOP)
-                             .connect(
-                                     URI.create(
-                                             "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                                     .formatted(port)))) {
+                new TestWebSocketClient(TestWebSocketClient.NOOP)
+                        .connect(
+                                URI.create(
+                                        "ws://localhost:%d/v1/produce/tenant1/application1/produce"
+                                                .formatted(port)))) {
             final ProduceRequest produceRequest = new ProduceRequest(null, "msg3", null);
             produce(produceRequest, producer);
         }
@@ -1038,11 +1068,11 @@ class ProduceConsumeHandlerTest {
         try {
 
             try (final TestWebSocketClient producer =
-                         new TestWebSocketClient(TestWebSocketClient.NOOP)
-                                 .connect(
-                                         URI.create(
-                                                 "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                                         .formatted(port)))) {
+                    new TestWebSocketClient(TestWebSocketClient.NOOP)
+                            .connect(
+                                    URI.create(
+                                            "ws://localhost:%d/v1/produce/tenant1/application1/produce"
+                                                    .formatted(port)))) {
                 final ProduceRequest produceRequest = new ProduceRequest(null, "msg1", null);
                 produce(produceRequest, producer);
             }
@@ -1057,11 +1087,11 @@ class ProduceConsumeHandlerTest {
             }
 
             try (final TestWebSocketClient producer =
-                         new TestWebSocketClient(TestWebSocketClient.NOOP)
-                                 .connect(
-                                         URI.create(
-                                                 "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                                         .formatted(port)))) {
+                    new TestWebSocketClient(TestWebSocketClient.NOOP)
+                            .connect(
+                                    URI.create(
+                                            "ws://localhost:%d/v1/produce/tenant1/application1/produce"
+                                                    .formatted(port)))) {
                 final ProduceRequest produceRequest = new ProduceRequest(null, "msg2", null);
                 produce(produceRequest, producer);
             }
@@ -1095,26 +1125,26 @@ class ProduceConsumeHandlerTest {
 
         AtomicReference<CloseReason> closeReason = new AtomicReference<>();
         try (final TestWebSocketClient client =
-                     new TestWebSocketClient(
-                             new TestWebSocketClient.Handler() {
-                                 @Override
-                                 public void onMessage(String msg) {
-                                     fail("should not receive a message");
-                                     countDownLatch.countDown();
-                                 }
+                new TestWebSocketClient(
+                                new TestWebSocketClient.Handler() {
+                                    @Override
+                                    public void onMessage(String msg) {
+                                        fail("should not receive a message");
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onClose(CloseReason cr) {
-                                     closeReason.set(cr);
-                                     countDownLatch.countDown();
-                                 }
+                                    @Override
+                                    public void onClose(CloseReason cr) {
+                                        closeReason.set(cr);
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onError(Throwable throwable) {
-                                     throw new RuntimeException(throwable);
-                                 }
-                             })
-                             .connect(connectTo)) {
+                                    @Override
+                                    public void onError(Throwable throwable) {
+                                        throw new RuntimeException(throwable);
+                                    }
+                                })
+                        .connect(connectTo)) {
             Thread.sleep(5000);
             countDownLatch.await();
             assertEquals(
@@ -1131,25 +1161,24 @@ class ProduceConsumeHandlerTest {
 
         AtomicReference<CloseReason> closeReason = new AtomicReference<>();
         try (final TestWebSocketClient client =
-                     new TestWebSocketClient(
-                             new TestWebSocketClient.Handler() {
-                                 @Override
-                                 public void onOpen(Session session) {
-                                     TestWebSocketClient.Handler.super.onOpen(session);
-                                     countDownLatch.countDown();
-                                 }
+                new TestWebSocketClient(
+                                new TestWebSocketClient.Handler() {
+                                    @Override
+                                    public void onOpen(Session session) {
+                                        TestWebSocketClient.Handler.super.onOpen(session);
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onMessage(String msg) {
-                                 }
+                                    @Override
+                                    public void onMessage(String msg) {}
 
-                                 @Override
-                                 public void onClose(CloseReason cr) {
-                                     closeReason.set(cr);
-                                     countDownLatch.countDown();
-                                 }
-                             })
-                             .connect(connectTo)) {
+                                    @Override
+                                    public void onClose(CloseReason cr) {
+                                        closeReason.set(cr);
+                                        countDownLatch.countDown();
+                                    }
+                                })
+                        .connect(connectTo)) {
             client.send("message");
             countDownLatch.await();
             assertNull(closeReason.get());
@@ -1168,29 +1197,29 @@ class ProduceConsumeHandlerTest {
 
         AtomicReference<CloseReason> closeReason = new AtomicReference<>();
         try (final TestWebSocketClient client =
-                     new TestWebSocketClient(
-                             new TestWebSocketClient.Handler() {
-                                 @Override
-                                 public void onOpen(Session session) {
-                                     TestWebSocketClient.Handler.super.onOpen(session);
-                                 }
+                new TestWebSocketClient(
+                                new TestWebSocketClient.Handler() {
+                                    @Override
+                                    public void onOpen(Session session) {
+                                        TestWebSocketClient.Handler.super.onOpen(session);
+                                    }
 
-                                 @Override
-                                 @SneakyThrows
-                                 public void onMessage(String msg) {
-                                     response.set(
-                                             new ObjectMapper()
-                                                     .readValue(msg, ProduceResponse.class));
-                                     countDownLatch.countDown();
-                                 }
+                                    @Override
+                                    @SneakyThrows
+                                    public void onMessage(String msg) {
+                                        response.set(
+                                                new ObjectMapper()
+                                                        .readValue(msg, ProduceResponse.class));
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onClose(CloseReason cr) {
-                                     closeReason.set(cr);
-                                     countDownLatch.countDown();
-                                 }
-                             })
-                             .connect(connectTo)) {
+                                    @Override
+                                    public void onClose(CloseReason cr) {
+                                        closeReason.set(cr);
+                                        countDownLatch.countDown();
+                                    }
+                                })
+                        .connect(connectTo)) {
             client.send(json);
             countDownLatch.await();
             assertNull(closeReason.get());
@@ -1212,22 +1241,22 @@ class ProduceConsumeHandlerTest {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         final TestWebSocketClient client =
                 new TestWebSocketClient(
-                        new TestWebSocketClient.Handler() {
-                            @Override
-                            public void onOpen(Session session) {
-                                countDownLatch.countDown();
-                            }
+                                new TestWebSocketClient.Handler() {
+                                    @Override
+                                    public void onOpen(Session session) {
+                                        countDownLatch.countDown();
+                                    }
 
-                            @Override
-                            public void onMessage(String msg) {
-                                collect.add(msg);
-                            }
+                                    @Override
+                                    public void onMessage(String msg) {
+                                        collect.add(msg);
+                                    }
 
-                            @Override
-                            public void onClose(CloseReason cr) {
-                                closeReason.set(cr);
-                            }
-                        })
+                                    @Override
+                                    public void onClose(CloseReason cr) {
+                                        closeReason.set(cr);
+                                    }
+                                })
                         .connect(connectTo);
         countDownLatch.await();
         return new ClientSession() {
@@ -1264,64 +1293,61 @@ class ProduceConsumeHandlerTest {
                                         .topic(topic)
                                         .parameters(List.of("p"))
                                         .eventsTopic(eventsTopic)
-                                        .build()
-                                ,
+                                        .build(),
                                 Gateway.builder()
                                         .id("consume")
                                         .type(Gateway.GatewayType.consume)
                                         .topic(eventsTopic)
                                         .parameters(List.of("p"))
                                         .eventsTopic(eventsTopic)
-                                        .build())
-                );
+                                        .build()));
 
         CountDownLatch consumerReady = new CountDownLatch(1);
         CountDownLatch countDownLatch = new CountDownLatch(5);
         List<String> messages = new ArrayList<>();
         try (final TestWebSocketClient consumerClient =
-                     new TestWebSocketClient(
-                             new TestWebSocketClient.Handler() {
-                                 @Override
-                                 public void onMessage(String msg) {
-                                     messages.add(msg);
-                                     countDownLatch.countDown();
-                                 }
+                new TestWebSocketClient(
+                                new TestWebSocketClient.Handler() {
+                                    @Override
+                                    public void onMessage(String msg) {
+                                        messages.add(msg);
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onOpen(Session session) {
-                                     consumerReady.countDown();
-                                 }
+                                    @Override
+                                    public void onOpen(Session session) {
+                                        consumerReady.countDown();
+                                    }
 
-                                 @Override
-                                 public void onClose(CloseReason closeReason) {
-                                     countDownLatch.countDown();
-                                 }
+                                    @Override
+                                    public void onClose(CloseReason closeReason) {
+                                        countDownLatch.countDown();
+                                    }
 
-                                 @Override
-                                 public void onError(Throwable throwable) {
-                                     countDownLatch.countDown();
-                                 }
-                             })
-                             .connect(
-                                     URI.create(
-                                             ("ws://localhost:%d/v1/consume/tenant1/application1/consume?param:p"
-                                              + "=consumer")
-                                                     .formatted(port)))) {
+                                    @Override
+                                    public void onError(Throwable throwable) {
+                                        countDownLatch.countDown();
+                                    }
+                                })
+                        .connect(
+                                URI.create(
+                                        ("ws://localhost:%d/v1/consume/tenant1/application1/consume?param:p"
+                                                        + "=consumer")
+                                                .formatted(port)))) {
             consumerReady.await();
 
             try (final TestWebSocketClient producer =
-                         new TestWebSocketClient(TestWebSocketClient.NOOP)
-                                 .connect(
-                                         URI.create(
-                                                 ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:p"
-                                                  + "=producer")
-                                                         .formatted(port)))) {
+                    new TestWebSocketClient(TestWebSocketClient.NOOP)
+                            .connect(
+                                    URI.create(
+                                            ("ws://localhost:%d/v1/produce/tenant1/application1/produce?param:p"
+                                                            + "=producer")
+                                                    .formatted(port)))) {
                 final ProduceRequest produceRequest =
                         new ProduceRequest(null, "this is a message", null);
                 produce(produceRequest, producer);
             }
-            new TestWebSocketClient(new TestWebSocketClient.Handler() {
-            })
+            new TestWebSocketClient(new TestWebSocketClient.Handler() {})
                     .connect(
                             URI.create(
                                     "ws://localhost:%d/v1/consume/tenant1/application1/consume?param:p=consumer1"

--- a/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
@@ -19,43 +19,35 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-public record Gateway(
-        String id,
-        GatewayType type,
-        String topic,
-        Authentication authentication,
-        List<String> parameters,
-        @JsonAlias({"produce-options"}) ProduceOptions produceOptions,
-        @JsonAlias({"consume-options"}) ConsumeOptions consumeOptions,
-        @JsonProperty("events-topic") String eventsTopic) {
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public final class Gateway {
+
+    private String id;
+    private GatewayType type;
+    private String topic;
+    private Authentication authentication;
+    private List<String> parameters;
+    @JsonAlias({"produce-options"})
+    private ProduceOptions produceOptions;
+    @JsonAlias({"consume-options"})
+    private ConsumeOptions consumeOptions;
+    @JsonProperty("chat-options")
+    private ChatOptions chatOptions;
+    @JsonProperty("events-topic")
+    private String eventsTopic;
+
     public enum GatewayType {
         produce,
         consume
-    }
-
-    public Gateway(
-            String id,
-            GatewayType type,
-            String topic,
-            List<String> parameters,
-            ProduceOptions produceOptions,
-            ConsumeOptions consumeOptions) {
-        this(id, type, topic, null, parameters, produceOptions, consumeOptions, null);
-    }
-
-    public Gateway(
-            String id,
-            GatewayType type,
-            String topic,
-            Authentication authentication,
-            List<String> parameters,
-            ProduceOptions produceOptions,
-            ConsumeOptions consumeOptions) {
-        this(id, type, topic, authentication, parameters, produceOptions, consumeOptions, null);
     }
 
     @Data
@@ -89,9 +81,29 @@ public record Gateway(
         }
     }
 
-    public record ProduceOptions(List<KeyValueComparison> headers) {}
+    public record ProduceOptions(List<KeyValueComparison> headers) {
+    }
 
-    public record ConsumeOptions(ConsumeOptionsFilters filters) {}
+    public record ConsumeOptions(ConsumeOptionsFilters filters) {
+    }
 
-    public record ConsumeOptionsFilters(List<KeyValueComparison> headers) {}
+    public record ConsumeOptionsFilters(List<KeyValueComparison> headers) {
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatOptions {
+
+
+        @JsonProperty("questions-topic")
+        private String questionsTopic;
+        @JsonProperty("answers-topic")
+        private String answersTopic;
+
+        @JsonProperty("session-parameter")
+        private String sessionParameter;
+        @JsonProperty("user-parameter")
+        private String userParameter;
+    }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -36,12 +35,16 @@ public final class Gateway {
     private String topic;
     private Authentication authentication;
     private List<String> parameters;
+
     @JsonAlias({"produce-options"})
     private ProduceOptions produceOptions;
+
     @JsonAlias({"consume-options"})
     private ConsumeOptions consumeOptions;
+
     @JsonProperty("chat-options")
     private ChatOptions chatOptions;
+
     @JsonProperty("events-topic")
     private String eventsTopic;
 
@@ -81,28 +84,26 @@ public final class Gateway {
         }
     }
 
-    public record ProduceOptions(List<KeyValueComparison> headers) {
-    }
+    public record ProduceOptions(List<KeyValueComparison> headers) {}
 
-    public record ConsumeOptions(ConsumeOptionsFilters filters) {
-    }
+    public record ConsumeOptions(ConsumeOptionsFilters filters) {}
 
-    public record ConsumeOptionsFilters(List<KeyValueComparison> headers) {
-    }
+    public record ConsumeOptionsFilters(List<KeyValueComparison> headers) {}
 
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChatOptions {
 
-
         @JsonProperty("questions-topic")
         private String questionsTopic;
+
         @JsonProperty("answers-topic")
         private String answersTopic;
 
         @JsonProperty("session-parameter")
         private String sessionParameter;
+
         @JsonProperty("user-parameter")
         private String userParameter;
     }

--- a/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
@@ -175,30 +175,31 @@ public class ApplicationPlaceholderResolver {
         }
         List<Gateway> newGateways = new ArrayList<>();
         for (Gateway gateway : instance.getGateways().gateways()) {
-            Gateway.Authentication authentication = gateway.authentication();
-            if (gateway.authentication() != null
-                    && gateway.authentication().getConfiguration() != null) {
+            Gateway.Authentication authentication = gateway.getAuthentication();
+            if (gateway.getAuthentication() != null
+                    && gateway.getAuthentication().getConfiguration() != null) {
                 authentication =
                         new Gateway.Authentication(
                                 authentication.getProvider(),
-                                resolveMap(context, gateway.authentication().getConfiguration()),
+                                resolveMap(context, gateway.getAuthentication().getConfiguration()),
                                 authentication.isAllowTestMode());
             }
 
-            final String topic = resolveValue(context, gateway.topic());
+            final String topic = resolveValue(context, gateway.getTopic());
             final String eventsTopic =
-                    gateway.eventsTopic() == null
+                    gateway.getEventsTopic() == null
                             ? null
-                            : resolveValue(context, gateway.eventsTopic());
+                            : resolveValue(context, gateway.getEventsTopic());
             newGateways.add(
                     new Gateway(
-                            gateway.id(),
-                            gateway.type(),
+                            gateway.getId(),
+                            gateway.getType(),
                             topic,
                             authentication,
-                            gateway.parameters(),
-                            gateway.produceOptions(),
-                            gateway.consumeOptions(),
+                            gateway.getParameters(),
+                            gateway.getProduceOptions(),
+                            gateway.getConsumeOptions(),
+                            gateway.getChatOptions(),
                             eventsTopic));
         }
         return new Gateways(newGateways);

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -323,28 +323,28 @@ public class ModelBuilder {
     }
 
     private static void validateGateway(Gateway gateway) {
-        if (gateway.id() == null || gateway.id().isBlank()) {
+        if (gateway.getId() == null || gateway.getId().isBlank()) {
             throw new IllegalArgumentException("Gateway id is required");
         }
-        if (gateway.type() == null) {
+        if (gateway.getType() == null) {
             throw new IllegalArgumentException("Gateway type is required");
         }
-        if (gateway.type() == Gateway.GatewayType.consume) {
-            if (gateway.produceOptions() != null) {
+        if (gateway.getType() == Gateway.GatewayType.consume) {
+            if (gateway.getProduceOptions() != null) {
                 throw new IllegalArgumentException(
                         "Gateway of type 'consume' cannot have produce options");
             }
-            if (gateway.consumeOptions() != null) {
-                if (gateway.consumeOptions().filters() != null) {
+            if (gateway.getConsumeOptions() != null) {
+                if (gateway.getConsumeOptions().filters() != null) {
                     final Gateway.ConsumeOptionsFilters filters =
-                            gateway.consumeOptions().filters();
+                            gateway.getConsumeOptions().filters();
                     if (filters.headers() != null) {
                         filters.headers().forEach(ModelBuilder::validateGatewayKeyValueComparison);
                     }
                 }
             }
-        } else if (gateway.type() == Gateway.GatewayType.produce) {
-            if (gateway.consumeOptions() != null) {
+        } else if (gateway.getType() == Gateway.GatewayType.produce) {
+            if (gateway.getConsumeOptions() != null) {
                 throw new IllegalArgumentException(
                         "Gateway of type 'produce' cannot have consume options");
             }

--- a/langstream-core/src/test/java/ai/langstream/impl/common/ApplicationPlaceholderResolverTest.java
+++ b/langstream-core/src/test/java/ai/langstream/impl/common/ApplicationPlaceholderResolverTest.java
@@ -343,9 +343,9 @@ class ApplicationPlaceholderResolverTest {
 
         final Application resolved =
                 ApplicationPlaceholderResolver.resolvePlaceholders(applicationInstance);
-        assertEquals("my-input-topic", resolved.getGateways().gateways().get(0).topic());
-        assertEquals("my-stream-topic", resolved.getGateways().gateways().get(0).eventsTopic());
-        assertEquals("my-input-topic", resolved.getGateways().gateways().get(1).topic());
-        assertEquals("my-stream-topic", resolved.getGateways().gateways().get(1).eventsTopic());
+        assertEquals("my-input-topic", resolved.getGateways().gateways().get(0).getTopic());
+        assertEquals("my-stream-topic", resolved.getGateways().gateways().get(0).getEventsTopic());
+        assertEquals("my-input-topic", resolved.getGateways().gateways().get(1).getTopic());
+        assertEquals("my-stream-topic", resolved.getGateways().gateways().get(1).getEventsTopic());
     }
 }

--- a/langstream-core/src/test/java/ai/langstream/impl/parser/ModelBuilderTest.java
+++ b/langstream-core/src/test/java/ai/langstream/impl/parser/ModelBuilderTest.java
@@ -129,9 +129,9 @@ class ModelBuilderTest {
         final List<Gateway> gateways = applicationInstance.getGateways().gateways();
         Assertions.assertEquals(1, gateways.size());
         final Gateway gateway = gateways.get(0);
-        assertEquals("gw", gateway.id());
-        assertEquals("t1", gateway.topic());
-        assertEquals("google", gateway.authentication().getProvider());
-        assertTrue(gateway.authentication().isAllowTestMode());
+        assertEquals("gw", gateway.getId());
+        assertEquals("t1", gateway.getTopic());
+        assertEquals("google", gateway.getAuthentication().getProvider());
+        assertTrue(gateway.getAuthentication().isAllowTestMode());
     }
 }

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
@@ -134,9 +134,9 @@ public class ApplicationService {
         if (applicationDeployProperties.gateway().requireAuthentication()) {
             if (application.getGateways() != null && application.getGateways().gateways() != null) {
                 for (Gateway gateway : application.getGateways().gateways()) {
-                    if (gateway.authentication() == null) {
+                    if (gateway.getAuthentication() == null) {
                         throw new IllegalArgumentException(
-                                "Gateway " + gateway.id() + " is missing authentication");
+                                "Gateway " + gateway.getId() + " is missing authentication");
                     }
                 }
             }


### PR DESCRIPTION
Moved Gateway class from record to class in order to easily handle new properties. 
Also moved tests to use builder instead of constructor