### PR TITLE
Introduce deletion-mode for assets

### DIFF
--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraAssetsManagerProvider.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraAssetsManagerProvider.java
@@ -60,10 +60,8 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
 
         @Override
         public boolean assetExists() throws Exception {
-            String tableName =
-                    ConfigurationUtils.getString("table-name", null, assetDefinition.getConfig());
-            String keySpace =
-                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
+            String tableName = getTableName();
+            String keySpace = getKeySpace();
             log.info("Checking is table {} exists in keyspace {}", tableName, keySpace);
 
             CqlSession session = datasource.getSession();
@@ -90,13 +88,21 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
             return table.isPresent();
         }
 
+        private String getTableName() {
+            String tableName =
+                    ConfigurationUtils.getString("table-name", null, assetDefinition.getConfig());
+            return tableName;
+        }
+
         @Override
         public void deployAsset() throws Exception {
-            String keySpace =
-                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
-
+            String keySpace = getKeySpace();
             List<String> statements =
                     ConfigurationUtils.getList("create-statements", assetDefinition.getConfig());
+            execStatements(keySpace, statements);
+        }
+
+        private void execStatements(String keySpace, List<String> statements) {
             for (String statement : statements) {
                 log.info("Executing: {}", statement);
                 SimpleStatement simpleStatement = SimpleStatement.newInstance(statement);
@@ -111,9 +117,23 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
             }
         }
 
+        private String getKeySpace() {
+            String keySpace =
+                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
+            return keySpace;
+        }
+
         @Override
-        public void deleteAsset() throws Exception {
-            throw new UnsupportedOperationException();
+        public boolean deleteAssetIfExists() throws Exception {
+            final String keySpace = getKeySpace();
+            List<String> statements =
+                    ConfigurationUtils.getList("delete-statements", assetDefinition.getConfig());
+            if (statements.isEmpty()) {
+                statements =
+                        List.of("DROP TABLE IF EXISTS %s.%s;".formatted(keySpace, getTableName()));
+            }
+            execStatements(keySpace, statements);
+            return true;
         }
     }
 
@@ -121,8 +141,7 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
 
         @Override
         public boolean assetExists() throws Exception {
-            String keySpace =
-                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
+            String keySpace = getKeyspace();
             log.info("Checking if keyspace {} exists", keySpace);
 
             CqlSession session = datasource.getSession();
@@ -136,11 +155,20 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
             return keyspace.isPresent();
         }
 
