### PR TITLE
Change the default provider to OpenAI

### DIFF
--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -26,7 +26,7 @@ secrets:
     data:
       access-key: "${OPEN_AI_ACCESS_KEY:-}"
       url: "${OPEN_AI_URL:-}"
-      provider: "${OPEN_AI_PROVIDER:-azure}"
+      provider: "${OPEN_AI_PROVIDER:-openai}"
       embeddings-model: "${OPEN_AI_EMBEDDINGS_MODEL:-text-embedding-ada-002}"
       chat-completions-model: "${OPEN_AI_CHAT_COMPLETIONS_MODEL:-gpt-35-turbo}"
   - id: vertex-ai

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -28,7 +28,7 @@ secrets:
       url: "${OPEN_AI_URL:-}"
       provider: "${OPEN_AI_PROVIDER:-openai}"
       embeddings-model: "${OPEN_AI_EMBEDDINGS_MODEL:-text-embedding-ada-002}"
-      chat-completions-model: "${OPEN_AI_CHAT_COMPLETIONS_MODEL:-gpt-35-turbo}"
+      chat-completions-model: "${OPEN_AI_CHAT_COMPLETIONS_MODEL:-gpt-3.5-turbo}"
   - id: vertex-ai
     data:
       url: "${VERTEX_AI_URL:-https://us-central1-aiplatform.googleapis.com}"


### PR DESCRIPTION
The default provider should be OpenAI, not Azure. The average user is more likely to have an OpenAI key, which is quite easy to get, than an Azure key. By defaulting to `openai` there is one less env var to set for in the quick start path.