### PR TITLE
Add workflow for needs-doc label

### DIFF
--- a/.github/workflows/needs-doc.yml
+++ b/.github/workflows/needs-doc.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add issue to project
+    name: Add labeled PR to project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@0.5.0
@@ -15,4 +15,3 @@ jobs:
           project-url: https://github.com/orgs/LangStream/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: needs-doc
-          label-operator: AND

--- a/.github/workflows/needs-doc.yml
+++ b/.github/workflows/needs-doc.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@RELEASE_VERSION
+      - uses: actions/add-to-project@0.5.0
         with:
           project-url: https://github.com/orgs/LangStream/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/needs-doc.yml
+++ b/.github/workflows/needs-doc.yml
@@ -1,0 +1,18 @@
+name: Add pull requests with needs-doc label to documentation project
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/LangStream/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: needs-doc
+          label-operator: AND


### PR DESCRIPTION
This [workflow](https://github.com/actions/add-to-project) adds pull requests with the `needs-doc` label to the documentation backlog project.
The ADD_TO_PROJECT_PAT is used for the action.
It should keep the docs backlog updated with less noise for all.