+        private String getKeyspace() {
+            String keySpace =
+                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
+            return keySpace;
+        }
+
         @Override
         public void deployAsset() throws Exception {
-
             List<String> statements =
                     ConfigurationUtils.getList("create-statements", assetDefinition.getConfig());
+            execStatements(statements);
+        }
+
+        private void execStatements(List<String> statements) {
             for (String statement : statements) {
                 log.info("Executing: {}", statement);
                 try {
@@ -154,8 +182,14 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
         }
 
         @Override
-        public void deleteAsset() throws Exception {
-            throw new UnsupportedOperationException();
+        public boolean deleteAssetIfExists() throws Exception {
+            List<String> statements =
+                    ConfigurationUtils.getList("delete-statements", assetDefinition.getConfig());
+            if (statements.isEmpty()) {
+                statements = List.of("DROP KEYSPACE IF EXISTS %s;".formatted(getKeyspace()));
+            }
+            execStatements(statements);
+            return true;
         }
     }
 
@@ -182,8 +216,7 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
 
         @Override
         public boolean assetExists() throws Exception {
-            String keySpace =
-                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
+            String keySpace = getKeyspace();
             log.info("Checking if keyspace {} exists", keySpace);
             DatabaseClient astraDbClient = datasource.buildAstraClient();
             boolean exist = astraDbClient.keyspaces().exist(keySpace);
@@ -193,8 +226,7 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
 
         @Override
         public void deployAsset() throws Exception {
-            String keySpace =
-                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
+            String keySpace = getKeyspace();
             DatabaseClient astraDbClient = datasource.buildAstraClient();
             try {
                 astraDbClient.keyspaces().create(keySpace);
@@ -214,9 +246,27 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
             }
         }
 
+        private String getKeyspace() {
+            String keySpace =
+                    ConfigurationUtils.getString("keyspace", null, assetDefinition.getConfig());
+            return keySpace;
+        }
+
         @Override
-        public void deleteAsset() throws Exception {
-            throw new UnsupportedOperationException();
+        public boolean deleteAssetIfExists() throws Exception {
+            String keySpace = getKeyspace();
+
+            log.info("Deleting keyspace {}", keySpace);
+            DatabaseClient astraDbClient = datasource.buildAstraClient();
+            try {
+                astraDbClient.keyspaces().delete(keySpace);
+                return true;
+            } catch (com.dtsx.astra.sdk.db.exception.KeyspaceNotFoundException e) {
+                log.info(
+                        "Keyspace does not exist, maybe it was deleted by another agent ({})",
+                        e.toString());
+                return false;
+            }
         }
     }
 

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraAssetsManagerProvider.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraAssetsManagerProvider.java
@@ -128,10 +128,6 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
             final String keySpace = getKeySpace();
             List<String> statements =
                     ConfigurationUtils.getList("delete-statements", assetDefinition.getConfig());
-            if (statements.isEmpty()) {
-                statements =
-                        List.of("DROP TABLE IF EXISTS %s.%s;".formatted(keySpace, getTableName()));
-            }
             execStatements(keySpace, statements);
             return true;
         }
@@ -185,9 +181,6 @@ public class CassandraAssetsManagerProvider implements AssetManagerProvider {
         public boolean deleteAssetIfExists() throws Exception {
             List<String> statements =
                     ConfigurationUtils.getList("delete-statements", assetDefinition.getConfig());
-            if (statements.isEmpty()) {
-                statements = List.of("DROP KEYSPACE IF EXISTS %s;".formatted(getKeyspace()));
-            }
             execStatements(statements);
             return true;
         }

--- a/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/AssetDefinition.java
@@ -32,14 +32,19 @@ public class AssetDefinition {
     public static final String CREATE_MODE_NONE = "none";
     public static final String CREATE_MODE_CREATE_IF_NOT_EXISTS = "create-if-not-exists";
 
+    public static final String DELETE_MODE_NONE = "none";
+    public static final String DELETE_MODE_DELETE = "delete";
+
     public AssetDefinition() {
         creationMode = CREATE_MODE_NONE;
+        deletionMode = DELETE_MODE_NONE;
     }
 
     public AssetDefinition(
             String id,
             String name,
             String creationMode,
+            String deletionMode,
             String assetType,
             Map<String, Object> config) {
         this();
@@ -48,7 +53,9 @@ public class AssetDefinition {
         this.name = name;
         this.config = config;
         this.creationMode = Objects.requireNonNullElse(creationMode, CREATE_MODE_NONE);
+        this.deletionMode = Objects.requireNonNullElse(deletionMode, DELETE_MODE_NONE);
         validateCreationMode();
+        validateDeletionMode();
     }
 
     private String id;
@@ -56,6 +63,9 @@ public class AssetDefinition {
 
     @JsonProperty("creation-mode")
     private String creationMode;
+
+    @JsonProperty("deletion-mode")
+    private String deletionMode;
 
     private Map<String, Object> config;
 
@@ -69,6 +79,16 @@ public class AssetDefinition {
                 break;
             default:
                 throw new IllegalArgumentException("Invalid creation mode: " + creationMode);
+        }
+    }
+
+    private void validateDeletionMode() {
+        switch (deletionMode) {
+            case DELETE_MODE_DELETE:
+            case DELETE_MODE_NONE:
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid deletion mode: " + deletionMode);
         }
     }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManager.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManager.java
@@ -26,7 +26,7 @@ public interface AssetManager {
 
     void deployAsset() throws Exception;
 
-    void deleteAsset() throws Exception;
+    boolean deleteAssetIfExists() throws Exception;
 
     default void close() throws Exception {}
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/assets/AssetManagerAndLoader.java
@@ -59,8 +59,8 @@ public record AssetManagerAndLoader(AssetManager agentCode, ClassLoader classLoa
             }
 
             @Override
-            public void deleteAsset() throws Exception {
-                executeWithContextClassloader(agentCode -> agentCode.deleteAsset());
+            public boolean deleteAssetIfExists() throws Exception {
+                return callWithContextClassloader(agentCode -> agentCode.deleteAssetIfExists());
             }
 
             @Override

--- a/langstream-core/src/main/java/ai/langstream/impl/assets/CassandraAssetsProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/assets/CassandraAssetsProvider.java
@@ -46,10 +46,12 @@ public class CassandraAssetsProvider extends AbstractAssetProvider {
                 requiredNonEmptyField(configuration, "table-name", describe(assetDefinition));
                 requiredNonEmptyField(configuration, "keyspace", describe(assetDefinition));
                 requiredListField(configuration, "create-statements", describe(assetDefinition));
+                checkDeleteStatements(assetDefinition, configuration);
             }
             case "cassandra-keyspace" -> {
                 requiredNonEmptyField(configuration, "keyspace", describe(assetDefinition));
                 requiredListField(configuration, "create-statements", describe(assetDefinition));
+                checkDeleteStatements(assetDefinition, configuration);
                 if (datasourceConfiguration.containsKey("secureBundle")
                         || datasourceConfiguration.containsKey("database")) {
                     throw new IllegalArgumentException("Use astra-keyspace for AstraDB services");
@@ -70,6 +72,18 @@ public class CassandraAssetsProvider extends AbstractAssetProvider {
             }
             default -> throw new IllegalStateException(
                     "Unexpected value: " + assetDefinition.getAssetType());
+        }
+    }
+
+    private static void checkDeleteStatements(
+            AssetDefinition assetDefinition, Map<String, Object> configuration) {
+        if (AssetDefinition.DELETE_MODE_DELETE.equals(assetDefinition.getDeletionMode())) {
+            requiredListField(configuration, "delete-statements", describe(assetDefinition));
+        } else {
+            if (configuration.containsKey("delete-statements")) {
+                throw new IllegalArgumentException(
+                        "delete-statements must be set only if deletion-mode=delete");
+            }
         }
     }
 

--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
@@ -75,6 +75,7 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
         asset.put("name", assetDefinition.getName());
         asset.put("asset-type", assetDefinition.getAssetType());
         asset.put("creation-mode", assetDefinition.getCreationMode());
+        asset.put("deletion-mode", assetDefinition.getDeletionMode());
         Map<String, Object> configuration = new HashMap<>();
         if (assetDefinition.getConfig() != null) {
             assetDefinition

--- a/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/BasicClusterRuntime.java
@@ -354,7 +354,7 @@ public abstract class BasicClusterRuntime implements ComputeClusterRuntime {
                 new TopicDefinition(
                         name,
                         creationMode,
-                        TopicDefinition.CREATE_MODE_NONE,
+                        inputTopicDefinition.getDeletionMode(),
                         inputTopicDefinition.isImplicit(),
                         inputTopicDefinition.getPartitions(),
                         inputTopicDefinition.getKeySchema(),

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -482,6 +482,7 @@ public class ModelBuilder {
                                 assetId,
                                 name,
                                 assetDefinition.getCreationMode(),
+                                assetDefinition.getDeletionMode(),
                                 assetDefinition.getAssetType(),
                                 assetDefinition.getConfig()));
             }
@@ -653,6 +654,9 @@ public class ModelBuilder {
 
         @JsonProperty("creation-mode")
         private String creationMode;
+
+        @JsonProperty("deletion-mode")
+        private String deletionMode;
 
         @JsonProperty("asset-type")
         private String assetType;

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/CassandraSinkIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/CassandraSinkIT.java
@@ -15,7 +15,6 @@
  */
 package ai.langstream.tests;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -68,7 +67,10 @@ public class CassandraSinkIT extends BaseEndToEndTest {
         copyFileToClientContainer(
                 Paths.get(testSecretBaseDir, "secret1.yaml").toFile(),
                 "/tmp/secrets.yaml",
-                file -> file.replace("CASSANDRA-HOST-INJECTED", cassandraHost));
+                file ->
+                        file.replace("CASSANDRA-HOST-INJECTED", cassandraHost)
+                                .replace("CASSANDRA-LOCAL-DC-INJECTED", "datacenter1")
+                                .replace("CASSANDRA-PORT-INJECTED", "9042"));
 
         executeCommandOnClient(
                 "bin/langstream apps deploy %s -app /tmp/cassandra-sink -i /tmp/instance.yaml -s /tmp/secrets.yaml"
@@ -112,7 +114,9 @@ public class CassandraSinkIT extends BaseEndToEndTest {
                                 fail("Keyspace vsearch should not exist anymore");
                             } catch (Throwable t) {
                                 log.info("Got exception: {}", t.getMessage());
-                                assertEquals(t.getMessage(), "'vsearch' not found in keyspaces");
+                                assertTrue(
+                                        t.getMessage()
+                                                .contains("'vsearch' not found in keyspaces"));
                             }
                         });
     }

--- a/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/configuration.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/configuration.yaml
@@ -16,6 +16,14 @@
 #
 
 configuration:
+  resources:
+    - type: "vector-database"
+      name: "CassandraDatasource"
+      configuration:
+        service: "cassandra"
+        contact-points: "{{{ secrets.cassandra.contact-points }}}"
+        loadBalancing-localDc: "{{{ secrets.cassandra.local-dc }}}"
+        port: "{{{ secrets.cassandra.port }}}"
   dependencies:
     - name: "Kafka Connect Sink for Apache Cassandra from DataStax"
       url: "https://github.com/datastax/kafka-sink/releases/download/1.5.0/kafka-connect-cassandra-sink-1.5.0.jar"

--- a/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/pipeline.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/pipeline.yaml
@@ -17,6 +17,26 @@
 module: "module-1"
 id: "pipeline-1"
 name: "Write to Cassandra"
+assets:
+  - name: "vsearch-keyspace"
+    asset-type: "cassandra-keyspace"
+    creation-mode: create-if-not-exists
+    deletion-mode: delete
+    config:
+      keyspace: "vsearch"
+      datasource: "CassandraDatasource"
+      create-statements:
+        - "CREATE KEYSPACE vsearch WITH REPLICATION = {'class' : 'SimpleStrategy','replication_factor' : 1};"
+  - name: "documents-table"
+    asset-type: "cassandra-table"
+    creation-mode: create-if-not-exists
+    config:
+      table-name: "documents"
+      keyspace: "vsearch"
+      datasource: "CassandraDatasource"
+      create-statements:
+        - "CREATE TABLE IF NOT EXISTS vsearch.products (id int PRIMARY KEY, name TEXT, description TEXT);"
+        - "INSERT INTO vsearch.products(id, name, description) VALUES (1, 'test-init', 'test-init');"
 topics:
   - name: "TEST_TOPIC_C1"
     creation-mode: create-if-not-exists

--- a/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/pipeline.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/cassandra-sink/pipeline.yaml
@@ -27,6 +27,8 @@ assets:
       datasource: "CassandraDatasource"
       create-statements:
         - "CREATE KEYSPACE vsearch WITH REPLICATION = {'class' : 'SimpleStrategy','replication_factor' : 1};"
+      delete-statements:
+        - "DROP KEYSPACE IF EXISTS vsearch;"
   - name: "documents-table"
     asset-type: "cassandra-table"
     creation-mode: create-if-not-exists

--- a/langstream-e2e-tests/src/test/resources/secrets/secret1.yaml
+++ b/langstream-e2e-tests/src/test/resources/secrets/secret1.yaml
@@ -24,3 +24,5 @@ secrets:
     id: cassandra
     data:
       contact-points: CASSANDRA-HOST-INJECTED
+      local-dc: CASSANDRA-LOCAL-DC-INJECTED
+      port: CASSANDRA-PORT-INJECTED

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AstraDBAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AstraDBAssetQueryWriteIT.java
@@ -116,7 +116,7 @@ class AstraDBAssetQueryWriteIT extends AbstractApplicationRunner {
 
         try (ApplicationRuntime applicationRuntime =
                 deployApplicationWithSecrets(
-                        tenant, "app", application, buildInstanceYaml(), secrets, expectedAgents)) {
+                        tenant, "app", application, buildInstanceYaml(), null, expectedAgents)) {
             try (KafkaProducer<String, String> producer = createProducer();
                     KafkaConsumer<String, String> consumer = createConsumer("output-topic")) {
 
@@ -128,6 +128,8 @@ class AstraDBAssetQueryWriteIT extends AbstractApplicationRunner {
                         List.of(
                                 "{\"documentId\":2,\"queryresult\":{\"name\":\"A\",\"description\":\"A description\",\"id\":\"1\"},\"name\":\"A\",\"description\":\"A description\"}"));
             }
+
+            applicationDeployer.cleanup(tenant, applicationRuntime.implementation());
         }
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AstraDBAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AstraDBAssetQueryWriteIT.java
@@ -116,7 +116,7 @@ class AstraDBAssetQueryWriteIT extends AbstractApplicationRunner {
 
         try (ApplicationRuntime applicationRuntime =
                 deployApplicationWithSecrets(
-                        tenant, "app", application, buildInstanceYaml(), null, expectedAgents)) {
+                        tenant, "app", application, buildInstanceYaml(), secrets, expectedAgents)) {
             try (KafkaProducer<String, String> producer = createProducer();
                     KafkaConsumer<String, String> consumer = createConsumer("output-topic")) {
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
@@ -80,6 +80,8 @@ class CassandraAssetQueryWriteIT extends AbstractApplicationRunner {
                                        datasource: "CassandraDatasource"
                                        create-statements:
                                           - "CREATE KEYSPACE vsearch WITH REPLICATION = {'class' : 'SimpleStrategy','replication_factor' : 1};"
+                                       delete-statements:
+                                          - "DROP KEYSPACE vsearch;"
                                   - name: "documents-table"
                                     asset-type: "cassandra-table"
                                     creation-mode: create-if-not-exists
@@ -216,6 +218,8 @@ class CassandraAssetQueryWriteIT extends AbstractApplicationRunner {
                                        create-statements:
                                           - "CREATE TABLE IF NOT EXISTS v1.documents (id int PRIMARY KEY, name text, description text);"
                                           - "INSERT INTO v1.documents (id, name, description) VALUES (1, 'A', 'A description');"
+                                       delete-statements:
+                                          - "DROP TABLE v1.documents;"
                                 topics:
                                   - name: "input-topic"
                                     creation-mode: create-if-not-exists

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
@@ -16,12 +16,14 @@
 package ai.langstream.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import ai.langstream.AbstractApplicationRunner;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,6 +74,7 @@ class CassandraAssetQueryWriteIT extends AbstractApplicationRunner {
                                   - name: "vsearch-keyspace"
                                     asset-type: "cassandra-keyspace"
                                     creation-mode: create-if-not-exists
+                                    deletion-mode: delete
                                     config:
                                        keyspace: "vsearch"
                                        datasource: "CassandraDatasource"
@@ -152,6 +155,108 @@ class CassandraAssetQueryWriteIT extends AbstractApplicationRunner {
                     all.forEach(row -> log.info("row id {}", row.get("id", Integer.class)));
                     assertEquals(2, all.size());
                     assertEquals(Set.of(1, 2), documentIds);
+                }
+
+                applicationDeployer.cleanup(tenant, applicationRuntime.implementation());
+
+                try (CqlSession cqlSession = builder.build(); ) {
+                    try {
+                        cqlSession.execute("DESCRIBE KEYSPACE vsearch");
+                        fail();
+                    } catch (InvalidQueryException e) {
+                        assertEquals("'vsearch' not found in keyspaces", e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCassandraTable() throws Exception {
+        String tenant = "tenant1";
+        String[] expectedAgents = {"app-step1", "app-step2"};
+
+        Map<String, String> application =
+                Map.of(
+                        "configuration.yaml",
+                        """
+                        configuration:
+                          resources:
+                            - type: "vector-database"
+                              name: "CassandraDatasource"
+                              configuration:
+                                service: "cassandra"
+                                contact-points: "%s"
+                                loadBalancing-localDc: "%s"
+                                port: %d
+                        """
+                                .formatted(
+                                        cassandra.getContactPoint().getHostString(),
+                                        cassandra.getLocalDatacenter(),
+                                        cassandra.getContactPoint().getPort()),
+                        "pipeline.yaml",
+                        """
+                                assets:
+                                  - name: "vsearch-keyspace"
+                                    asset-type: "cassandra-keyspace"
+                                    creation-mode: create-if-not-exists
+                                    config:
+                                       keyspace: "v1"
+                                       datasource: "CassandraDatasource"
+                                       create-statements:
+                                          - "CREATE KEYSPACE v1 WITH REPLICATION = {'class' : 'SimpleStrategy','replication_factor' : 1};"
+                                  - name: "documents-table"
+                                    asset-type: "cassandra-table"
+                                    creation-mode: create-if-not-exists
+                                    deletion-mode: delete
+                                    config:
+                                       table-name: "documents"
+                                       keyspace: "v1"
+                                       datasource: "CassandraDatasource"
+                                       create-statements:
+                                          - "CREATE TABLE IF NOT EXISTS v1.documents (id int PRIMARY KEY, name text, description text);"
+                                          - "INSERT INTO v1.documents (id, name, description) VALUES (1, 'A', 'A description');"
+                                topics:
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                  - name: "output-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - id: step1
+                                    name: "Execute Query"
+                                    type: "query-vector-db"
+                                    input: "input-topic"
+                                    output: "output-topic"
+                                    configuration:
+                                      datasource: "CassandraDatasource"
+                                      query: "SELECT * FROM v1.documents WHERE id=?;"
+                                      only-first: true
+                                      output-field: "value.queryresult"
+                                      fields:
+                                        - "value.documentId"
+                                """);
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+
+            CqlSessionBuilder builder = new CqlSessionBuilder();
+            builder.addContactPoint(cassandra.getContactPoint());
+            builder.withLocalDatacenter(cassandra.getLocalDatacenter());
+
+            try (CqlSession cqlSession = builder.build(); ) {
+                ResultSet execute = cqlSession.execute("SELECT count(*) FROM v1.documents");
+                assertEquals(1, execute.one().getLong(0));
+            }
+
+            applicationDeployer.cleanup(tenant, applicationRuntime.implementation());
+
+            try (CqlSession cqlSession = builder.build(); ) {
+                try {
+                    ResultSet execute = cqlSession.execute("SELECT count(*) FROM v1.documents");
+                    fail();
+                } catch (InvalidQueryException e) {
+                    assertEquals("table documents does not exist", e.getMessage());
                 }
             }
         }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockAssetManagerCodeProvider.java
@@ -80,12 +80,13 @@ public class MockAssetManagerCodeProvider implements AssetManagerProvider {
         }
 
         @Override
-        public synchronized void deleteAsset() throws Exception {
+        public synchronized boolean deleteAssetIfExists() throws Exception {
             log.info("Deleting asset {}", assetDefinition);
             final boolean remove = DEPLOYED_ASSETS.remove(assetDefinition);
             if (!remove) {
                 throw new IllegalStateException("Asset not found: " + assetDefinition);
             }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Same of https://github.com/LangStream/langstream/pull/418 but for assets.

new field `deletion-mode: none|delete`. Default is none

```
assets:
- name: "vsearch-keyspace"
    asset-type: "cassandra-keyspace"
    creation-mode: create-if-not-exists
    deletion-mode: delete
    config:
      keyspace: "vsearch"
      datasource: "CassandraDatasource"
      create-statements:
        - "CREATE KEYSPACE vsearch WITH REPLICATION = {'class' : 'SimpleStrategy','replication_factor' : 1};"
```