### PR TITLE
Introduce new gateway type: 'chat'

### DIFF
--- a/examples/applications/gateway-authentication/gateways.yaml
+++ b/examples/applications/gateway-authentication/gateways.yaml
@@ -35,6 +35,13 @@ gateways:
         headers:
           - key: langstream-client-session-id
             value-from-parameters: sessionId
+  - id: chat-no-auth
+    type: chat
+    chat-options:
+      headers:
+      - value-from-parameters: session-id
+      questions-topic: input-topic
+      answers-topic: output-topic
 
   - id: produce-input-auth-google
     type: produce

--- a/examples/instances/kafka-docker.yaml
+++ b/examples/instances/kafka-docker.yaml
@@ -20,4 +20,4 @@ instance:
     type: "kafka"
     configuration:
       admin:
-        bootstrap.servers: localhost:9092
+        bootstrap.servers: localhost:39092

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
@@ -19,6 +19,7 @@ import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
+import ai.langstream.apigateway.websocket.handlers.ChatHandler;
 import ai.langstream.apigateway.websocket.handlers.ConsumeHandler;
 import ai.langstream.apigateway.websocket.handlers.ProduceHandler;
 import jakarta.annotation.PreDestroy;
@@ -42,6 +43,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     public static final String CONSUME_PATH = "/v1/consume/{tenant}/{application}/{gateway}";
     public static final String PRODUCE_PATH = "/v1/produce/{tenant}/{application}/{gateway}";
