### PR TITLE
Introduce deletion-mode for topics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,7 @@ jobs:
         run: |
           chmod +x mvnw
           uname -m
-          eval $(minikube docker-env)
-          ./docker/build.sh
-          eval $(minikube docker-env -u)
+          ./dev/prepare-minikube-for-e2e-tests.sh
           ./mvnw install -pl langstream-e2e-tests -am -DskipTests
           ./mvnw verify -pl langstream-e2e-tests -De2eTests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
           fi
   e2e-tests:
     name: End to End tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    runs-on: LangStream-4-cores
+    timeout-minutes: 45
     steps:
       - name: 'Setup: checkout project'
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
       - name: Start minikube
         id: minikube
         uses: medyagh/setup-minikube@latest
+        with:
+          cpus: 4
+          memory: 8192
+          kubernetes-version: 1.26.3
       - uses: azure/setup-helm@v3
         with:
           version: v3.7.0

--- a/dev/prepare-minikube-for-e2e-tests.sh
+++ b/dev/prepare-minikube-for-e2e-tests.sh
@@ -1,0 +1,21 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.26.3
+eval $(minikube docker-env)
+./docker/build.sh
+eval $(minikube docker-env -u)

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraAssetsManagerProvider.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraAssetsManagerProvider.java
@@ -110,6 +110,11 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
                 }
             }
         }
+
+        @Override
+        public void deleteAsset() throws Exception {
+            throw new UnsupportedOperationException();
+        }
     }
 
     private static class CassandraKeyspaceAssetManager extends BaseCassandraAssetManager {
@@ -146,6 +151,11 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
                             e.toString());
                 }
             }
+        }
+
+        @Override
+        public void deleteAsset() throws Exception {
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -202,6 +212,11 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
                     throw new IllegalStateException("Error creating keyspace", e);
                 }
             }
