### PR TITLE
[docker run] Make the version configurable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
             docker push $repo/$image:$docker_tag
           }
           tag_and_push langstream-runtime
+          tag_and_push langstream-runtime-tester
           tag_and_push langstream-cli
           tag_and_push langstream-deployer
           tag_and_push langstream-control-plane

--- a/examples/instances/kafka-docker.yaml
+++ b/examples/instances/kafka-docker.yaml
@@ -20,4 +20,4 @@ instance:
     type: "kafka"
     configuration:
       admin:
-        bootstrap.servers: localhost:39092
+        bootstrap.servers: localhost:9092

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/VersionProvider.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/VersionProvider.java
@@ -19,27 +19,32 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import picocli.CommandLine;
 
 public class VersionProvider implements CommandLine.IVersionProvider {
 
-    private static final String[] VERSION = new String[] {getVersionFromJar()};
+    private static final List<String> VERSION_INFO = getVersionFromJar();
 
-    public String[] getVersion() {
-        return VERSION;
+    public static String getMavenVersion() {
+        return VERSION_INFO.get(1);
     }
 
-    private static String getVersionFromJar() {
+    public String[] getVersion() {
+        return new String[] {VERSION_INFO.get(0)};
+    }
+
+    private static List<String> getVersionFromJar() {
         try {
             Manifest manifest = getManifest();
             final String version = getVersionFromManifest(manifest);
             final String gitRevision = getGitRevisionFromManifest(manifest);
-            return String.format("LangStream CLI %s (%s)", version, gitRevision);
+            return List.of(String.format("LangStream CLI %s (%s)", version, gitRevision), version);
         } catch (Throwable t) {
             // never ever let this exception bubble up otherwise any command will fail
-            return String.format("Error: %s", t.getMessage());
+            return List.of(String.format("Error: %s", t.getMessage()), "unknown");
         }
     }
 

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
@@ -41,8 +41,9 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
     @CommandLine.Parameters(description = "Application ID")
     private String applicationId;
 
-    // optional
-    @CommandLine.Parameters(arity = "1..2", description = "Chat gateway ID")
+    @CommandLine.Option(
+            names = {"-g", "--chat-gateway"},
+            description = "Use a 'chat' gateway")
     private String chatGatewayId;
 
     @CommandLine.Option(


### PR DESCRIPTION
Summary:
- allow to choose the docker image to use when running the "docker run" command
- fix a regression in the examples/instances/kafka-docker.yaml file
- fix a regression in the "gateway chat" command 