### PR TITLE
[cli] "langstream run docker" command: start the webservices and other improvements

### DIFF
--- a/langstream-api-gateway/pom.xml
+++ b/langstream-api-gateway/pom.xml
@@ -194,6 +194,21 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<phase>package</phase>
+						<configuration>
+							<classifier>original</classifier>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/ApplicationStartupTraces.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/ApplicationStartupTraces.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Objects;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+
+final class ApplicationStartupTraces {
+
+    private static final String SEPARATOR = "-".repeat(58);
+    private static final String BREAK = "\n";
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationStartupTraces.class);
+
+    private ApplicationStartupTraces() {}
+
+    static String of(Environment environment) {
+        Objects.requireNonNull(environment, "Environment must not be null");
+
+        return new ApplicationStartupTracesBuilder()
+                .append(BREAK)
+                .appendSeparator()
+                .append(applicationRunningTrace(environment))
+                .append(localUrl(environment))
+                .append(externalUrl(environment))
+                .append(profilesTrace(environment))
+                .appendSeparator()
+                .append(configServer(environment))
+                .build();
+    }
+
+    private static String applicationRunningTrace(Environment environment) {
+        String applicationId = environment.getProperty("spring.application.name");
+
+        if (StringUtils.isBlank(applicationId)) {
+            return "Application is running!";
+        }
+
+        return "Application '%s' is running!".formatted(applicationId);
+    }
+
+    private static String localUrl(Environment environment) {
+        return url("Local", "localhost", environment);
+    }
+
+    private static String externalUrl(Environment environment) {
+        return url("External", hostAddress(), environment);
+    }
+
+    private static String url(String type, String host, Environment environment) {
+        if (notWebEnvironment(environment)) {
+            return null;
+        }
+
+        return "%s: \t%s://%s:%s%s"
+                .formatted(
+                        type,
+                        protocol(environment),
+                        host,
+                        port(environment),
+                        contextPath(environment));
+    }
+
+    private static boolean notWebEnvironment(Environment environment) {
+        return StringUtils.isBlank(environment.getProperty("server.port"));
+    }
+
+    private static String protocol(Environment environment) {
+        if (noKeyStore(environment)) {
+            return "http";
+        }
+
+        return "https";
+    }
+
+    private static boolean noKeyStore(Environment environment) {
+        return StringUtils.isBlank(environment.getProperty("server.ssl.key-store"));
+    }
+
+    private static String port(Environment environment) {
+        return environment.getProperty("server.port");
+    }
+
+    private static String profilesTrace(Environment environment) {
+        String[] profiles = environment.getActiveProfiles();
+
+        if (ArrayUtils.isEmpty(profiles)) {
+            return null;
+        }
+
+        return "Profile(s): \t%s".formatted(String.join(", ", profiles));
+    }
+
+    private static String hostAddress() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            log.warn("The host name could not be determined, using `localhost` as fallback");
+        }
+
+        return "localhost";
+    }
+
+    private static String contextPath(Environment environment) {
+        String contextPath = environment.getProperty("server.servlet.context-path");
+
+        if (StringUtils.isBlank(contextPath)) {
+            return "/";
+        }
+
+        return contextPath;
+    }
+
+    private static String configServer(Environment environment) {
+        String configServer = environment.getProperty("configserver.status");
+
+        if (StringUtils.isBlank(configServer)) {
+            return null;
+        }
+
+        return "Config Server: %s%s%s%s".formatted(configServer, BREAK, SEPARATOR, BREAK);
+    }
+
+    private static class ApplicationStartupTracesBuilder {
+
+        private static final String SPACER = "  ";
+
+        private final StringBuilder trace = new StringBuilder();
+
+        public ApplicationStartupTracesBuilder appendSeparator() {
+            trace.append(SEPARATOR).append(BREAK);
+
+            return this;
+        }
+
+        public ApplicationStartupTracesBuilder append(String line) {
+            if (line == null) {
+                return this;
+            }
+
+            trace.append(SPACER).append(line).append(BREAK);
+
+            return this;
+        }
+
+        public String build() {
+            return trace.toString();
+        }
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/LangStreamApiGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/LangStreamApiGateway.java
@@ -34,7 +34,10 @@ public class LangStreamApiGateway {
 
     private static final Logger log = LoggerFactory.getLogger(LangStreamApiGateway.class);
 
-    public static void main(String[] args) {
+    public static void main(String... args) {
         Environment env = SpringApplication.run(LangStreamApiGateway.class, args).getEnvironment();
+        if (log.isInfoEnabled()) {
+            log.info(ApplicationStartupTraces.of(env));
+        }
     }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
@@ -24,6 +24,10 @@ public abstract class BaseDockerCmd extends BaseCmd {
 
     @CommandLine.ParentCommand private RootDockerCmd rootDockerCmd;
 
+    protected String getTenant() {
+        return getCurrentProfile().getTenant();
+    }
+
     @Override
     protected RootCmd getRootCmd() {
         return rootDockerCmd.getRootCmd();

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -27,6 +27,9 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "run", header = "Run on a docker container a LangStream application")
 public class LocalRunApplicationCmd extends BaseDockerCmd {
 
+    @CommandLine.Parameters(description = "Name of the application")
+    private String name;
+
     @CommandLine.Option(
             names = {"-app", "--application"},
             description = "Application directory path",
@@ -50,34 +53,60 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
     private boolean startS3 = true;
 
     @CommandLine.Option(
+            names = {"--start-webservices"},
+            description = "Start LangStream webservices")
+    private boolean startWebservices = true;
+
+    @CommandLine.Option(
+            names = {"--only-agent"},
+            description = "Run only one agent")
+    private String singleAgentId;
+
+    @CommandLine.Option(
             names = {"-s", "--secrets"},
             description = "Secrets file path")
     private String secretFilePath;
 
-    String appPath() {
-        return appPath;
-    }
+    @CommandLine.Option(
+            names = {"--memory"},
+            description = "Memory for the docker container")
+    private String memory;
 
-    String instanceFilePath() {
-        return instanceFilePath;
-    }
+    @CommandLine.Option(
+            names = {"--cpus"},
+            description = "CPU for the docker container")
+    private String cpus;
 
-    String secretFilePath() {
-        return secretFilePath;
-    }
+    @CommandLine.Option(
+            names = {"--docker-args"},
+            description = "Additional docker arguments")
+    private List<String> dockerAdditionalArgs = new ArrayList<>();
+
+    @CommandLine.Option(
+            names = {"--docker-command"},
+            description = "Command to run docker")
+    private String dockerCommand = "docker";
 
     @Override
     @SneakyThrows
     public void run() {
-        final File appDirectory = checkFileExistsOrDownload(appPath());
-        final File instanceFile = checkFileExistsOrDownload(instanceFilePath());
-        final File secretsFile = checkFileExistsOrDownload(secretFilePath());
+        final File appDirectory = checkFileExistsOrDownload(appPath);
+        final File instanceFile = checkFileExistsOrDownload(instanceFilePath);
+        final File secretsFile = checkFileExistsOrDownload(secretFilePath);
 
+        log("Tenant " + getTenant());
+        log("Application " + name);
         log("Application directory: " + appDirectory.getAbsolutePath());
+        if (singleAgentId != null && !singleAgentId.isEmpty()) {
+            log("Filter agent: " + singleAgentId);
+        } else {
+            log("Running all the agents in the application");
+        }
         log("Instance file: " + instanceFile.getAbsolutePath());
         log("Secrets file: " + secretsFile.getAbsolutePath());
         log("Start broker: " + startBroker);
         log("Start S3: " + startS3);
+        log("Start Webservices " + startWebservices);
 
         if ((appDirectory == null || instanceFile == null)) {
             throw new IllegalArgumentException("application and instance files are required");
@@ -113,15 +142,28 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
             throw e;
         }
 
-        executeOnDocker(appDirectory, instanceContents, secretsContents, startBroker, startS3);
+        executeOnDocker(
+                getTenant(),
+                name,
+                singleAgentId,
+                appDirectory,
+                instanceContents,
+                secretsContents,
+                startBroker,
+                startS3,
+                startWebservices);
     }
 
     private void executeOnDocker(
+            String tenant,
+            String applicationId,
+            String singleAgentId,
             File appDirectory,
             String instanceContents,
             String secretsContents,
             boolean startBroker,
-            boolean startS3)
+            boolean startS3,
+            boolean startWebservices)
             throws Exception {
         File tmpInstanceFile = Files.createTempFile("instance", ".yaml").toFile();
         Files.write(tmpInstanceFile.toPath(), instanceContents.getBytes(StandardCharsets.UTF_8));
@@ -129,7 +171,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         Files.write(tmpSecretsFile.toPath(), secretsContents.getBytes(StandardCharsets.UTF_8));
         String imageName = "langstream/langstream-runtime-tester:latest-dev";
         List<String> commandLine = new ArrayList<>();
-        commandLine.add("docker");
+        commandLine.add(dockerCommand);
         commandLine.add("run");
         commandLine.add("--rm");
         commandLine.add("-it");
@@ -137,6 +179,18 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         commandLine.add("START_BROKER=" + startBroker);
         commandLine.add("-e");
         commandLine.add("START_S3=" + startS3);
+        commandLine.add("-e");
+        commandLine.add("LANSGSTREAM_TESTER_TENANT=" + tenant);
+        commandLine.add("-e");
+        commandLine.add("LANSGSTREAM_TESTER_APPLICATIONID=" + applicationId);
+        commandLine.add("-e");
+        commandLine.add("LANSGSTREAM_TESTER_STARTWEBSERVICES=" + startWebservices);
+
+        if (singleAgentId != null && !singleAgentId.isEmpty()) {
+            commandLine.add("-e");
+            commandLine.add("LANSGSTREAM_TESTER_AGENTID=" + singleAgentId);
+        }
+
         commandLine.add("-v");
         commandLine.add(appDirectory.getAbsolutePath() + ":/code/application");
         commandLine.add("-v");
@@ -147,7 +201,34 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         commandLine.add("minio.minio-dev.svc.cluster.local:127.0.0.1");
         commandLine.add("--add-host");
         commandLine.add("my-cluster-kafka-bootstrap.kafka:127.0.0.1");
+        // gateway
+        commandLine.add("-p");
+        commandLine.add("8091:8091");
+        // web service
+        commandLine.add("-p");
+        commandLine.add("8090:8090");
+
+        if (memory != null && !memory.isEmpty()) {
+            commandLine.add("--memory");
+            commandLine.add(memory);
+        }
+
+        if (cpus != null && !cpus.isEmpty()) {
+            commandLine.add("--cpus");
+            commandLine.add(cpus);
+        }
+
+        if (dockerAdditionalArgs != null) {
+            commandLine.addAll(dockerAdditionalArgs);
+        }
+
         commandLine.add(imageName);
+
+        if (getRootCmd().isVerbose()) {
+            System.out.println("Executing:");
+            System.out.println(String.join(" ", commandLine));
+        }
+
         ProcessBuilder processBuilder = new ProcessBuilder(commandLine).inheritIO();
         Process process = processBuilder.start();
         process.waitFor();

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -1051,7 +1051,7 @@ public class AgentRunner {
 
     private void deployAsset(AssetDefinition asset, AssetManagerRegistry assetManagerRegistry)
             throws Exception {
-        log.info("Deploying asset {}", asset);
+        log.info("Deploying asset {} type {}", asset.getId(), asset.getAssetType());
         AssetManagerAndLoader assetManager =
                 assetManagerRegistry.getAssetManager(asset.getAssetType());
         if (assetManager == null) {

--- a/langstream-runtime/langstream-runtime-tester/pom.xml
+++ b/langstream-runtime/langstream-runtime-tester/pom.xml
@@ -36,6 +36,13 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>langstream-api-gateway</artifactId>
       <version>${project.version}</version>
+      <classifier>original</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-webservice</artifactId>
+      <version>${project.version}</version>
+      <classifier>original</classifier>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -85,7 +92,6 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
-
   </dependencies>
   <build>
     <plugins>

--- a/langstream-runtime/langstream-runtime-tester/pom.xml
+++ b/langstream-runtime/langstream-runtime-tester/pom.xml
@@ -34,6 +34,11 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>langstream-api-gateway</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>langstream-runtime-impl</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.tester;
+
+import ai.langstream.api.model.AgentLifecycleStatus;
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.ApplicationLifecycleStatus;
+import ai.langstream.api.model.ApplicationSpecs;
+import ai.langstream.api.model.ApplicationStatus;
+import ai.langstream.api.model.Secrets;
+import ai.langstream.api.model.StoredApplication;
+import ai.langstream.api.runner.code.AgentStatusResponse;
+import ai.langstream.api.runtime.ExecutionPlan;
+import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.deployer.k8s.agents.AgentResourcesFactory;
+import ai.langstream.deployer.k8s.api.crds.apps.SerializedApplicationInstance;
+import ai.langstream.runtime.agent.api.AgentInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+@Slf4j
+public class InMemoryApplicationStore implements ApplicationStore {
+
+    private static final ConcurrentHashMap<String, LocalApplication> APPLICATIONS =
+            new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, Secrets> SECRETS = new ConcurrentHashMap<>();
+
+    public interface AgentInfoCollector {
+        public Map<String, AgentInfo> collectAgentsStatus();
+    }
+
+    private static AgentInfoCollector agentsInfoCollector = Map::of;
+    private static Collection<String> filterAgents = null;
+
+    public static void setAgentsInfoCollector(AgentInfoCollector agentsInfoCollector) {
+        InMemoryApplicationStore.agentsInfoCollector = agentsInfoCollector;
+    }
+
+    public static void setFilterAgents(Collection<String> filterAgents) {
+        InMemoryApplicationStore.filterAgents = filterAgents;
+    }
+
+    @Override
+    public void validateTenant(String tenant, boolean failIfNotExists)
+            throws IllegalStateException {}
+
+    @Override
+    public void onTenantCreated(String tenant) {}
+
+    @Override
+    public void onTenantUpdated(String tenant) {}
+
+    @Override
+    public void onTenantDeleted(String tenant) {}
+
+    record LocalApplication(
+            String tenant,
+            String applicationId,
+            Application applicationInstance,
+            String codeArchiveReference,
+            ExecutionPlan executionPlan) {}
+
+    @Override
+    public void put(
+            String tenant,
+            String applicationId,
+            Application applicationInstance,
+            String codeArchiveReference,
+            ExecutionPlan executionPlan) {
+        APPLICATIONS.put(
+                getKey(tenant, applicationId),
+                new LocalApplication(
+                        tenant,
+                        applicationId,
+                        applicationInstance,
+                        codeArchiveReference,
+                        executionPlan));
+        SECRETS.put(getKey(tenant, applicationId), applicationInstance.getSecrets());
+    }
+
+    @Override
+    public StoredApplication get(String tenant, String applicationId, boolean queryPods) {
+        LocalApplication localApplication = APPLICATIONS.get(getKey(tenant, applicationId));
+        if (localApplication == null) {
+            return null;
+        }
+        return buildMockStoredApplication(localApplication, queryPods);
+    }
+
+    @Override
+    public ApplicationSpecs getSpecs(String tenant, String applicationId) {
+        LocalApplication localApplication = APPLICATIONS.get(getKey(tenant, applicationId));
+        if (localApplication == null) {
+            return null;
+        }
+        return new ApplicationSpecs(
+                applicationId,
+                localApplication.applicationInstance(),
+                localApplication.codeArchiveReference());
+    }
+
+    @Override
+    public Secrets getSecrets(String tenant, String applicationId) {
+        return SECRETS.get(getKey(tenant, applicationId));
+    }
+
+    @NotNull
+    private static String getKey(String tenant, String applicationId) {
+        return tenant + "-" + applicationId;
+    }
+
+    @Override
+    public void delete(String tenant, String applicationId) {
+        APPLICATIONS.remove(getKey(tenant, applicationId));
+        SECRETS.remove(getKey(tenant, applicationId));
+    }
+
+    @Override
+    public Map<String, StoredApplication> list(String tenant) {
+        return APPLICATIONS.values().stream()
+                .filter(a -> tenant.equals(a.tenant))
+                .collect(
+                        Collectors.toMap(
+                                LocalApplication::applicationId,
+                                a ->
+                                        InMemoryApplicationStore.buildMockStoredApplication(
+                                                a, false)));
+    }
+
+    @NotNull
+    private static StoredApplication buildMockStoredApplication(
+            LocalApplication a, boolean queryPods) {
+        return new StoredApplication(
+                a.applicationId,
+                a.applicationInstance,
+                a.codeArchiveReference,
+                buildMockApplicationStatus(a, queryPods));
+    }
+
+    @NotNull
+    private static ApplicationStatus buildMockApplicationStatus(
+            LocalApplication localApplication, boolean queryPods) {
+
+        SerializedApplicationInstance serializedApplicationInstance =
+                new SerializedApplicationInstance(
+                        localApplication.applicationInstance, localApplication.executionPlan);
+        Map<String, SerializedApplicationInstance.AgentRunnerDefinition> agentRunners =
+                serializedApplicationInstance.getAgentRunners();
+        List<String> declaredAgents = new ArrayList<>();
+
+        Map<String, AgentResourcesFactory.AgentRunnerSpec> agentRunnerSpecMap = new HashMap<>();
+        agentRunners.forEach(
+                (agentId, agentRunnerDefinition) -> {
+                    log.info("Adding agent id {} (def {})", agentId, agentRunnerDefinition);
+
+                    if (filterAgents != null
+                            && !filterAgents.contains(agentRunnerDefinition.getAgentId())) {
+                        log.info(
+                                "Ignoring agent id {} (filtered out, keep only {})",
+                                agentRunnerDefinition.getAgentId(),
+                                filterAgents);
+                        return;
+                    }
+
+                    // this agentId doesn't contain the "module" prefix
+                    declaredAgents.add(agentRunnerDefinition.getAgentId());
+                    agentRunnerSpecMap.put(
+                            agentId,
+                            AgentResourcesFactory.AgentRunnerSpec.builder()
+                                    .agentId(agentRunnerDefinition.getAgentId())
+                                    .agentType(agentRunnerDefinition.getAgentType())
+                                    .componentType(agentRunnerDefinition.getComponentType())
+                                    .configuration(agentRunnerDefinition.getConfiguration())
+                                    .inputTopic(agentRunnerDefinition.getInputTopic())
+                                    .outputTopic(agentRunnerDefinition.getOutputTopic())
+                                    .build());
+                });
+
+        Map<String, ApplicationStatus.AgentStatus> agents = new HashMap<>();
+
+        Map<String, AgentInfo> agentsInfo = agentsInfoCollector.collectAgentsStatus();
+
+        for (String declaredAgent : declaredAgents) {
+            ApplicationStatus.AgentStatus agentStatus = new ApplicationStatus.AgentStatus();
+            agentStatus.setStatus(AgentLifecycleStatus.DEPLOYED);
+            AgentResourcesFactory.AgentRunnerSpec agentRunnerSpec =
+                    agentRunnerSpecMap.values().stream()
+                            .filter(a -> a.getAgentId().equals(declaredAgent))
+                            .findFirst()
+                            .orElse(null);
+
+            if (agentRunnerSpec == null) {
+                throw new IllegalStateException("No agent runner spec for agent " + declaredAgent);
+            }
+
+            AgentInfo agentInfo = agentsInfo.get(declaredAgent);
+            Map<String, ApplicationStatus.AgentWorkerStatus> podStatuses =
+                    getPodStatuses(agentInfo, agentRunnerSpec, queryPods);
+            agentStatus.setWorkers(podStatuses);
+
+            agents.put(declaredAgent, agentStatus);
+        }
+
+        ApplicationStatus result = new ApplicationStatus();
+        result.setStatus(ApplicationLifecycleStatus.DEPLOYED);
+        result.setAgents(agents);
+        return result;
+    }
+
+    private static Map<String, ApplicationStatus.AgentWorkerStatus> getPodStatuses(
+            AgentInfo agentInfo,
+            final AgentResourcesFactory.AgentRunnerSpec agentRunnerSpec,
+            boolean queryPods) {
+
+        Map<String, ApplicationStatus.AgentWorkerStatus> result = new HashMap<>();
+        ApplicationStatus.AgentWorkerStatus agentWorkerStatus =
+                new ApplicationStatus.AgentWorkerStatus();
+        agentWorkerStatus.setStatus(ApplicationStatus.AgentWorkerStatus.Status.RUNNING);
+
+        // definition from the execution plan
+
+        agentWorkerStatus =
+                agentWorkerStatus.withAgentSpec(
+                        agentRunnerSpec.getAgentId(),
+                        agentRunnerSpec.getAgentType(),
+                        agentRunnerSpec.getComponentType(),
+                        agentRunnerSpec.getConfiguration(),
+                        agentRunnerSpec.getInputTopic(),
+                        agentRunnerSpec.getOutputTopic());
+
+        if (queryPods) {
+            // status of the agents
+            List<AgentStatusResponse> agentStatusResponses = agentInfo.serveWorkerStatus();
+            agentWorkerStatus = agentWorkerStatus.applyAgentStatus(agentStatusResponses);
+        }
+
+        result.put("docker", agentWorkerStatus);
+        return result;
+    }
+
+    @Override
+    public Map<String, Integer> getResourceUsage(String tenant) {
+        notSupported();
+        return null;
+    }
+
+    @Override
+    public List<PodLogHandler> logs(String tenant, String applicationId, LogOptions logOptions) {
+        notSupported();
+        return null;
+    }
+
+    @Override
+    public String storeType() {
+        return "memory";
+    }
+
+    @Override
+    public void initialize(Map<String, Object> configuration) {}
+
+    private void notSupported() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/KubeTestServer.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/KubeTestServer.java
@@ -120,7 +120,7 @@ public class KubeTestServer implements AutoCloseable {
                                             mapper.readValue(
                                                     byteArrayOutputStream.toByteArray(),
                                                     AgentCustomResource.class);
-                                    log.info("received patch request for agent {}", agentId);
+                                    log.debug("received patch request for agent {}", agentId);
                                     currentAgents.put(agentId, agent);
                                     return agent;
                                 } catch (IOException e) {
@@ -135,7 +135,7 @@ public class KubeTestServer implements AutoCloseable {
                     .andReply(
                             HttpURLConnection.HTTP_OK,
                             recordedRequest -> {
-                                log.info("received get request for agent {}", agentId);
+                                log.debug("received get request for agent {}", agentId);
                                 return currentAgents.get(agentId);
                             })
                     .always();
@@ -146,7 +146,7 @@ public class KubeTestServer implements AutoCloseable {
                     .andReply(
                             HttpURLConnection.HTTP_OK,
                             recordedRequest -> {
-                                log.info("received delete request for agent {}", agentId);
+                                log.debug("received delete request for agent {}", agentId);
                                 currentAgents.remove(agentId);
                                 return List.of();
                             })
@@ -175,7 +175,7 @@ public class KubeTestServer implements AutoCloseable {
                                             mapper.readValue(
                                                     byteArrayOutputStream.toByteArray(),
                                                     Secret.class);
-                                    log.info(
+                                    log.debug(
                                             "received patch request secret for agent {}: {}",
                                             agentId,
                                             secret);
@@ -193,7 +193,7 @@ public class KubeTestServer implements AutoCloseable {
                     .andReply(
                             HttpURLConnection.HTTP_OK,
                             recordedRequest -> {
-                                log.info("received delete request for secret agent {}", agentId);
+                                log.debug("received delete request for secret agent {}", agentId);
                                 currentAgentsSecrets.remove(agentId);
                                 return List.of();
                             })
@@ -281,7 +281,7 @@ public class KubeTestServer implements AutoCloseable {
                                             mapper.readValue(
                                                     byteArrayOutputStream.toByteArray(),
                                                     ApplicationCustomResource.class);
-                                    log.info("received patch request for app {}", appId);
+                                    log.debug("received patch request for app {}", appId);
                                     currentApplications.put(appId, app);
                                     return app;
                                 } catch (IOException e) {
@@ -314,7 +314,7 @@ public class KubeTestServer implements AutoCloseable {
                     .andReply(
                             HttpURLConnection.HTTP_OK,
                             recordedRequest -> {
-                                log.info("received delete request for app {}", appId);
+                                log.debug("received delete request for app {}", appId);
                                 currentApplications.remove(appId);
                                 return List.of();
                             })

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.runtime.tester;
 
+import ai.langstream.apigateway.LangStreamApiGateway;
 import ai.langstream.impl.parser.ModelBuilder;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +27,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Main {
     public static void main(String... args) {
+
+        Thread thread =
+                new Thread(
+                        () -> {
+                            LangStreamApiGateway.main(args);
+                        });
+        thread.setDaemon(true);
+        thread.start();
+
         try {
             String applicationPath = "/code/application";
             String instanceFile = "/code/instance.yaml";
@@ -90,6 +100,7 @@ public class Main {
                     runner.executeAgentRunners(applicationRuntime);
                 }
             }
+
         } catch (Throwable error) {
             error.printStackTrace();
         }

--- a/langstream-runtime/langstream-runtime-tester/src/main/resources/META-INF/services/ai.langstream.api.storage.ApplicationStore
+++ b/langstream-runtime/langstream-runtime-tester/src/main/resources/META-INF/services/ai.langstream.api.storage.ApplicationStore
@@ -1,0 +1,1 @@
+ai.langstream.runtime.tester.InMemoryApplicationStore

--- a/langstream-runtime/langstream-runtime-tester/src/main/resources/gateway.application.properties
+++ b/langstream-runtime/langstream-runtime-tester/src/main/resources/gateway.application.properties
@@ -1,0 +1,2 @@
+application.storage.apps.type=memory
+server.port=8091

--- a/langstream-runtime/langstream-runtime-tester/src/main/resources/webservice.application.properties
+++ b/langstream-runtime/langstream-runtime-tester/src/main/resources/webservice.application.properties
@@ -1,0 +1,15 @@
+
+server.port=8090
+
+
+spring.jackson.serialization.indent-output=true
+spring.jackson.serialization.order-map-entries-by-keys=true
+
+application.storage.global.type=local
+application.storage.apps.type=memory
+application.storage.apps.configuration.namespaceprefix=langstream-
+application.storage.apps.configuration.control-plane-url=http://localhost:8090
+application.storage.code.type=none
+application.tenants.default-tenant.create=true
+application.tenants.default-tenant.name=default
+application.apps.gateway.require-authentication=false

--- a/langstream-webservice/pom.xml
+++ b/langstream-webservice/pom.xml
@@ -250,6 +250,21 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<phase>package</phase>
+						<configuration>
+							<classifier>original</classifier>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/LangStreamControlPlaneWebApplication.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/LangStreamControlPlaneWebApplication.java
@@ -43,7 +43,7 @@ public class LangStreamControlPlaneWebApplication {
     private static final Logger log =
             LoggerFactory.getLogger(LangStreamControlPlaneWebApplication.class);
 
-    public static void main(String[] args) {
+    public static void main(String... args) {
         Environment env =
                 SpringApplication.run(LangStreamControlPlaneWebApplication.class, args)
                         .getEnvironment();

--- a/pom.xml
+++ b/pom.xml
@@ -774,7 +774,6 @@
         <module>langstream-kafka-runtime</module>
         <module>langstream-k8s-runtime</module>
         <module>langstream-codestorage-providers</module>
-        <module>langstream-runtime</module>
         <module>langstream-webservice</module>
         <module>langstream-k8s-storage</module>
         <module>langstream-k8s-deployer</module>
@@ -782,6 +781,7 @@
         <module>langstream-e2e-tests</module>
         <module>langstream-api-gateway</module>
         <module>langstream-api-gateway-auth</module>
+        <module>langstream-runtime</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
Summary:
- Now with the "langstream run docker" command the container runs also the Gateway API service and the Control Plane service
- This way when you run the application locally you can have almost the same user experience as while running on K8S or on a cloud provider
- Now you can also customise the "docker run" command by setting the name of the "docker" CLI command (--docker-command), resource requests (--memory, --cpus) and also you can pass additional arguments (--docker-additional-args)
- You can also now filter your application and run only one "agent" (actually and "executor") with the "--only-agent" option


Changes:
- build the jar artifact for the gateway and the webservice project
- implement the things above
- reduce some logging (we are printing too much on the logs, especially secrets)