+        }
+
+        @Override
+        public void deleteAsset() throws Exception {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/langstream-api/src/main/java/ai/langstream/api/model/TopicDefinition.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/TopicDefinition.java
@@ -32,18 +32,23 @@ public class TopicDefinition {
     public static final String CREATE_MODE_NONE = "none";
     public static final String CREATE_MODE_CREATE_IF_NOT_EXISTS = "create-if-not-exists";
 
+    public static final String DELETE_MODE_NONE = "none";
+    public static final String DELETE_MODE_DELETE = "delete";
+
     public TopicDefinition() {
         creationMode = CREATE_MODE_NONE;
+        deletionMode = DELETE_MODE_NONE;
     }
 
     public static TopicDefinition fromName(String name) {
         return new TopicDefinition(
-                name, CREATE_MODE_NONE, false, 0, null, null, Map.of(), Map.of());
+                name, CREATE_MODE_NONE, DELETE_MODE_NONE, false, 0, null, null, Map.of(), Map.of());
     }
 
     public TopicDefinition(
             String name,
             String creationMode,
+            String deletionMode,
             boolean implicit,
             int partitions,
             SchemaDefinition keySchema,
@@ -53,6 +58,7 @@ public class TopicDefinition {
         this();
         this.name = name;
         this.creationMode = Objects.requireNonNullElse(creationMode, CREATE_MODE_NONE);
+        this.deletionMode = Objects.requireNonNullElse(deletionMode, DELETE_MODE_NONE);
         this.implicit = implicit;
         this.partitions = partitions;
         this.keySchema = keySchema;
@@ -66,6 +72,9 @@ public class TopicDefinition {
 
     @JsonProperty("creation-mode")
     private String creationMode;
+
+    @JsonProperty("deletion-mode")
+    private String deletionMode;
 
     // Kafka Admin special configuration options
     private Map<String, Object> config;
@@ -87,10 +96,21 @@ public class TopicDefinition {
         }
     }
 
+    private void validateDeletionMode() {
+        switch (deletionMode) {
+            case DELETE_MODE_DELETE:
+            case DELETE_MODE_NONE:
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid deletion mode: " + deletionMode);
+        }
+    }
+
     public TopicDefinition copy() {
         TopicDefinition copy = new TopicDefinition();
         copy.setName(name);
         copy.setCreationMode(creationMode);
+        copy.setDeletionMode(deletionMode);
         copy.setImplicit(implicit);
         copy.setPartitions(partitions);
         copy.setKeySchema(keySchema);

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManager.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManager.java
@@ -26,5 +26,7 @@ public interface AssetManager {
 
     void deployAsset() throws Exception;
 
+    void deleteAsset() throws Exception;
+
     default void close() throws Exception {}
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerAndLoader.java
@@ -59,6 +59,11 @@ public record AssetManagerAndLoader(AssetManager agentCode, ClassLoader classLoa
             }
 
             @Override
+            public void deleteAsset() throws Exception {
+                executeWithContextClassloader(agentCode -> agentCode.deleteAsset());
+            }
+
+            @Override
             public void close() throws Exception {
                 executeWithContextClassloader(agentCode -> agentCode.close());
             }

--- a/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
@@ -354,6 +354,7 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
                 new TopicDefinition(
                         name,
                         creationMode,
+                        TopicDefinition.CREATE_MODE_NONE,
                         inputTopicDefinition.isImplicit(),
                         inputTopicDefinition.getPartitions(),
                         inputTopicDefinition.getKeySchema(),
@@ -372,18 +373,20 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
             AgentConfiguration agentConfiguration,
             StreamingClusterRuntime streamingClusterRuntime) {
         // connecting two agents requires an intermediate topic
-        String name = "agent-" + agentConfiguration.getId() + "-input";
+        final String name = "agent-" + agentConfiguration.getId() + "-input";
         log.info(
                 "Automatically creating topic {} in order to connect as input for agent {}",
                 name,
                 agentConfiguration.getId());
         // short circuit...the Pulsar Runtime works only with Pulsar Topics on the same Pulsar
         // Cluster
-        String creationMode = TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS;
+        final String creationMode = TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS;
+        final String deletionMode = TopicDefinition.DELETE_MODE_NONE;
         TopicDefinition topicDefinition =
                 new TopicDefinition(
                         name,
                         creationMode,
+                        deletionMode,
                         true,
                         DEFAULT_PARTITIONS_FOR_IMPLICIT_TOPICS,
                         null,

--- a/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
@@ -161,8 +161,7 @@ public final class ApplicationDeployer implements AutoCloseable {
      * @param executionPlan the application plan
      * @param codeStorageArchiveId the code storage archive id
      */
-    public void delete(
-            String tenant, ExecutionPlan executionPlan, String codeStorageArchiveId) {
+    public void delete(String tenant, ExecutionPlan executionPlan, String codeStorageArchiveId) {
         Application applicationInstance = executionPlan.getApplication();
         ComputeClusterRuntime clusterRuntime =
                 registry.getClusterRuntime(applicationInstance.getInstance().computeCluster());
@@ -176,7 +175,6 @@ public final class ApplicationDeployer implements AutoCloseable {
                 codeStorageArchiveId,
                 deployContext);
     }
-
 
     /**
      * Cleanup all the resources associated with an application.
@@ -196,7 +194,6 @@ public final class ApplicationDeployer implements AutoCloseable {
                         .asTopicConnectionsRuntime();
         topicConnectionsRuntime.delete(executionPlan);
     }
-
 
     @Override
     public void close() {

--- a/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/deploy/ApplicationDeployer.java
@@ -155,14 +155,15 @@ public final class ApplicationDeployer implements AutoCloseable {
     }
 
     /**
-     * Delete the application instance and all the resources associated with it.
+     * Undeploy the application and delete all the agents.
      *
-     * @param physicalApplicationInstance the application instance
+     * @param tenant
+     * @param executionPlan the application plan
      * @param codeStorageArchiveId the code storage archive id
      */
     public void delete(
-            String tenant, ExecutionPlan physicalApplicationInstance, String codeStorageArchiveId) {
-        Application applicationInstance = physicalApplicationInstance.getApplication();
+            String tenant, ExecutionPlan executionPlan, String codeStorageArchiveId) {
+        Application applicationInstance = executionPlan.getApplication();
         ComputeClusterRuntime clusterRuntime =
                 registry.getClusterRuntime(applicationInstance.getInstance().computeCluster());
         StreamingClusterRuntime streamingClusterRuntime =
@@ -170,11 +171,32 @@ public final class ApplicationDeployer implements AutoCloseable {
                         applicationInstance.getInstance().streamingCluster());
         clusterRuntime.delete(
                 tenant,
-                physicalApplicationInstance,
+                executionPlan,
                 streamingClusterRuntime,
                 codeStorageArchiveId,
                 deployContext);
     }
+
+
+    /**
+     * Cleanup all the resources associated with an application.
+     *
+     * @param tenant
+     * @param executionPlan the application instance
+     */
+    public void cleanup(String tenant, ExecutionPlan executionPlan) {
+        cleanupTopics(executionPlan);
+    }
+
+    private void cleanupTopics(ExecutionPlan executionPlan) {
+        TopicConnectionsRuntime topicConnectionsRuntime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(
+                                executionPlan.getApplication().getInstance().streamingCluster())
+                        .asTopicConnectionsRuntime();
+        topicConnectionsRuntime.delete(executionPlan);
+    }
+
 
     @Override
     public void close() {

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -455,6 +455,7 @@ public class ModelBuilder {
                         new TopicDefinition(
                                 topicDefinition.getName(),
                                 topicDefinition.getCreationMode(),
+                                topicDefinition.getDeletionMode(),
                                 false,
                                 topicDefinition.getPartitions(),
                                 topicDefinition.getKeySchema(),
@@ -630,6 +631,9 @@ public class ModelBuilder {
 
         @JsonProperty("creation-mode")
         private String creationMode;
+
+        @JsonProperty("deletion-mode")
+        private String deletionMode;
 
         private SchemaDefinition schema;
 

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/BaseEndToEndTest.java
@@ -66,6 +66,7 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -79,6 +80,7 @@ public class BaseEndToEndTest implements TestWatcher {
     public static final File TEST_LOGS_DIR = new File("target", "e2e-test-logs");
     protected static final String TENANT_NAMESPACE_PREFIX = "ls-tenant-";
     protected static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+    protected static final String KAFKA_NAMESPACE = "kafka-ns";
 
     interface KubeServer {
         void start();
@@ -98,14 +100,7 @@ public class BaseEndToEndTest implements TestWatcher {
         public void ensureImage(String image) {}
 
         @Override
-        public void stop() {
-            try (final KubernetesClient client =
-                    new KubernetesClientBuilder()
-                            .withConfig(Config.fromKubeconfig(kubeServer.getKubeConfig()))
-                            .build()) {
-                client.namespaces().withName(namespace).delete();
-            }
-        }
+        public void stop() {}
 
         @Override
         @SneakyThrows
@@ -299,6 +294,11 @@ public class BaseEndToEndTest implements TestWatcher {
 
     public static CompletableFuture<String> execInPod(
             String podName, String containerName, String... cmds) {
+        return execInPodInNamespace(namespace, podName, containerName, cmds);
+    }
+
+    public static CompletableFuture<String> execInPodInNamespace(
+            String namespace, String podName, String containerName, String... cmds) {
 
         final String cmd = String.join(" ", cmds);
         log.info(
@@ -515,6 +515,12 @@ public class BaseEndToEndTest implements TestWatcher {
                 .serverSideApply();
     }
 
+    @AfterEach
+    public void cleanupAfterEach() {
+        cleanupAllEndToEndTestsNamespaces();
+        execInKafkaPod("rpk topic delete -r \".*\"");
+    }
+
     private static void cleanupAllEndToEndTestsNamespaces() {
         client.namespaces().withLabel("app", "ls-test").delete();
         client.namespaces().list().getItems().stream()
@@ -670,7 +676,7 @@ public class BaseEndToEndTest implements TestWatcher {
         client.resource(
                         new NamespaceBuilder()
                                 .withNewMetadata()
-                                .withName("kafka-ns")
+                                .withName(KAFKA_NAMESPACE)
                                 .endMetadata()
                                 .build())
                 .serverSideApply();
@@ -846,12 +852,19 @@ public class BaseEndToEndTest implements TestWatcher {
 
     private static void dumpResources(
             String filePrefix, Class<? extends HasMetadata> clazz, List<String> namespaces) {
-        for (String namespace : namespaces) {
-            client.resources(clazz)
-                    .inNamespace(namespace)
-                    .list()
-                    .getItems()
-                    .forEach(resource -> dumpResource(filePrefix, resource));
+        try {
+            for (String namespace : namespaces) {
+                client.resources(clazz)
+                        .inNamespace(namespace)
+                        .list()
+                        .getItems()
+                        .forEach(resource -> dumpResource(filePrefix, resource));
+            }
+        } catch (Throwable t) {
+            log.warn(
+                    "failed to dump resources of type {}: {}",
+                    clazz.getSimpleName(),
+                    t.getMessage());
         }
     }
 
@@ -921,5 +934,31 @@ public class BaseEndToEndTest implements TestWatcher {
         } catch (Throwable e) {
             log.error("failed to write events logs to file {}", outputFile, e);
         }
+    }
+
+    @SneakyThrows
+    protected static List<String> getAllTopicsFromKafka() {
+        final String result = execInKafkaPod("rpk topic list");
+        if (result == null) {
+            throw new IllegalStateException("failed to get topics from kafka");
+        }
+
+        final List<String> topics = new ArrayList<>();
+        final List<String> lines = result.lines().collect(Collectors.toList());
+        boolean first = true;
+        for (String line : lines) {
+            if (first) {
+                first = false;
+                continue;
+            }
+            topics.add(line.split(" ")[0]);
+        }
+        return topics;
+    }
+
+    @SneakyThrows
+    private static String execInKafkaPod(String cmd) {
+        return execInPodInNamespace(KAFKA_NAMESPACE, "redpanda-0", "redpanda", cmd.split(" "))
+                .get(1, TimeUnit.MINUTES);
     }
 }

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
@@ -82,40 +82,40 @@ public class PythonFunctionIT extends BaseEndToEndTest {
 
         executeCommandOnClient("bin/langstream apps delete %s".formatted(applicationId).split(" "));
 
-
         Awaitility.await()
                 .atMost(1, TimeUnit.MINUTES)
-                .untilAsserted(() -> {
-                    Assertions.assertNull(
-                            client.apps()
-                                    .statefulSets()
-                                    .inNamespace(tenantNamespace)
-                                    .withName(applicationId + "-test-python-processor")
-                                    .get());
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertNull(
+                                    client.apps()
+                                            .statefulSets()
+                                            .inNamespace(tenantNamespace)
+                                            .withName(applicationId + "-test-python-processor")
+                                            .get());
 
-                    Assertions.assertEquals(
-                            0,
-                            client.resources(AgentCustomResource.class)
-                                    .inNamespace(tenantNamespace)
-                                    .list()
-                                    .getItems()
-                                    .size());
+                            Assertions.assertEquals(
+                                    0,
+                                    client.resources(AgentCustomResource.class)
+                                            .inNamespace(tenantNamespace)
+                                            .list()
+                                            .getItems()
+                                            .size());
 
-                    Assertions.assertEquals(
-                            0,
-                            client.resources(ApplicationCustomResource.class)
-                                    .inNamespace(tenantNamespace)
-                                    .list()
-                                    .getItems()
-                                    .size());
+                            Assertions.assertEquals(
+                                    0,
+                                    client.resources(ApplicationCustomResource.class)
+                                            .inNamespace(tenantNamespace)
+                                            .list()
+                                            .getItems()
+                                            .size());
 
-                    Assertions.assertEquals(
-                            1,
-                            client.resources(Secret.class)
-                                    .inNamespace(tenantNamespace)
-                                    .list()
-                                    .getItems()
-                                    .size());
-                });
+                            Assertions.assertEquals(
+                                    1,
+                                    client.resources(Secret.class)
+                                            .inNamespace(tenantNamespace)
+                                            .list()
+                                            .getItems()
+                                            .size());
+                        });
     }
 }

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/PythonFunctionIT.java
@@ -19,6 +19,7 @@ import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
 import io.fabric8.kubernetes.api.model.Secret;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
@@ -117,5 +118,8 @@ public class PythonFunctionIT extends BaseEndToEndTest {
                                             .getItems()
                                             .size());
                         });
+
+        final List<String> topics = getAllTopicsFromKafka();
+        Assertions.assertEquals(List.of("TEST_TOPIC_0"), topics);
     }
 }

--- a/langstream-e2e-tests/src/test/resources/apps/python-processor/pipeline.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/python-processor/pipeline.yaml
@@ -27,6 +27,7 @@ topics:
       type: string
   - name: TEST_TOPIC_1
     creation-mode: create-if-not-exists
+    deletion-mode: delete
     schema:
       type: string
     keySchema:

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -271,7 +271,9 @@ public class AppResourcesFactory {
                                 .withName(ApplicationSetupConstants.APP_SECRETS_ENV)
                                 .withValue("/app-secrets/secrets")
                                 .build());
-        final List<String> args = List.of("application-setup", "deploy");
+        final String cmd = isDeleteJob ? "cleanup" : "deploy";
+
+        final List<String> args = List.of("application-setup", cmd);
         final String containerName = "setup";
         final Container container =
                 createContainer(

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -382,7 +382,7 @@ class AppResourcesFactoryTest {
                               containers:
                               - args:
                                 - application-setup
-                                - deploy
+                                - cleanup
                                 env:
                                 - name: LANGSTREAM_APPLICATION_SETUP_APP_CONFIGURATION
                                   value: /app-config/config

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
@@ -100,7 +100,9 @@ public class AppController extends BaseController<ApplicationCustomResource>
                     resource.getMetadata().getName(),
                     rescheduleDuration != null ? "not completed" : "completed");
         } else {
-            log.infof("deployer cleanup job for %s is not completed yet", resource.getMetadata().getName());
+            log.infof(
+                    "deployer cleanup job for %s is not completed yet",
+                    resource.getMetadata().getName());
         }
         return rescheduleDuration != null
                 ? DeleteControl.noFinalizerRemoval().rescheduleAfter(rescheduleDuration)

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
@@ -279,10 +279,16 @@ public class KafkaTopicConnectionsRuntime implements TopicConnectionsRuntime {
                         }
                     }
                 } else {
-                    log.info("Keeping Kafka topic {} since deletion-mode is {}", topic.name(), topic.deleteMode());
+                    log.info(
+                            "Keeping Kafka topic {} since deletion-mode is {}",
+                            topic.name(),
+                            topic.deleteMode());
                 }
             }
-            default -> log.info("Keeping Kafka topic {} since creation-mode is {}", topic.name(), topic.createMode());
+            default -> log.info(
+                    "Keeping Kafka topic {} since creation-mode is {}",
+                    topic.name(),
+                    topic.createMode());
         }
     }
 

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
@@ -265,20 +265,24 @@ public class KafkaTopicConnectionsRuntime implements TopicConnectionsRuntime {
     private void deleteTopic(AdminClient admin, KafkaTopic topic) {
         switch (topic.createMode()) {
             case TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS -> {
-                log.info("Deleting Kafka topic {}", topic.name());
-                try {
-                    admin.deleteTopics(List.of(topic.name()), new DeleteTopicsOptions())
-                            .all()
-                            .get();
-                } catch (ExecutionException e) {
-                    if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-                        log.info("Topic {} does not exist", topic.name());
-                    } else {
-                        throw e;
+                if (topic.deleteMode().equals(TopicDefinition.DELETE_MODE_DELETE)) {
+                    log.info("Deleting Kafka topic {}", topic.name());
+                    try {
+                        admin.deleteTopics(List.of(topic.name()), new DeleteTopicsOptions())
+                                .all()
+                                .get();
+                    } catch (ExecutionException e) {
+                        if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                            log.info("Topic {} does not exist", topic.name());
+                        } else {
+                            throw e;
+                        }
                     }
+                } else {
+                    log.info("Keeping Kafka topic {} since deletion-mode is {}", topic.name(), topic.deleteMode());
                 }
             }
-            default -> log.info("Keeping Kafka topic {}", topic.name());
+            default -> log.info("Keeping Kafka topic {} since creation-mode is {}", topic.name(), topic.createMode());
         }
     }
 

--- a/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaClusterRuntimeDockerTest.java
+++ b/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaClusterRuntimeDockerTest.java
@@ -109,7 +109,6 @@ class KafkaClusterRuntimeDockerTest {
         assertTrue(topics.contains("input-topic-2-partitions"));
         assertTrue(topics.contains("input-topic-delete"));
 
-
         deployer.cleanup("tenant", implementation);
         topics = admin.listTopics().names().get();
         log.info("Topics {}", topics);

--- a/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaClusterRuntimeDockerTest.java
+++ b/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaClusterRuntimeDockerTest.java
@@ -16,6 +16,7 @@
 package ai.langstream.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.langstream.api.model.Application;
@@ -60,7 +61,11 @@ class KafkaClusterRuntimeDockerTest {
                                     creation-mode: create-if-not-exists
                                   - name: "input-topic-2-partitions"
                                     creation-mode: create-if-not-exists
+                                    deletion-mode: none
                                     partitions: 2
+                                  - name: "input-topic-delete"
+                                    creation-mode: create-if-not-exists
+                                    deletion-mode: delete
                                 """),
                                 buildInstanceYaml(),
                                 null)
@@ -90,6 +95,7 @@ class KafkaClusterRuntimeDockerTest {
         log.info("Topics {}", topics);
         assertTrue(topics.contains("input-topic"));
         assertTrue(topics.contains("input-topic-2-partitions"));
+        assertTrue(topics.contains("input-topic-delete"));
 
         Map<String, TopicDescription> stats =
                 admin.describeTopics(Set.of("input-topic", "input-topic-2-partitions")).all().get();
@@ -97,11 +103,19 @@ class KafkaClusterRuntimeDockerTest {
         assertEquals(2, stats.get("input-topic-2-partitions").partitions().size());
 
         deployer.delete("tenant", implementation, null);
-        // delete should only delete the agents
         topics = admin.listTopics().names().get();
         log.info("Topics {}", topics);
         assertTrue(topics.contains("input-topic"));
         assertTrue(topics.contains("input-topic-2-partitions"));
+        assertTrue(topics.contains("input-topic-delete"));
+
+
+        deployer.cleanup("tenant", implementation);
+        topics = admin.listTopics().names().get();
+        log.info("Topics {}", topics);
+        assertTrue(topics.contains("input-topic"));
+        assertTrue(topics.contains("input-topic-2-partitions"));
+        assertFalse(topics.contains("input-topic-delete"));
     }
 
     private static String buildInstanceYaml() {

--- a/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
+++ b/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
@@ -80,6 +80,7 @@ class KafkaConsumerTest {
                                                 topics:
                                                   - name: %s
                                                     creation-mode: create-if-not-exists
+                                                    deletion-mode: delete
                                                     partitions: %d
                                                 """
                                                 .formatted(topicName, numPartitions)),
@@ -116,14 +117,7 @@ class KafkaConsumerTest {
         assertEquals(numPartitions, stats.get(topicName).partitions().size());
 
         deployer.delete("tenant", implementation, null);
-        topics = admin.listTopics().names().get();
-        log.info("Topics {}", topics);
-        assertTrue(topics.contains(topicName));
-        topicConnectionsRuntimeRegistry
-                .getTopicConnectionsRuntime(
-                        implementation.getApplication().getInstance().streamingCluster())
-                .asTopicConnectionsRuntime()
-                .delete(implementation);
+        deployer.cleanup("tenant", implementation);
         topics = admin.listTopics().names().get();
         log.info("Topics {}", topics);
         assertFalse(topics.contains(topicName));
@@ -215,6 +209,7 @@ class KafkaConsumerTest {
                                                 topics:
                                                   - name: %s
                                                     creation-mode: create-if-not-exists
+                                                    deletion-mode: delete
                                                     partitions: %d
                                                 """
                                                 .formatted(topicName, numPartitions)),
@@ -250,16 +245,9 @@ class KafkaConsumerTest {
         Map<String, TopicDescription> stats = admin.describeTopics(Set.of(topicName)).all().get();
         assertEquals(numPartitions, stats.get(topicName).partitions().size());
 
+        deployer.cleanup("tenant", implementation);
         deployer.delete("tenant", implementation, null);
-        topics = admin.listTopics().names().get();
-        log.info("Topics {}", topics);
-        assertTrue(topics.contains(topicName));
 
-        topicConnectionsRuntimeRegistry
-                .getTopicConnectionsRuntime(
-                        implementation.getApplication().getInstance().streamingCluster())
-                .asTopicConnectionsRuntime()
-                .delete(implementation);
         topics = admin.listTopics().names().get();
         log.info("Topics {}", topics);
         assertFalse(topics.contains(topicName));
@@ -322,6 +310,7 @@ class KafkaConsumerTest {
                                                 topics:
                                                   - name: %s
                                                     creation-mode: create-if-not-exists
+                                                    deletion-mode: delete
                                                     partitions: %d
                                                 """
                                                 .formatted(topicName, numPartitions)),
@@ -357,16 +346,8 @@ class KafkaConsumerTest {
         Map<String, TopicDescription> stats = admin.describeTopics(Set.of(topicName)).all().get();
         assertEquals(numPartitions, stats.get(topicName).partitions().size());
 
-        topics = admin.listTopics().names().get();
-        log.info("Topics {}", topics);
-        assertTrue(topics.contains(topicName));
-
-        topicConnectionsRuntimeRegistry
-                .getTopicConnectionsRuntime(
-                        implementation.getApplication().getInstance().streamingCluster())
-                .asTopicConnectionsRuntime()
-                .delete(implementation);
         deployer.delete("tenant", implementation, null);
+        deployer.cleanup("tenant", implementation);
         topics = admin.listTopics().names().get();
         log.info("Topics {}", topics);
         assertFalse(topics.contains(topicName));
@@ -423,6 +404,7 @@ class KafkaConsumerTest {
                                                 topics:
                                                   - name: %s
                                                     creation-mode: create-if-not-exists
+                                                    deletion-mode: delete
                                                     partitions: %d
                                                 """
                                                 .formatted(topicName, numPartitions)),
@@ -458,16 +440,10 @@ class KafkaConsumerTest {
         Map<String, TopicDescription> stats = admin.describeTopics(Set.of(topicName)).all().get();
         assertEquals(numPartitions, stats.get(topicName).partitions().size());
 
-        deployer.delete("tenant", implementation, null);
-        topics = admin.listTopics().names().get();
-        log.info("Topics {}", topics);
-        assertTrue(topics.contains(topicName));
 
-        topicConnectionsRuntimeRegistry
-                .getTopicConnectionsRuntime(
-                        implementation.getApplication().getInstance().streamingCluster())
-                .asTopicConnectionsRuntime()
-                .delete(implementation);
+        deployer.delete("tenant", implementation, null);
+        deployer.cleanup("tenant", implementation);
+
         topics = admin.listTopics().names().get();
         log.info("Topics {}", topics);
         assertFalse(topics.contains(topicName));

--- a/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
+++ b/langstream-kafka-runtime/src/test/java/ai/langstream/kafka/KafkaConsumerTest.java
@@ -440,7 +440,6 @@ class KafkaConsumerTest {
         Map<String, TopicDescription> stats = admin.describeTopics(Set.of(topicName)).all().get();
         assertEquals(numPartitions, stats.get(topicName).partitions().size());
 
-
         deployer.delete("tenant", implementation, null);
         deployer.cleanup("tenant", implementation);
 

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runtime/KafkaStreamingClusterRuntime.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runtime/KafkaStreamingClusterRuntime.java
@@ -57,6 +57,7 @@ public class KafkaStreamingClusterRuntime implements StreamingClusterRuntime {
                 topicDefinition.getKeySchema(),
                 topicDefinition.getValueSchema(),
                 creationMode,
+                topicDefinition.getDeletionMode(),
                 topicDefinition.isImplicit(),
                 configs,
                 options);

--- a/langstream-kafka/src/main/java/ai/langstream/kafka/runtime/KafkaTopic.java
+++ b/langstream-kafka/src/main/java/ai/langstream/kafka/runtime/KafkaTopic.java
@@ -31,6 +31,7 @@ public record KafkaTopic(
         SchemaDefinition keySchema,
         SchemaDefinition valueSchema,
         String createMode,
+        String deleteMode,
         boolean implicit,
         Map<String, Object> config,
         Map<String, Object> options)

--- a/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
+++ b/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
@@ -278,13 +278,19 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
             switch (topic.createMode()) {
                 case TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS -> {}
                 default -> {
-                    log.info("Keeping Pulsar topic {} since creation-mode is {}", topic.name(), topic.createMode());
+                    log.info(
+                            "Keeping Pulsar topic {} since creation-mode is {}",
+                            topic.name(),
+                            topic.createMode());
                     return;
                 }
             }
 
             if (!topic.deleteMode().equals(TopicDefinition.DELETE_MODE_DELETE)) {
-                log.info("Keeping Pulsar topic {} since deletion-mode is {}", topic.name(), topic.deleteMode());
+                log.info(
+                        "Keeping Pulsar topic {} since deletion-mode is {}",
+                        topic.name(),
+                        topic.deleteMode());
                 return;
             }
 

--- a/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
+++ b/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
@@ -278,9 +278,14 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
             switch (topic.createMode()) {
                 case TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS -> {}
                 default -> {
-                    log.info("Keeping Pulsar topic {}", topic.name());
+                    log.info("Keeping Pulsar topic {} since creation-mode is {}", topic.name(), topic.createMode());
                     return;
                 }
+            }
+
+            if (!topic.deleteMode().equals(TopicDefinition.DELETE_MODE_DELETE)) {
+                log.info("Keeping Pulsar topic {} since deletion-mode is {}", topic.name(), topic.deleteMode());
+                return;
             }
 
             String topicName =

--- a/langstream-pulsar/src/main/java/ai/langstream/pulsar/PulsarStreamingClusterRuntime.java
+++ b/langstream-pulsar/src/main/java/ai/langstream/pulsar/PulsarStreamingClusterRuntime.java
@@ -52,6 +52,7 @@ public class PulsarStreamingClusterRuntime implements StreamingClusterRuntime {
                 keySchema,
                 valueSchema,
                 creationMode,
+                topicDefinition.getDeletionMode(),
                 topicDefinition.isImplicit());
     }
 

--- a/langstream-pulsar/src/main/java/ai/langstream/pulsar/PulsarTopic.java
+++ b/langstream-pulsar/src/main/java/ai/langstream/pulsar/PulsarTopic.java
@@ -27,6 +27,7 @@ public record PulsarTopic(
         SchemaDefinition keySchema,
         SchemaDefinition valueSchema,
         String createMode,
+        String deleteMode,
         boolean implicit)
         implements ConnectionImplementation, Topic {
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/application/ApplicationSetupRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/application/ApplicationSetupRunner.java
@@ -54,11 +54,10 @@ public class ApplicationSetupRunner {
         log.info("Setup application {}", applicationId);
         final Application appInstance = parseApplicationInstance(configuration, secrets);
 
-        try (NarFileHandler narFileHandler =
-                     getNarFileHandler(packagesDirectory)) {
+        try (NarFileHandler narFileHandler = getNarFileHandler(packagesDirectory)) {
             narFileHandler.scan();
             try (ApplicationDeployer deployer =
-                         buildDeployer(clusterRuntimeConfiguration, narFileHandler)) {
+                    buildDeployer(clusterRuntimeConfiguration, narFileHandler)) {
                 final ExecutionPlan executionPlan =
                         deployer.createImplementation(applicationId, appInstance);
                 deployer.setup(configuration.getTenant(), executionPlan);
@@ -78,11 +77,10 @@ public class ApplicationSetupRunner {
         log.info("Cleanup application {}", applicationId);
         final Application appInstance = parseApplicationInstance(configuration, secrets);
 
-        try (NarFileHandler narFileHandler =
-                     getNarFileHandler(packagesDirectory)) {
+        try (NarFileHandler narFileHandler = getNarFileHandler(packagesDirectory)) {
             narFileHandler.scan();
             try (ApplicationDeployer deployer =
-                         buildDeployer(clusterRuntimeConfiguration, narFileHandler)) {
+                    buildDeployer(clusterRuntimeConfiguration, narFileHandler)) {
                 final ExecutionPlan executionPlan =
                         deployer.createImplementation(applicationId, appInstance);
 
@@ -94,12 +92,11 @@ public class ApplicationSetupRunner {
 
     private NarFileHandler getNarFileHandler(Path packagesDirectory) throws Exception {
         return new NarFileHandler(
-                packagesDirectory,
-                List.of(),
-                Thread.currentThread().getContextClassLoader());
+                packagesDirectory, List.of(), Thread.currentThread().getContextClassLoader());
     }
 
-    private Application parseApplicationInstance(ApplicationSetupConfiguration configuration, Secrets secrets)
+    private Application parseApplicationInstance(
+            ApplicationSetupConfiguration configuration, Secrets secrets)
             throws JsonProcessingException {
         final String applicationConfig = configuration.getApplication();
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/application/ApplicationSetupRunnerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/application/ApplicationSetupRunnerStarter.java
@@ -89,6 +89,8 @@ public class ApplicationSetupRunnerStarter extends RuntimeStarter {
         switch (arg0) {
             case "deploy" -> applicationSetupRunner.runSetup(
                     clusterRuntimeConfiguration, configuration, secrets, packagesDirectory);
+            case "cleanup" -> applicationSetupRunner.runCleanup(
+                    clusterRuntimeConfiguration, configuration, secrets, packagesDirectory);
             default -> throw new IllegalArgumentException("Unknown command " + arg0);
         }
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
@@ -86,7 +86,6 @@ public class MockAssetManagerCodeProvider implements AssetManagerProvider {
             if (!remove) {
                 throw new IllegalStateException("Asset not found: " + assetDefinition);
             }
-
         }
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
@@ -78,5 +78,15 @@ public class MockAssetManagerCodeProvider implements AssetManagerProvider {
             }
             DEPLOYED_ASSETS.add(assetDefinition);
         }
+
+        @Override
+        public synchronized void deleteAsset() throws Exception {
+            log.info("Deleting asset {}", assetDefinition);
+            final boolean remove = DEPLOYED_ASSETS.remove(assetDefinition);
+            if (!remove) {
+                throw new IllegalStateException("Asset not found: " + assetDefinition);
+            }
+
+        }
     }
 }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceValidateUpdateTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceValidateUpdateTest.java
@@ -41,41 +41,41 @@ class ApplicationServiceValidateUpdateTest {
         checkTopics(
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 true);
 
         checkTopics(
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic1", null, null, 0, null, null, null)),
+                                "input-topic1", null, null, null, 0, null, null, null)),
                 false);
 
         checkTopics(
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null),
+                                "input-topic", null, null, null, 0, null, null, null),
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic1", null, null, 0, null, null, null)),
+                                "input-topic1", null, null, null, 0, null, null, null)),
                 false);
 
         checkTopics(
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null),
+                                "input-topic", null, null, null, 0, null, null, null),
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic1", null, null, 0, null, null, null)),
+                                "input-topic1", null, null, null, 0, null, null, null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 false);
 
         checkTopics(
@@ -83,6 +83,7 @@ class ApplicationServiceValidateUpdateTest {
                         new ModelBuilder.TopicDefinitionModel(
                                 "input-topic",
                                 TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS,
+                                null,
                                 null,
                                 0,
                                 null,
@@ -92,6 +93,7 @@ class ApplicationServiceValidateUpdateTest {
                         new ModelBuilder.TopicDefinitionModel(
                                 "input-topic",
                                 TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS,
+                                null,
                                 null,
                                 0,
                                 null,
@@ -105,13 +107,14 @@ class ApplicationServiceValidateUpdateTest {
                                 "input-topic",
                                 TopicDefinition.CREATE_MODE_NONE,
                                 null,
+                                null,
                                 0,
                                 null,
                                 null,
                                 null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 true);
 
         checkTopics(
@@ -119,6 +122,7 @@ class ApplicationServiceValidateUpdateTest {
                         new ModelBuilder.TopicDefinitionModel(
                                 "input-topic",
                                 null,
+                                null,
                                 new SchemaDefinition("avro", "{}", null),
                                 0,
                                 null,
@@ -126,7 +130,7 @@ class ApplicationServiceValidateUpdateTest {
                                 null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 false);
 
         checkTopics(
@@ -134,6 +138,7 @@ class ApplicationServiceValidateUpdateTest {
                         new ModelBuilder.TopicDefinitionModel(
                                 "input-topic",
                                 null,
+                                null,
                                 new SchemaDefinition("avro", "{}", null),
                                 0,
                                 null,
@@ -142,6 +147,7 @@ class ApplicationServiceValidateUpdateTest {
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
                                 "input-topic",
+                                null,
                                 null,
                                 new SchemaDefinition("json", "{}", null),
                                 0,
@@ -155,6 +161,7 @@ class ApplicationServiceValidateUpdateTest {
                         new ModelBuilder.TopicDefinitionModel(
                                 "input-topic",
                                 null,
+                                null,
                                 new SchemaDefinition("avro", "{}", null),
                                 0,
                                 null,
@@ -163,6 +170,7 @@ class ApplicationServiceValidateUpdateTest {
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
                                 "input-topic",
+                                null,
                                 null,
                                 new SchemaDefinition("avro", "{schema:true}", null),
                                 0,
@@ -174,19 +182,19 @@ class ApplicationServiceValidateUpdateTest {
         checkTopics(
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 1, null, null, null)),
+                                "input-topic", null, null, null, 1, null, null, null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null)),
+                                "input-topic", null, null, null, 0, null, null, null)),
                 false);
 
         checkTopics(
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 1, null, null, null)),
+                                "input-topic", null, null, null, 1, null, null, null)),
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 2, null, null, null)),
+                                "input-topic", null, null, null, 2, null, null, null)),
                 false);
     }
 
@@ -659,9 +667,9 @@ class ApplicationServiceValidateUpdateTest {
         pipelineFileModel.setTopics(
                 List.of(
                         new ModelBuilder.TopicDefinitionModel(
-                                "input-topic", null, null, 0, null, null, null),
+                                "input-topic", null, null, null, 0, null, null, null),
                         new ModelBuilder.TopicDefinitionModel(
-                                "output-topic", null, null, 0, null, null, null)));
+                                "output-topic", null, null, null, 0, null, null, null)));
         pipelineFileModel.setPipeline(agents);
         Application applicationInstance =
                 ModelBuilder.buildApplicationInstance(


### PR DESCRIPTION
Changes:

* New option in the topic section `deletion-mode`
Possible values are `none`, `delete`
`none` is the default value.

`none` means to keep the topic when the app is deleted
`delete` means to delete the topic when the app is deleted

Note that `delete` works only if the `creation-mode` is `create-if-not-exists`. This is because in that case we know that we can actually manage that topic inside the langstream app.

Example:
```
topics:
  - name: input-topic
    creation-mode: create-if-not-exists
  - name: output-topic
    creation-mode: create-if-not-exists
    deletion-mode: delete
```

* Added a new setup-cleanup job right after the runtime deployer cleanup. The latter only deletes the agents. The new job is responsible to delete the topics (and the assets very soon)
* Added the app deletion in the e2e tests to ensure correct behaviour