+    public static final String CHAT_PATH = "/v1/chat/{tenant}/{application}/{gateway}";
 
     private final ApplicationStore applicationStore;
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
@@ -61,6 +63,12 @@ public class WebSocketConfig implements WebSocketConfigurer {
                 .addHandler(
                         new ProduceHandler(applicationStore, topicConnectionsRuntimeRegistry),
                         PRODUCE_PATH)
+                .addHandler(
+                        new ChatHandler(
+                                applicationStore,
+                                consumeThreadPool,
+                                topicConnectionsRuntimeRegistry),
+                        CHAT_PATH)
                 .setAllowedOrigins("*")
                 .addInterceptors(
                         new HttpSessionHandshakeInterceptor(),

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -421,11 +421,13 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
             for (Record record : records) {
                 log.debug("[{}] Received record {}", session.getId(), record);
                 boolean skip = false;
-                for (Function<Record, Boolean> filter : filters) {
-                    if (!filter.apply(record)) {
-                        skip = true;
-                        log.debug("[{}] Skipping record {}", session.getId(), record);
-                        break;
+                if (filters != null) {
+                    for (Function<Record, Boolean> filter : filters) {
+                        if (!filter.apply(record)) {
+                            skip = true;
+                            log.debug("[{}] Skipping record {}", session.getId(), record);
+                            break;
+                        }
                     }
                 }
                 if (!skip) {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -24,23 +24,41 @@ import ai.langstream.api.model.ApplicationSpecs;
 import ai.langstream.api.model.Gateway;
 import ai.langstream.api.model.Gateways;
 import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
+import ai.langstream.api.runner.topics.OffsetPerPartition;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
+import ai.langstream.api.runner.topics.TopicOffsetPosition;
 import ai.langstream.api.runner.topics.TopicProducer;
+import ai.langstream.api.runner.topics.TopicReadResult;
+import ai.langstream.api.runner.topics.TopicReader;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
+import ai.langstream.apigateway.websocket.api.ConsumePushMessage;
+import ai.langstream.apigateway.websocket.api.ProduceRequest;
+import ai.langstream.apigateway.websocket.api.ProduceResponse;
 import ai.langstream.apigateway.websocket.impl.GatewayRequestContextImpl;
 import ai.langstream.impl.common.ApplicationPlaceholderResolver;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
@@ -227,7 +245,7 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         final Gateway.GatewayType type = gatewayType();
         final Gateway gateway = extractGateway(gatewayId, application, type);
 
-        final List<String> requiredParameters = gateway.getParameters();
+        final List<String> requiredParameters = getAllRequiredParameters(gateway);
         Set<String> allUserParameterKeys = new HashSet<>(userParameters.keySet());
         if (requiredParameters != null) {
             for (String requiredParameter : requiredParameters) {
@@ -261,7 +279,9 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
                 .build();
     }
 
-    protected void recordCloseableResource(
+    protected abstract List<String> getAllRequiredParameters(Gateway gateway);
+
+    protected static void recordCloseableResource(
             Map<String, Object> attributes, AutoCloseable... closeables) {
         List<AutoCloseable> currentCloseable = (List<AutoCloseable>) attributes.get("closeables");
 
@@ -348,5 +368,322 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
             producer.write(record).get();
             log.info("sent event {}", recordValue);
         }
+    }
+
+    protected static void startReadingMessages(
+            WebSocketSession session,
+            AuthenticatedGatewayRequestContext context,
+            Executor executor) {
+        final CompletableFuture<Void> future =
+                CompletableFuture.runAsync(
+                        () -> {
+                            final Map<String, Object> attributes = session.getAttributes();
+                            TopicReader reader = (TopicReader) attributes.get("topicReader");
+                            final String tenant = context.tenant();
+                            final String gatewayId = context.gateway().getId();
+                            final String applicationId = context.applicationId();
+                            try {
+                                log.info(
+                                        "[{}] Started reader for gateway {}/{}/{}",
+                                        session.getId(),
+                                        tenant,
+                                        applicationId,
+                                        gatewayId);
+                                readMessages(
+                                        session,
+                                        (List<Function<Record, Boolean>>)
+                                                attributes.get("consumeFilters"),
+                                        reader);
+                            } catch (InterruptedException | CancellationException ex) {
+                                // ignore
+                            } catch (Throwable ex) {
+                                log.error(ex.getMessage(), ex);
+                            } finally {
+                                closeReader(reader);
+                            }
+                        },
+                        executor);
+        session.getAttributes().put("future", future);
+    }
+
+    protected static void readMessages(
+            WebSocketSession session, List<Function<Record, Boolean>> filters, TopicReader reader)
+            throws Exception {
+        while (true) {
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (!session.isOpen()) {
+                return;
+            }
+            final TopicReadResult readResult = reader.read();
+            final List<Record> records = readResult.records();
+            for (Record record : records) {
+                log.debug("[{}] Received record {}", session.getId(), record);
+                boolean skip = false;
+                for (Function<Record, Boolean> filter : filters) {
+                    if (!filter.apply(record)) {
+                        skip = true;
+                        log.debug("[{}] Skipping record {}", session.getId(), record);
+                        break;
+                    }
+                }
+                if (!skip) {
+                    final Map<String, String> messageHeaders = computeMessageHeaders(record);
+                    final String offset = computeOffset(readResult);
+
+                    final ConsumePushMessage message =
+                            new ConsumePushMessage(
+                                    new ConsumePushMessage.Record(
+                                            record.key(), record.value(), messageHeaders),
+                                    offset);
+                    final String jsonMessage = mapper.writeValueAsString(message);
+                    session.sendMessage(new TextMessage(jsonMessage));
+                }
+            }
+        }
+    }
+
+    private static void closeReader(TopicReader reader) {
+        if (reader == null) {
+            return;
+        }
+        try {
+            reader.close();
+        } catch (Exception e) {
+            log.error("error closing reader", e);
+        }
+    }
+
+    private static Map<String, String> computeMessageHeaders(Record record) {
+        final Collection<Header> headers = record.headers();
+        final Map<String, String> messageHeaders;
+        if (headers == null) {
+            messageHeaders = Map.of();
+        } else {
+            messageHeaders = new HashMap<>();
+            headers.forEach(h -> messageHeaders.put(h.key(), h.valueAsString()));
+        }
+        return messageHeaders;
+    }
+
+    private static String computeOffset(TopicReadResult readResult) throws JsonProcessingException {
+        final OffsetPerPartition offsetPerPartition = readResult.partitionsOffsets();
+        if (offsetPerPartition == null) {
+            return null;
+        }
+        return Base64.getEncoder().encodeToString(mapper.writeValueAsBytes(offsetPerPartition));
+    }
+
+    protected static List<Function<Record, Boolean>> createMessageFilters(
+            List<Gateway.KeyValueComparison> headersFilters,
+            Map<String, String> passedParameters,
+            Map<String, String> principalValues) {
+        List<Function<Record, Boolean>> filters = new ArrayList<>();
+        if (headersFilters == null) {
+            return filters;
+        }
+        for (Gateway.KeyValueComparison comparison : headersFilters) {
+            if (comparison.key() == null) {
+                throw new IllegalArgumentException("Key cannot be null");
+            }
+            filters.add(
+                    record -> {
+                        final Header header = record.getHeader(comparison.key());
+                        if (header == null) {
+                            return false;
+                        }
+                        final String expectedValue = header.valueAsString();
+                        if (expectedValue == null) {
+                            return false;
+                        }
+                        String value = comparison.value();
+                        if (value == null && comparison.valueFromParameters() != null) {
+                            value = passedParameters.get(comparison.valueFromParameters());
+                        }
+                        if (value == null && comparison.valueFromAuthentication() != null) {
+                            value = principalValues.get(comparison.valueFromAuthentication());
+                        }
+                        if (value == null) {
+                            return false;
+                        }
+                        return expectedValue.equals(value);
+                    });
+        }
+        return filters;
+    }
+
+    protected void setupReader(
+            Map<String, Object> sessionAttributes,
+            String topic,
+            StreamingCluster streamingCluster,
+            List<Function<Record, Boolean>> filters,
+            Map<String, String> options)
+            throws Exception {
+        sessionAttributes.put("consumeFilters", filters);
+
+        final TopicConnectionsRuntime topicConnectionsRuntime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(streamingCluster)
+                        .asTopicConnectionsRuntime();
+
+        final String positionParameter = options.getOrDefault("position", "latest");
+        TopicOffsetPosition position =
+                switch (positionParameter) {
+                    case "latest" -> TopicOffsetPosition.LATEST;
+                    case "earliest" -> TopicOffsetPosition.EARLIEST;
+                    default -> TopicOffsetPosition.absolute(
+                            new String(
+                                    Base64.getDecoder().decode(positionParameter),
+                                    StandardCharsets.UTF_8));
+                };
+        TopicReader reader =
+                topicConnectionsRuntime.createReader(
+                        streamingCluster, Map.of("topic", topic), position);
+        reader.start();
+        sessionAttributes.put("topicReader", reader);
+    }
+
+    protected void stopReadingMessages(WebSocketSession webSocketSession) {
+        final CompletableFuture<Void> future =
+                (CompletableFuture<Void>) webSocketSession.getAttributes().get("future");
+        if (future != null && !future.isDone()) {
+            future.cancel(true);
+        }
+    }
+
+    protected void setupProducer(
+            Map<String, Object> sessionAttributes,
+            String topic,
+            StreamingCluster streamingCluster,
+            final List<Header> commonHeaders,
+            final String tenant,
+            final String applicationId,
+            final String gatewayId) {
+        final TopicConnectionsRuntime topicConnectionsRuntime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(streamingCluster)
+                        .asTopicConnectionsRuntime();
+
+        final TopicProducer producer =
+                topicConnectionsRuntime.createProducer(
+                        null, streamingCluster, Map.of("topic", topic));
+        recordCloseableResource(sessionAttributes, producer);
+        producer.start();
+
+        sessionAttributes.put("producer", producer);
+        sessionAttributes.put(
+                "headers",
+                commonHeaders == null ? List.of() : Collections.unmodifiableList(commonHeaders));
+        log.info(
+                "Started produced for gateway {}/{}/{} on topic {}",
+                tenant,
+                applicationId,
+                gatewayId,
+                topic);
+    }
+
+    protected static List<Header> getProducerCommonHeaders(
+            List<Gateway.KeyValueComparison> headerFilters,
+            Map<String, String> passedParameters,
+            Map<String, String> principalValues) {
+        final List<Header> headers = new ArrayList<>();
+        if (headerFilters == null) {
+            return headers;
+        }
+        for (Gateway.KeyValueComparison mapping : headerFilters) {
+            if (mapping.key() == null || mapping.key().isEmpty()) {
+                throw new IllegalArgumentException("Header key cannot be empty");
+            }
+            String value = mapping.value();
+            if (value == null && mapping.valueFromParameters() != null) {
+                value = passedParameters.get(mapping.valueFromParameters());
+            }
+            if (value == null && mapping.valueFromAuthentication() != null) {
+                value = principalValues.get(mapping.valueFromAuthentication());
+            }
+            if (value == null) {
+                throw new IllegalArgumentException("header " + mapping.key() + " cannot be empty");
+            }
+            headers.add(SimpleRecord.SimpleHeader.of(mapping.key(), value));
+        }
+        return headers;
+    }
+
+    protected static void produceMessage(WebSocketSession webSocketSession, TextMessage message)
+            throws IOException {
+        final TopicProducer topicProducer = getTopicProducer(webSocketSession, true);
+        final ProduceRequest produceRequest;
+        try {
+            produceRequest = mapper.readValue(message.getPayload(), ProduceRequest.class);
+        } catch (JsonProcessingException err) {
+            sendResponse(webSocketSession, ProduceResponse.Status.BAD_REQUEST, err.getMessage());
+            return;
+        }
+        if (produceRequest.value() == null && produceRequest.key() == null) {
+            sendResponse(
+                    webSocketSession,
+                    ProduceResponse.Status.BAD_REQUEST,
+                    "Either key or value must be set.");
+            return;
+        }
+
+        final Collection<Header> headers =
+                new ArrayList<>((List<Header>) webSocketSession.getAttributes().get("headers"));
+        if (produceRequest.headers() != null) {
+            final Set<String> configuredHeaders =
+                    headers.stream().map(Header::key).collect(Collectors.toSet());
+            for (Map.Entry<String, String> messageHeader : produceRequest.headers().entrySet()) {
+                if (configuredHeaders.contains(messageHeader.getKey())) {
+                    sendResponse(
+                            webSocketSession,
+                            ProduceResponse.Status.BAD_REQUEST,
+                            "Header "
+                                    + messageHeader.getKey()
+                                    + " is configured as parameter-level header.");
+                    return;
+                }
+                headers.add(
+                        SimpleRecord.SimpleHeader.of(
+                                messageHeader.getKey(), messageHeader.getValue()));
+            }
+        }
+        try {
+            final SimpleRecord record =
+                    SimpleRecord.builder()
+                            .key(produceRequest.key())
+                            .value(produceRequest.value())
+                            .headers(headers)
+                            .build();
+            topicProducer.write(record).get();
+            log.info("[{}] Produced record {}", webSocketSession.getId(), record);
+        } catch (Throwable tt) {
+            sendResponse(webSocketSession, ProduceResponse.Status.PRODUCER_ERROR, tt.getMessage());
+            return;
+        }
+
+        webSocketSession.sendMessage(
+                new TextMessage(mapper.writeValueAsString(ProduceResponse.OK)));
+    }
+
+    private static void sendResponse(
+            WebSocketSession webSocketSession, ProduceResponse.Status status, String reason)
+            throws IOException {
+        webSocketSession.sendMessage(
+                new TextMessage(mapper.writeValueAsString(new ProduceResponse(status, reason))));
+    }
+
+    private static TopicProducer getTopicProducer(
+            WebSocketSession webSocketSession, boolean throwIfNotFound) {
+        final TopicProducer topicProducer =
+                (TopicProducer) webSocketSession.getAttributes().get("producer");
+        if (topicProducer == null) {
+            if (throwIfNotFound) {
+                log.error("No producer found for session {}", webSocketSession.getId());
+                throw new IllegalStateException(
+                        "No producer found for session " + webSocketSession.getId());
+            }
+        }
+        return topicProducer;
     }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
@@ -18,25 +18,12 @@ package ai.langstream.apigateway.websocket.handlers;
 import static ai.langstream.apigateway.websocket.WebSocketConfig.PRODUCE_PATH;
 
 import ai.langstream.api.model.Gateway;
-import ai.langstream.api.model.StreamingCluster;
 import ai.langstream.api.runner.code.Header;
-import ai.langstream.api.runner.code.SimpleRecord;
-import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
-import ai.langstream.api.runner.topics.TopicProducer;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
-import ai.langstream.apigateway.websocket.api.ProduceRequest;
-import ai.langstream.apigateway.websocket.api.ProduceResponse;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -77,36 +64,34 @@ public class ProduceHandler extends AbstractHandler {
     }
 
     @Override
+    protected List<String> getAllRequiredParameters(Gateway gateway) {
+        return gateway.getParameters();
+    }
+
+    @Override
     public void onBeforeHandshakeCompleted(
             AuthenticatedGatewayRequestContext context, Map<String, Object> attributes)
             throws Exception {
-        Gateway gateway = context.gateway();
-
-        final List<Header> headers =
-                getCommonHeaders(gateway, context.userParameters(), context.principalValues());
-        final StreamingCluster streamingCluster =
-                context.application().getInstance().streamingCluster();
-
-        final TopicConnectionsRuntime topicConnectionsRuntime =
-                topicConnectionsRuntimeRegistry
-                        .getTopicConnectionsRuntime(streamingCluster)
-                        .asTopicConnectionsRuntime();
-
-        final String topicName = gateway.getTopic();
-        final TopicProducer producer =
-                topicConnectionsRuntime.createProducer(
-                        null, streamingCluster, Map.of("topic", topicName));
-        recordCloseableResource(attributes, producer);
-        producer.start();
-
-        attributes.put("producer", producer);
-        attributes.put("headers", Collections.unmodifiableList(headers));
-        log.info(
-                "Started produced for gateway {}/{}/{} on topic {}",
+        final Gateway gateway = context.gateway();
+        final Gateway.ProduceOptions produceOptions = gateway.getProduceOptions();
+        final List<Header> commonHeaders;
+        if (produceOptions != null) {
+            commonHeaders =
+                    getProducerCommonHeaders(
+                            produceOptions.headers(),
+                            context.userParameters(),
+                            context.principalValues());
+        } else {
+            commonHeaders = null;
+        }
+        setupProducer(
+                context.attributes(),
+                gateway.getTopic(),
+                context.application().getInstance().streamingCluster(),
+                commonHeaders,
                 context.tenant(),
                 context.applicationId(),
-                context.gateway().getId(),
-                topicName);
+                gateway.getId());
         sendClientConnectedEvent(context);
     }
 
@@ -120,81 +105,7 @@ public class ProduceHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context,
             TextMessage message)
             throws Exception {
-        final TopicProducer topicProducer = getTopicProducer(webSocketSession, true);
-        final ProduceRequest produceRequest;
-        try {
-            produceRequest = mapper.readValue(message.getPayload(), ProduceRequest.class);
-        } catch (JsonProcessingException err) {
-            sendResponse(webSocketSession, ProduceResponse.Status.BAD_REQUEST, err.getMessage());
-            return;
-        }
-        if (produceRequest.value() == null && produceRequest.key() == null) {
-            sendResponse(
-                    webSocketSession,
-                    ProduceResponse.Status.BAD_REQUEST,
-                    "Either key or value must be set.");
-            return;
-        }
-
-        final Collection<Header> headers =
-                new ArrayList<>((List<Header>) webSocketSession.getAttributes().get("headers"));
-        if (produceRequest.headers() != null) {
-            final Set<String> configuredHeaders =
-                    headers.stream().map(Header::key).collect(Collectors.toSet());
-            log.info(
-                    "configuredHeaders: {} passed {}", configuredHeaders, produceRequest.headers());
-            for (Map.Entry<String, String> messageHeader : produceRequest.headers().entrySet()) {
-                if (configuredHeaders.contains(messageHeader.getKey())) {
-                    sendResponse(
-                            webSocketSession,
-                            ProduceResponse.Status.BAD_REQUEST,
-                            "Header "
-                                    + messageHeader.getKey()
-                                    + " is configured as parameter-level header.");
-                    return;
-                }
-                headers.add(
-                        SimpleRecord.SimpleHeader.of(
-                                messageHeader.getKey(), messageHeader.getValue()));
-            }
-        }
-        try {
-            final SimpleRecord record =
-                    SimpleRecord.builder()
-                            .key(produceRequest.key())
-                            .value(produceRequest.value())
-                            .headers(headers)
-                            .build();
-            topicProducer.write(record).get();
-            log.info("[{}] Produced record {}", webSocketSession.getId(), record);
-        } catch (Throwable tt) {
-            sendResponse(webSocketSession, ProduceResponse.Status.PRODUCER_ERROR, tt.getMessage());
-            return;
-        }
-
-        webSocketSession.sendMessage(
-                new TextMessage(mapper.writeValueAsString(ProduceResponse.OK)));
-    }
-
-    private void sendResponse(
-            WebSocketSession webSocketSession, ProduceResponse.Status status, String reason)
-            throws IOException {
-        webSocketSession.sendMessage(
-                new TextMessage(mapper.writeValueAsString(new ProduceResponse(status, reason))));
-    }
-
-    private TopicProducer getTopicProducer(
-            WebSocketSession webSocketSession, boolean throwIfNotFound) {
-        final TopicProducer topicProducer =
-                (TopicProducer) webSocketSession.getAttributes().get("producer");
-        if (topicProducer == null) {
-            if (throwIfNotFound) {
-                log.error("No producer found for session {}", webSocketSession.getId());
-                throw new IllegalStateException(
-                        "No producer found for session " + webSocketSession.getId());
-            }
-        }
-        return topicProducer;
+        produceMessage(webSocketSession, message);
     }
 
     @Override
@@ -210,36 +121,5 @@ public class ProduceHandler extends AbstractHandler {
                 default -> throw new IllegalArgumentException("Unknown option " + option.getKey());
             }
         }
-    }
-
-    private List<Header> getCommonHeaders(
-            Gateway selectedGateway,
-            Map<String, String> passedParameters,
-            Map<String, String> principalValues) {
-        final List<Header> headers = new ArrayList<>();
-        if (selectedGateway.getProduceOptions() != null
-                && selectedGateway.getProduceOptions().headers() != null) {
-            final List<Gateway.KeyValueComparison> headersConfig =
-                    selectedGateway.getProduceOptions().headers();
-            for (Gateway.KeyValueComparison mapping : headersConfig) {
-                if (mapping.key() == null || mapping.key().isEmpty()) {
-                    throw new IllegalArgumentException("Header key cannot be empty");
-                }
-                String value = mapping.value();
-                if (value == null && mapping.valueFromParameters() != null) {
-                    value = passedParameters.get(mapping.valueFromParameters());
-                }
-                if (value == null && mapping.valueFromAuthentication() != null) {
-                    value = principalValues.get(mapping.valueFromAuthentication());
-                }
-                if (value == null) {
-                    throw new IllegalArgumentException(
-                            "header " + mapping.key() + " cannot be empty");
-                }
-
-                headers.add(SimpleRecord.SimpleHeader.of(mapping.key(), value));
-            }
-        }
-        return headers;
     }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
@@ -50,7 +50,8 @@ public final class Gateway {
 
     public enum GatewayType {
         produce,
-        consume
+        consume,
+        chat
     }
 
     @Data
@@ -69,6 +70,40 @@ public final class Gateway {
             String value,
             @JsonAlias({"value-from-parameters"}) String valueFromParameters,
             @JsonAlias({"value-from-authentication"}) String valueFromAuthentication) {
+
+        public KeyValueComparison {
+            if (value == null && valueFromAuthentication == null && valueFromParameters == null) {
+                throw new IllegalArgumentException(
+                        "Must specify one of value, value-from-parameters, or value-from-authentication");
+            }
+            if (value != null && valueFromParameters != null) {
+                throw new IllegalArgumentException(
+                        "Cannot specify both value and value-from-parameters");
+            }
+
+            if (value != null && valueFromAuthentication != null) {
+                throw new IllegalArgumentException(
+                        "Cannot specify both value and value-from-authentication");
+            }
+
+            if (valueFromAuthentication != null && valueFromParameters != null) {
+                throw new IllegalArgumentException(
+                        "Cannot specify both value-from-parameters and value-from-authentication");
+            }
+            if (key == null) {
+                if (value != null) {
+                    key = value;
+                } else if (valueFromParameters != null) {
+                    key = valueFromParameters;
+                } else {
+                    key = valueFromAuthentication;
+                }
+                if (key == null) {
+                    throw new IllegalArgumentException("Not able to compute key: " + this);
+                }
+            }
+        }
+
         public static KeyValueComparison value(String key, String value) {
             return new KeyValueComparison(key, value, null, null);
         }
@@ -81,6 +116,11 @@ public final class Gateway {
         public static KeyValueComparison valueFromAuthentication(
                 String key, String valueFromAuthentication) {
             return new KeyValueComparison(key, null, null, valueFromAuthentication);
+        }
+
+        private String getKeyWithDefaultValue() {
+
+            throw new IllegalStateException();
         }
     }
 
@@ -101,10 +141,6 @@ public final class Gateway {
         @JsonProperty("answers-topic")
         private String answersTopic;
 
-        @JsonProperty("session-parameter")
-        private String sessionParameter;
-
-        @JsonProperty("user-parameter")
-        private String userParameter;
+        List<KeyValueComparison> headers;
     }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/api/model/Gateways.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/api/model/Gateways.java
@@ -49,7 +49,8 @@ public class Gateways {
                                         (String) map.get("id"),
                                         (String) map.get("type"),
                                         (List<String>) map.get("parameters"),
-                                        (Map<String, Object>) map.get("authentication")))
+                                        (Map<String, Object>) map.get("authentication"),
+                                        (Map<String, Object>) map.get("chat-options")))
                 .collect(Collectors.toList());
     }
 
@@ -60,10 +61,12 @@ public class Gateways {
 
         public static final String TYPE_PRODUCE = "produce";
         public static final String TYPE_CONSUME = "consume";
+        public static final String TYPE_CHAT = "chat";
 
         String id;
         String type;
         List<String> parameters;
         Map<String, Object> authentication;
+        Map<String, Object> chatOptions;
     }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
@@ -22,6 +22,7 @@ import ai.langstream.cli.commands.RootGatewayCmd;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,31 +46,26 @@ public abstract class BaseGatewayCmd extends BaseCmd {
             Map<String, String> systemParams,
             Map<String, String> userParams,
             Map<String, String> options) {
-        String paramsPart = "";
-        String optionsPart = "";
-        String systemParamsPart = "";
+        List<String> queryString = new ArrayList<>();
         if (userParams != null) {
-            paramsPart =
-                    userParams.entrySet().stream()
+            userParams.entrySet().stream()
                             .map(e -> encodeParam(e, "param:"))
-                            .collect(Collectors.joining("&"));
+                            .forEach(queryString::add);
         }
 
         if (options != null) {
-            optionsPart =
-                    options.entrySet().stream()
+            options.entrySet().stream()
                             .map(e -> encodeParam(e, "option:"))
-                            .collect(Collectors.joining("&"));
+                            .forEach(queryString::add);
         }
 
         if (systemParams != null) {
-            systemParamsPart =
-                    systemParams.entrySet().stream()
+            systemParams.entrySet().stream()
                             .map(e -> encodeParam(e, ""))
-                            .collect(Collectors.joining("&"));
+                            .forEach(queryString::add);
         }
 
-        return String.join("&", List.of(systemParamsPart, paramsPart, optionsPart));
+        return queryString.stream().collect(Collectors.joining("&"));
     }
 
     private static String encodeParam(Map.Entry<String, String> e, String prefix) {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
@@ -49,20 +49,18 @@ public abstract class BaseGatewayCmd extends BaseCmd {
         List<String> queryString = new ArrayList<>();
         if (userParams != null) {
             userParams.entrySet().stream()
-                            .map(e -> encodeParam(e, "param:"))
-                            .forEach(queryString::add);
+                    .map(e -> encodeParam(e, "param:"))
+                    .forEach(queryString::add);
         }
 
         if (options != null) {
             options.entrySet().stream()
-                            .map(e -> encodeParam(e, "option:"))
-                            .forEach(queryString::add);
+                    .map(e -> encodeParam(e, "option:"))
+                    .forEach(queryString::add);
         }
 
         if (systemParams != null) {
-            systemParams.entrySet().stream()
-                            .map(e -> encodeParam(e, ""))
-                            .forEach(queryString::add);
+            systemParams.entrySet().stream().map(e -> encodeParam(e, "")).forEach(queryString::add);
         }
 
         return queryString.stream().collect(Collectors.joining("&"));

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.websocket.CloseReason;
 import java.net.URI;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.CancellationException;
@@ -28,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
@@ -39,16 +41,18 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
     @CommandLine.Parameters(description = "Application ID")
     private String applicationId;
 
+    // optional
+    @CommandLine.Parameters(arity = "1..2", description = "Chat gateway ID")
+    private String chatGatewayId;
+
     @CommandLine.Option(
             names = {"-cg", "--consume-from-gateway"},
-            description = "Consume from gateway",
-            required = true)
+            description = "Consume from gateway")
     private String consumeFromGatewayId;
 
     @CommandLine.Option(
             names = {"-pg", "--produce-to-gateway"},
-            description = "Produce to gateway",
-            required = true)
+            description = "Produce to gateway")
     private String produceToGatewayId;
 
     @CommandLine.Option(
@@ -75,7 +79,160 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
     @Override
     @SneakyThrows
     public void run() {
+        GatewayConnection connection = createGatewayConnection();
+
+        AtomicBoolean waitingProduceResponse = new AtomicBoolean(false);
+        AtomicBoolean waitingConsumeMessage = new AtomicBoolean(false);
+
+        final AtomicReference<CompletableFuture<Void>> loop = new AtomicReference<>();
+
+        final Consumer<Map> onProducerResponse =
+                map -> {
+                    final String status = (String) map.getOrDefault("status", "OK");
+                    if (!"OK".equals(status)) {
+                        err(String.format("Error sending message, got response: %s", map));
+                    } else {
+                        logUser("✅");
+                    }
+                    waitingProduceResponse.set(false);
+                };
+
+        final Consumer<Map> onConsumerMessage =
+                map -> {
+                    final Map<String, Object> record = (Map<String, Object>) map.get("record");
+                    Map<String, String> headers = (Map<String, String>) record.get("headers");
+                    boolean isStreamingOutput = false;
+                    boolean isLastMessage = false;
+                    int streamIndex = -1;
+                    if (headers != null) {
+                        String streamLastMessage = headers.get("stream-last-message");
+                        if (streamLastMessage != null) {
+                            isStreamingOutput = true;
+                            isLastMessage = Boolean.parseBoolean(streamLastMessage + "");
+                            streamIndex =
+                                    Integer.parseInt(headers.getOrDefault("stream-index", "-1"));
+                        }
+                    }
+                    if (isStreamingOutput) {
+                        if (streamIndex == 1) {
+                            logServer("Server:");
+                        }
+                        logNoNewline(String.valueOf(record.get("value")));
+                        if (isLastMessage) {
+                            logServer("\n");
+                            logServer(".");
+                            waitingConsumeMessage.set(false);
+                        }
+                    } else {
+                        logServer("\n");
+                        logServer("Server:");
+                        log(String.valueOf(record.get("value")));
+                        waitingConsumeMessage.set(false);
+                    }
+                };
+
+        final Consumer<CloseReason> onClose =
+                closeReason -> {
+                    if (closeReason.getCloseCode() != CloseReason.CloseCodes.NORMAL_CLOSURE) {
+                        err(
+                                String.format(
+                                        "Server closed connection with unexpected code: %s %s",
+                                        closeReason.getCloseCode(), closeReason.getReasonPhrase()));
+                    }
+                    final CompletableFuture<Void> future = loop.get();
+                    future.cancel(true);
+                };
+        try {
+            connection.start(onConsumerMessage, onProducerResponse, onClose);
+
+            final CompletableFuture<Void> future =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try {
+                                    Scanner scanner = new Scanner(System.in);
+                                    while (true) {
+                                        logUser("\nYou:");
+                                        logUserNoNewLine("> ");
+                                        String line = scanner.nextLine().trim();
+                                        if (line.isBlank()) {
+                                            continue;
+                                        }
+                                        connection.produce(
+                                                messageMapper.writeValueAsString(
+                                                        new ProduceGatewayCmd.ProduceRequest(
+                                                                null, line, Map.of())));
+                                        waitingProduceResponse.set(true);
+                                        waitingConsumeMessage.set(true);
+                                        while (waitingProduceResponse.get()) {
+                                            Thread.sleep(500);
+                                            if (waitingProduceResponse.get()) {
+                                                logUserNoNewLine(".");
+                                            }
+                                        }
+                                        while (waitingConsumeMessage.get()) {
+                                            Thread.sleep(500);
+                                            if (waitingConsumeMessage.get()) {
+                                                logUserNoNewLine(".");
+                                            }
+                                        }
+                                    }
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                } catch (JsonProcessingException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+            loop.set(future);
+            try {
+                future.join();
+            } catch (CancellationException cancel) {
+                // ignore
+            }
+        } finally {
+            connection.close();
+        }
+    }
+
+    private GatewayConnection createGatewayConnection() {
+        if (chatGatewayId != null && (produceToGatewayId != null || consumeFromGatewayId != null)) {
+            throw new IllegalArgumentException(
+                    "Cannot specify both chat gateway id and produce/--consume-from-gateway");
+        }
+        if (produceToGatewayId != null && consumeFromGatewayId == null) {
+            throw new IllegalArgumentException(
+                    "Cannot specify --produce-to-gateway without --consume-from-gateway");
+        }
+        if (consumeFromGatewayId != null && produceToGatewayId == null) {
+            throw new IllegalArgumentException(
+                    "Cannot specify --consume-from-gateway without --produce-to-gateway");
+        }
+
         final Map<String, String> consumeGatewayOptions = Map.of("position", "latest");
+        final Duration connectTimeout =
+                connectTimeoutSeconds > 0 ? Duration.ofSeconds(connectTimeoutSeconds) : null;
+
+        if (chatGatewayId != null) {
+            final Map<String, String> finalParams = new HashMap<>();
+            final Map<String, String> generatedParams =
+                    generatedParamsForChatGateway(applicationId, chatGatewayId);
+            if (generatedParams != null) {
+                finalParams.putAll(generatedParams);
+            }
+            if (params != null) {
+                finalParams.putAll(params);
+            }
+            final String url =
+                    validateGatewayAndGetUrl(
+                            applicationId,
+                            chatGatewayId,
+                            Gateways.Gateway.TYPE_CHAT,
+                            finalParams,
+                            consumeGatewayOptions,
+                            credentials,
+                            testCredentials);
+            return new ChatGatewayConnection(url, connectTimeout);
+        }
+
         final String consumePath =
                 validateGatewayAndGetUrl(
                         applicationId,
@@ -94,181 +251,7 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
                         Map.of(),
                         credentials,
                         testCredentials);
-
-        final Duration connectTimeout =
-                connectTimeoutSeconds > 0 ? Duration.ofSeconds(connectTimeoutSeconds) : null;
-
-        AtomicBoolean waitingProduceResponse = new AtomicBoolean(false);
-        AtomicBoolean waitingConsumeMessage = new AtomicBoolean(false);
-        CountDownLatch consumerReady = new CountDownLatch(1);
-
-        final AtomicReference<CompletableFuture<Void>> loop = new AtomicReference<>();
-
-        final WebSocketClient.Handler produceHandler =
-                new WebSocketClient.Handler() {
-
-                    @Override
-                    public void onOpen() {
-                        log(String.format("Connected to %s", producePath));
-                    }
-
-                    @Override
-                    @SneakyThrows
-                    public void onMessage(String msg) {
-                        final Map response = messageMapper.readValue(msg, Map.class);
-                        final String status = (String) response.getOrDefault("status", "OK");
-                        if (!"OK".equals(status)) {
-                            err(String.format("Error sending message: %s", msg));
-                        } else {
-                            logUser("✅");
-                        }
-                        waitingProduceResponse.set(false);
-                    }
-
-                    @Override
-                    public void onClose(CloseReason closeReason) {
-                        if (closeReason.getCloseCode() != CloseReason.CloseCodes.NORMAL_CLOSURE) {
-                            err(
-                                    String.format(
-                                            "Server closed connection with unexpected code: %s %s",
-                                            closeReason.getCloseCode(),
-                                            closeReason.getReasonPhrase()));
-                        }
-                        final CompletableFuture<Void> future = loop.get();
-                        future.cancel(true);
-                    }
-
-                    @Override
-                    public void onError(Throwable throwable) {
-                        err(String.format("Connection error: %s", throwable.getMessage()));
-                    }
-                };
-
-        final WebSocketClient.Handler consumeHandler =
-                new WebSocketClient.Handler() {
-
-                    @Override
-                    public void onOpen() {
-                        log(String.format("Connected to %s", consumePath));
-                        consumerReady.countDown();
-                    }
-
-                    @Override
-                    @SneakyThrows
-                    public void onMessage(String msg) {
-                        try {
-                            final Map response = messageMapper.readValue(msg, Map.class);
-                            final Map<String, Object> record =
-                                    (Map<String, Object>) response.get("record");
-                            Map<String, String> headers =
-                                    (Map<String, String>) record.get("headers");
-                            boolean isStreamingOutput = false;
-                            boolean isLastMessage = false;
-                            int streamIndex = -1;
-                            if (headers != null) {
-                                String streamLastMessage = headers.get("stream-last-message");
-                                if (streamLastMessage != null) {
-                                    isStreamingOutput = true;
-                                    isLastMessage = Boolean.parseBoolean(streamLastMessage + "");
-                                    streamIndex =
-                                            Integer.parseInt(
-                                                    headers.getOrDefault("stream-index", "-1"));
-                                }
-                            }
-                            if (isStreamingOutput) {
-                                if (streamIndex == 1) {
-                                    logServer("Server:");
-                                }
-                                logNoNewline(String.valueOf(record.get("value")));
-                                if (isLastMessage) {
-                                    logServer("\n");
-                                    logServer(".");
-                                    waitingConsumeMessage.set(false);
-                                }
-                            } else {
-                                logServer("\n");
-                                logServer("Server:");
-                                log(String.valueOf(record.get("value")));
-                                waitingConsumeMessage.set(false);
-                            }
-                        } catch (Throwable e) {
-                            err(String.format("Error consuming message: %s", msg));
-                        }
-                    }
-
-                    @Override
-                    @SneakyThrows
-                    public void onClose(CloseReason closeReason) {
-                        if (closeReason.getCloseCode() != CloseReason.CloseCodes.NORMAL_CLOSURE) {
-                            err(
-                                    String.format(
-                                            "Server closed connection with unexpected code: %s %s",
-                                            closeReason.getCloseCode(),
-                                            closeReason.getReasonPhrase()));
-                        }
-                        final CompletableFuture<Void> future = loop.get();
-                        future.cancel(true);
-                    }
-
-                    @Override
-                    public void onError(Throwable throwable) {
-                        err(String.format("Connection error: %s", throwable.getMessage()));
-                    }
-                };
-        try (final WebSocketClient ignored =
-                new WebSocketClient(consumeHandler)
-                        .connect(URI.create(consumePath), connectTimeout)) {
-            try (final WebSocketClient produceClient =
-                    new WebSocketClient(produceHandler)
-                            .connect(URI.create(producePath), connectTimeout)) {
-
-                consumerReady.await();
-
-                final CompletableFuture<Void> future =
-                        CompletableFuture.runAsync(
-                                () -> {
-                                    try {
-                                        Scanner scanner = new Scanner(System.in);
-                                        while (true) {
-                                            logUser("\nYou:");
-                                            logUserNoNewLine("> ");
-                                            String line = scanner.nextLine().trim();
-                                            if (line.isBlank()) {
-                                                continue;
-                                            }
-                                            produceClient.send(
-                                                    messageMapper.writeValueAsString(
-                                                            new ProduceGatewayCmd.ProduceRequest(
-                                                                    null, line, Map.of())));
-                                            waitingProduceResponse.set(true);
-                                            waitingConsumeMessage.set(true);
-                                            while (waitingProduceResponse.get()) {
-                                                Thread.sleep(500);
-                                                if (waitingProduceResponse.get()) {
-                                                    logUserNoNewLine(".");
-                                                }
-                                            }
-                                            while (waitingConsumeMessage.get()) {
-                                                Thread.sleep(500);
-                                                if (waitingConsumeMessage.get()) {
-                                                    logUserNoNewLine(".");
-                                                }
-                                            }
-                                        }
-                                    } catch (InterruptedException e) {
-                                        Thread.currentThread().interrupt();
-                                    } catch (JsonProcessingException e) {
-                                        throw new RuntimeException(e);
-                                    }
-                                });
-                loop.set(future);
-                try {
-                    future.join();
-                } catch (CancellationException cancel) {
-                    // ignore
-                }
-            }
-        }
+        return new ProduceConsumeGatewaysConnection(consumePath, producePath, connectTimeout);
     }
 
     private void logUser(String message) {
@@ -284,5 +267,209 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
     private void logServer(String message) {
         log("\u001B[32m" + message + "\u001B[0m");
         command.commandLine().getOut().flush();
+    }
+
+    private class ProduceConsumeGatewaysConnection implements GatewayConnection {
+        private final String consumePath;
+        private final String producePath;
+        private final Duration connectTimeout;
+
+        private WebSocketClient consumeClient;
+        private WebSocketClient produceClient;
+
+        public ProduceConsumeGatewaysConnection(
+                String consumePath, String producePath, Duration connectTimeout) {
+            this.consumePath = consumePath;
+            this.producePath = producePath;
+            this.connectTimeout = connectTimeout;
+        }
+
+        @Override
+        @SneakyThrows
+        public void start(
+                Consumer<Map> onConsumeMessage,
+                Consumer<Map> onProducerResponse,
+                Consumer<CloseReason> onClose) {
+            CountDownLatch consumerReady = new CountDownLatch(1);
+            consumeClient =
+                    new WebSocketClient(
+                                    new WebSocketClient.Handler() {
+
+                                        @Override
+                                        public void onOpen() {
+                                            log(String.format("Connected to %s", consumePath));
+                                            consumerReady.countDown();
+                                        }
+
+                                        @Override
+                                        public void onMessage(String msg) {
+
+                                            try {
+                                                final Map response =
+                                                        messageMapper.readValue(msg, Map.class);
+                                                onConsumeMessage.accept(response);
+                                            } catch (Throwable error) {
+                                                err(
+                                                        String.format(
+                                                                "Error consuming message: %s %s",
+                                                                msg, error.getMessage()));
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onClose(CloseReason closeReason) {
+                                            onClose.accept(closeReason);
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            err(
+                                                    String.format(
+                                                            "Connection error: %s",
+                                                            throwable.getMessage()));
+                                        }
+                                    })
+                            .connect(URI.create(consumePath), connectTimeout);
+            produceClient =
+                    new WebSocketClient(
+                                    new WebSocketClient.Handler() {
+                                        @Override
+                                        public void onOpen() {
+                                            log(String.format("Connected to %s", producePath));
+                                        }
+
+                                        @Override
+                                        public void onMessage(String msg) {
+                                            try {
+                                                final Map response =
+                                                        messageMapper.readValue(msg, Map.class);
+                                                onProducerResponse.accept(response);
+                                            } catch (Throwable error) {
+                                                err(
+                                                        String.format(
+                                                                "Error consuming producer response: %s %s",
+                                                                msg, error.getMessage()));
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onClose(CloseReason closeReason) {
+                                            onClose.accept(closeReason);
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            err(
+                                                    String.format(
+                                                            "Connection error: %s",
+                                                            throwable.getMessage()));
+                                        }
+                                    })
+                            .connect(URI.create(producePath), connectTimeout);
+            consumerReady.await();
+        }
+
+        @Override
+        public void produce(String message) {
+            produceClient.send(message);
+        }
+
+        @Override
+        @SneakyThrows
+        public void close() {
+            if (consumeClient != null) {
+                consumeClient.close();
+            }
+            if (produceClient != null) {
+                produceClient.close();
+            }
+        }
+    }
+
+    private interface GatewayConnection extends AutoCloseable {
+
+        void start(
+                Consumer<Map> onConsumeMessage,
+                Consumer<Map> onProducerResponse,
+                Consumer<CloseReason> onClose);
+
+        void produce(String message);
+    }
+
+    private class ChatGatewayConnection implements GatewayConnection {
+        private final String gatewayPath;
+        private final Duration connectTimeout;
+
+        private WebSocketClient client;
+
+        public ChatGatewayConnection(String gatewayPath, Duration connectTimeout) {
+            this.gatewayPath = gatewayPath;
+            this.connectTimeout = connectTimeout;
+        }
+
+        @Override
+        @SneakyThrows
+        public void start(
+                Consumer<Map> onConsumeMessage,
+                Consumer<Map> onProducerResponse,
+                Consumer<CloseReason> onClose) {
+            CountDownLatch consumerReady = new CountDownLatch(1);
+            client =
+                    new WebSocketClient(
+                                    new WebSocketClient.Handler() {
+
+                                        @Override
+                                        public void onOpen() {
+                                            log(String.format("Connected to %s", gatewayPath));
+                                            consumerReady.countDown();
+                                        }
+
+                                        @Override
+                                        public void onMessage(String msg) {
+                                            try {
+                                                final Map response =
+                                                        messageMapper.readValue(msg, Map.class);
+                                                if (response.containsKey("status")) {
+                                                    onProducerResponse.accept(response);
+                                                } else {
+                                                    onConsumeMessage.accept(response);
+                                                }
+                                            } catch (Throwable error) {
+                                                err(
+                                                        String.format(
+                                                                "Error consuming message: %s %s",
+                                                                msg, error.getMessage()));
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onClose(CloseReason closeReason) {
+                                            onClose.accept(closeReason);
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            err(
+                                                    String.format(
+                                                            "Connection error: %s",
+                                                            throwable.getMessage()));
+                                        }
+                                    })
+                            .connect(URI.create(gatewayPath), connectTimeout);
+            consumerReady.await();
+        }
+
+        @Override
+        public void produce(String message) {
+            client.send(message);
+        }
+
+        @Override
+        @SneakyThrows
+        public void close() {
+            if (client != null) {
+                client.close();
+            }
+        }
     }
 }

--- a/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/ApplicationPlaceholderResolver.java
@@ -186,10 +186,7 @@ public class ApplicationPlaceholderResolver {
             }
 
             final String topic = resolveValue(context, gateway.getTopic());
-            final String eventsTopic =
-                    gateway.getEventsTopic() == null
-                            ? null
-                            : resolveValue(context, gateway.getEventsTopic());
+            final String eventsTopic = resolveValue(context, gateway.getEventsTopic());
             newGateways.add(
                     new Gateway(
                             gateway.getId(),
@@ -245,6 +242,9 @@ public class ApplicationPlaceholderResolver {
     private record Placeholder(String key, String value, String finalReplacement) {}
 
     static String resolveValue(Map<String, Object> context, String template) {
+        if (template == null) {
+            return null;
+        }
         List<Placeholder> placeholders = new ArrayList<>();
         placeholders.add(new Placeholder("{{% ", "{__MUSTACHE_ESCAPING_PREFIX ", "{{ "));
         placeholders.add(

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -332,7 +332,11 @@ public class ModelBuilder {
         if (gateway.getType() == Gateway.GatewayType.consume) {
             if (gateway.getProduceOptions() != null) {
                 throw new IllegalArgumentException(
-                        "Gateway of type 'consume' cannot have produce options");
+                        "Gateway of type 'consume' cannot have produce-options");
+            }
+            if (gateway.getChatOptions() != null) {
+                throw new IllegalArgumentException(
+                        "Gateway of type 'consume' cannot have chat-options");
             }
             if (gateway.getConsumeOptions() != null) {
                 if (gateway.getConsumeOptions().filters() != null) {
@@ -346,7 +350,38 @@ public class ModelBuilder {
         } else if (gateway.getType() == Gateway.GatewayType.produce) {
             if (gateway.getConsumeOptions() != null) {
                 throw new IllegalArgumentException(
-                        "Gateway of type 'produce' cannot have consume options");
+                        "Gateway of type 'produce' cannot have consume-options");
+            }
+            if (gateway.getChatOptions() != null) {
+                throw new IllegalArgumentException(
+                        "Gateway of type 'produce' cannot have chat-options");
+            }
+        } else if (gateway.getType() == Gateway.GatewayType.chat) {
+            if (gateway.getConsumeOptions() != null) {
+                throw new IllegalArgumentException(
+                        "Gateway of type 'chat' cannot have consume-options");
+            }
+            if (gateway.getProduceOptions() != null) {
+                throw new IllegalArgumentException(
+                        "Gateway of type 'chat' cannot have produce-options");
+            }
+            if (gateway.getTopic() != null) {
+                throw new IllegalArgumentException(
+                        "Gateway of type 'chat' cannot have topic. Use chat-options.question-topic and chat-options.answers-topic instead");
+            }
+            final Gateway.ChatOptions chatOptions = gateway.getChatOptions();
+            if (chatOptions == null) {
+                throw new IllegalArgumentException("Gateway of type 'chat' must have chat-options");
+            }
+
+            if (chatOptions.getAnswersTopic() == null) {
+                throw new IllegalArgumentException(
+                        "Gateway of type 'chat' must have chat-options.answers-topic");
+            }
+
+            if (chatOptions.getQuestionsTopic() == null) {
+                throw new IllegalArgumentException(
+                        "Gateway of type 'chat' must have chat-options.questions-topic");
             }
         }
     }


### PR DESCRIPTION
In many cases, the application declares two gateways for both producing and consuming messages at the end and beginning of the pipeline. This results in two connection opened to the gateway and hard configuration in the CLI. 
It would be useful to have a simpler gateway that does both in only one connection and optimized for the chat-like communication.

Changes: 
* Added a new type 'chat' to the gateway types

```
- id: chat
   type: chat
   authentication:
      provider: google
      configuration:
        clientId: "{{ secrets.google.client-id }}"
   chat-options:
      headers:
      - value-from-parameters: session-id
      - value-from-authentication: user-id
      answers-topic: output-topic
      user-parameter: subject
```
*questions-topic*: (required). Topic for producing messages. Typically the input topic of the pipeline
*answers-topic*: (required). Topic for reading messages. Typically the output topic of the pipeline
*headers*: (optional). When set, they become a required parameters to be passed to the gateway connection (like `parameters` in other gateway types). All the `value-from-parameters` are generated automatically by the CLI. 

The producer and consumer implicitly uses *session-parameter* and *user-parameter* to append headers to the produced messages and use them as consumer filters. 

The above chat example is functionally equivalent to:
```
- id: produce-input-auth-google
  type: produce
  topic: input-topic
  parameters:
    - session-id
  authentication:
      provider: google
      configuration:
        clientId: "{{ secrets.google.client-id }}"
    produce-options:
      headers:
        - key: subject
          value-from-authentication: subject
        - key: session-id
          value-from-parameters: session-id

  - id: consume-output-auth-google
    type: consume
    topic: output-topic
    parameters:
      - session-id
    authentication:
      provider: google
      configuration:
        clientId: "{{ secrets.google.client-id }}"
    consume-options:
      filters:
        headers:
          - key: subject
            value-from-authentication: subject
          - key: session-id
            value-from-parameters: session-id
```


* In the CLI you can connect to a chat gateway just by adding the id
```
langstream  gateway chat app chat -c TOKEN 
```
All the required parameters will be automatically generated by the CLI (UUID).