### PR TITLE
WebCrawler: improvements

### DIFF
--- a/examples/applications/webcrawler-source/crawler.yaml
+++ b/examples/applications/webcrawler-source/crawler.yaml
@@ -30,16 +30,19 @@ pipeline:
       min-time-between-requests: 500
       reindex-interval-seconds: 3600
       max-error-count: 5
+      max-urls: 1000
+      max-depth: 10
+      handle-robots-file: true
+      user-agent: "" # this is computed automatically, but you can override it
+      scan-html-documents: true
       http-timeout: 10000
       handle-cookies: true
       max-unflushed-pages: 100
-      user-agent: "langstream.ai-webcrawler/1.0"
       bucketName: "{{{secrets.s3.bucket-name}}}"
       endpoint: "{{{secrets.s3.endpoint}}}"
       access-key: "{{{secrets.s3.access-key}}}"
       secret-key: "{{{secrets.s3.secret}}}"
       region: "{{{secrets.s3.region}}}"
-      idle-time: 5
   - name: "Extract text"
     type: "text-extractor"
   - name: "Normalise text"

--- a/langstream-agents/langstream-agent-webcrawler/pom.xml
+++ b/langstream-agents/langstream-agent-webcrawler/pom.xml
@@ -43,6 +43,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.crawler-commons</groupId>
+      <artifactId>crawler-commons</artifactId>
+      <version>1.4</version>
+    </dependency>
+    <dependency>
       <groupId>io.minio</groupId>
       <artifactId>minio</artifactId>
     </dependency>

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.agents.webcrawler;
 
+import static ai.langstream.agents.webcrawler.crawler.WebCrawlerConfiguration.DEFAULT_USER_AGENT;
 import static ai.langstream.api.util.ConfigurationUtils.getBoolean;
 import static ai.langstream.api.util.ConfigurationUtils.getInt;
 import static ai.langstream.api.util.ConfigurationUtils.getSet;
@@ -114,7 +115,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
 
         flushNext.set(maxUnflushedPages);
         int minTimeBetweenRequests = getInt("min-time-between-requests", 500, configuration);
-        String userAgent = getString("user-agent", "langstream.ai-webcrawler/1.0", configuration);
+        String userAgent = getString("user-agent", DEFAULT_USER_AGENT, configuration);
         int maxErrorCount = getInt("max-error-count", 5, configuration);
         int httpTimeout = getInt("http-timeout", 10000, configuration);
 
@@ -187,6 +188,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         } else {
             log.info("Bucket {} already exists", bucketName);
         }
+    }
+
+    public WebCrawler getCrawler() {
+        return crawler;
     }
 
     private void flushStatus() {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -107,6 +107,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         allowedDomains = getSet("allowed-domains", configuration);
         forbiddenPaths = getSet("forbidden-paths", configuration);
         maxUrls = getInt("max-urls", 1000, configuration);
+        int maxDepth = getInt("max-depth", 10, configuration);
         handleRobotsFile = getBoolean("handle-robots-file", true, configuration);
         scanHtmlDocuments = getBoolean("scan-html-documents", true, configuration);
         seedUrls = getSet("seed-urls", configuration);
@@ -130,6 +131,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         log.info("forbidden-paths: {}", forbiddenPaths);
         log.info("seed-urls: {}", seedUrls);
         log.info("max-urls: {}", maxUrls);
+        log.info("max-depth: {}", maxDepth);
         log.info("handle-robots-file: {}", handleRobotsFile);
         log.info("scan-html-documents: {}", scanHtmlDocuments);
         log.info("user-agent: {}", userAgent);
@@ -150,6 +152,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
                 WebCrawlerConfiguration.builder()
                         .allowedDomains(allowedDomains)
                         .maxUrls(maxUrls)
+                        .maxDepth(maxDepth)
                         .forbiddenPaths(forbiddenPaths)
                         .handleRobotsFile(handleRobotsFile)
                         .minTimeBetweenRequests(minTimeBetweenRequests)

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -66,9 +66,11 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
     private String bucketName;
     private Set<String> allowedDomains;
     private Set<String> forbiddenPaths;
+    private int maxUrls;
+    private boolean handleRobotsFile;
+    private boolean scanHtmlDocuments;
     private Set<String> seedUrls;
     private MinioClient minioClient;
-    private int idleTime;
     private int reindexIntervalSeconds;
 
     private String statusFileName;
@@ -103,8 +105,10 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         String region = getString("region", "", configuration);
         allowedDomains = getSet("allowed-domains", configuration);
         forbiddenPaths = getSet("forbidden-paths", configuration);
+        maxUrls = getInt("max-urls", 1000, configuration);
+        handleRobotsFile = getBoolean("handle-robots-file", true, configuration);
+        scanHtmlDocuments = getBoolean("scan-html-documents", true, configuration);
         seedUrls = getSet("seed-urls", configuration);
-        idleTime = getInt("idle-time", 1, configuration);
         reindexIntervalSeconds = getInt("reindex-interval-seconds", 60 * 60 * 24, configuration);
         maxUnflushedPages = getInt("max-unflushed-pages", 100, configuration);
 
@@ -124,6 +128,9 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         log.info("allowed-domains: {}", allowedDomains);
         log.info("forbidden-paths: {}", forbiddenPaths);
         log.info("seed-urls: {}", seedUrls);
+        log.info("max-urls: {}", maxUrls);
+        log.info("handle-robots-file: {}", handleRobotsFile);
+        log.info("scan-html-documents: {}", scanHtmlDocuments);
         log.info("user-agent: {}", userAgent);
         log.info("max-unflushed-pages: {}", maxUnflushedPages);
         log.info("min-time-between-requests: {}", minTimeBetweenRequests);
@@ -141,7 +148,9 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         WebCrawlerConfiguration webCrawlerConfiguration =
                 WebCrawlerConfiguration.builder()
                         .allowedDomains(allowedDomains)
+                        .maxUrls(maxUrls)
                         .forbiddenPaths(forbiddenPaths)
+                        .handleRobotsFile(handleRobotsFile)
                         .minTimeBetweenRequests(minTimeBetweenRequests)
                         .userAgent(userAgent)
                         .handleCookies(handleCookies)
@@ -273,7 +282,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
     }
 
     private List<Record> sleepForNoResults() throws Exception {
-        Thread.sleep(idleTime * 1000L);
+        Thread.sleep(100);
         return List.of();
     }
 

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/StatusStorage.java
@@ -15,10 +15,22 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import java.util.List;
 import java.util.Map;
 
 public interface StatusStorage {
-    void storeStatus(Map<String, Object> metadata) throws Exception;
+    void storeStatus(Status metadata) throws Exception;
 
-    Map<String, Object> getCurrentStatus() throws Exception;
+    record StoreUrlReference(String url, String type, int depth) {}
+
+    record RobotsFile(String content, String contentType) {}
+
+    record Status(
+            List<String> remainingUrls,
+            List<StoreUrlReference> urls,
+            Long lastIndexEndTimestamp,
+            Long lastIndexStartTimestamp,
+            Map<String, RobotsFile> robotFiles) {}
+
+    Status getCurrentStatus() throws Exception;
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/URLReference.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/URLReference.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.webcrawler.crawler;
+
+public record URLReference(String url, Type type, int depth) {
+    enum Type {
+        PAGE,
+        ROBOTS,
+        SITEMAP
+    }
+}

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -15,8 +15,24 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
+import crawlercommons.robots.SimpleRobotRules;
+import crawlercommons.robots.SimpleRobotRulesParser;
+import crawlercommons.sitemaps.AbstractSiteMap;
+import crawlercommons.sitemaps.SiteMap;
+import crawlercommons.sitemaps.SiteMapIndex;
+import crawlercommons.sitemaps.SiteMapParser;
+import crawlercommons.sitemaps.SiteMapURL;
+import java.io.IOException;
 import java.net.CookieManager;
 import java.net.CookieStore;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +71,37 @@ public class WebCrawler {
         if (!configuration.isAllowedUrl(startUrl)) {
             return;
         }
-        status.addUrl(startUrl, true);
+
+        // add robots.txt to the list of urls to crawl
+        // before the original url
+        // because it may contain some interesting information that will drive the crawling
+        if (configuration.isHandleRobotsFile()) {
+            try {
+                URL url = new URL(startUrl);
+                String path = url.getPath();
+                if (path == null || path.isEmpty() || path.equals("/")) {
+                    String separator = startUrl.endsWith("/") ? "" : "/";
+                    String robotsFile = startUrl + separator + "robots.txt";
+                    log.info("Adding robots.txt to the list of urls to crawl: {}", robotsFile);
+                    // force add the url (no check on the max number of urls)
+                    status.addUrl(robotsFile, URLReference.Type.ROBOTS, 0, true);
+                }
+            } catch (MalformedURLException e) {
+                log.warn("Error while parsing the url: {}", startUrl, e);
+            }
+        }
+
+        addUrl(startUrl, null);
+    }
+
+    private void addUrl(String startUrl, URLReference parent) {
+        int size = status.getUrls().size();
+        if (configuration.getMaxUrls() <= 0 || size < configuration.getMaxUrls()) {
+            int newDepth = parent == null ? 0 : parent.depth() + 1;
+            status.addUrl(startUrl, URLReference.Type.PAGE, newDepth, true);
+        } else {
+            log.info("Max urls reached, skipping {}", startUrl);
+        }
     }
 
     public boolean runCycle() throws Exception {
@@ -64,6 +110,23 @@ public class WebCrawler {
             return false;
         }
         log.info("Crawling url: {}", current);
+
+        URLReference reference = status.getReference(current);
+
+        if (reference.type() == URLReference.Type.ROBOTS) {
+            log.info("Found a robots.txt file");
+            handleRobotsFile(current);
+            status.urlProcessed(current);
+            return true;
+        }
+
+        if (reference.type() == URLReference.Type.SITEMAP) {
+            log.info("Found a sitemap file");
+            handleSitemapsFile(current);
+            status.urlProcessed(current);
+            return true;
+        }
+
         Connection connect = Jsoup.connect(current);
         connect.cookieStore(cookieStore);
         connect.followRedirects(false);
@@ -89,7 +152,7 @@ public class WebCrawler {
                                 location);
                     } else {
                         log.info("A redirection happened from {} to {}", current, location);
-                        status.addUrl(location, true);
+                        addUrl(location, reference);
                         return true;
                     }
                 }
@@ -108,10 +171,10 @@ public class WebCrawler {
                 int currentCount = status.temporaryErrorOnUrl(current);
                 if (currentCount >= configuration.getMaxErrorCount()) {
                     log.info("Too many errors ({}) on url {}, skipping it", currentCount, current);
-                    status.addUrl(current, false);
+                    status.addUrl(current, reference.type(), reference.depth(), false);
                 } else {
                     log.info("Putting back the url {} into the backlog", current);
-                    status.addUrl(current, true);
+                    status.addUrl(current, reference.type(), reference.depth(), true);
                 }
             }
 
@@ -127,7 +190,7 @@ public class WebCrawler {
                     "Url {} lead to a {} content-type document. Skipping",
                     current,
                     notHtml.getMimeType());
-            status.addUrl(current, false);
+            status.addUrl(current, reference.type(), reference.depth(), false);
 
             // prevent from being banned for flooding
             if (configuration.getMinTimeBetweenRequests() > 0) {
@@ -139,19 +202,25 @@ public class WebCrawler {
         }
 
         if (!redirectedToForbiddenDomain) {
-            document.getElementsByAttribute("href")
-                    .forEach(
-                            element -> {
-                                if (configuration.isAllowedTag(element.tagName())) {
-                                    String url = element.absUrl("href");
-                                    if (configuration.isAllowedUrl(url)) {
-                                        status.addUrl(url, true);
-                                    } else {
-                                        log.debug("Ignoring not allowed url: {}", url);
-                                        status.addUrl(url, false);
+            if (configuration.isScanHtmlDocuments()) {
+                document.getElementsByAttribute("href")
+                        .forEach(
+                                element -> {
+                                    if (configuration.isAllowedTag(element.tagName())) {
+                                        String url = element.absUrl("href");
+                                        if (configuration.isAllowedUrl(url)) {
+                                            addUrl(url, reference);
+                                        } else {
+                                            log.debug("Ignoring not allowed url: {}", url);
+                                            status.addUrl(
+                                                    url,
+                                                    reference.type(),
+                                                    reference.depth(),
+                                                    false);
+                                        }
                                     }
-                                }
-                            });
+                                });
+            }
             visitor.visit(
                     new ai.langstream.agents.webcrawler.crawler.Document(current, document.html()));
         }
@@ -162,6 +231,74 @@ public class WebCrawler {
         }
 
         return true;
+    }
+
+    private void handleRobotsFile(String url) throws Exception {
+        HttpResponse<byte[]> response = downloadUrl(url);
+        SimpleRobotRulesParser parser = new SimpleRobotRulesParser();
+        SimpleRobotRules simpleRobotRules =
+                parser.parseContent(
+                        url,
+                        response.body(),
+                        response.headers().firstValue("content-type").orElse("text/plain"),
+                        List.of(configuration.getUserAgent()));
+
+        if (simpleRobotRules.getSitemaps().isEmpty()) {
+            log.info("The robots.txt file doesn't contain any site map");
+        } else {
+            simpleRobotRules
+                    .getSitemaps()
+                    .forEach(
+                            siteMap -> {
+                                log.info("Adding sitemap : {}", siteMap);
+                                // force add the url (no check on the max number of urls)
+                                status.addUrl(siteMap, URLReference.Type.SITEMAP, 0, true);
+                            });
+        }
+    }
+
+    private void handleSitemapsFile(String url) throws Exception {
+        HttpResponse<byte[]> response = downloadUrl(url);
+        SiteMapParser siteMapParser = new SiteMapParser();
+        AbstractSiteMap abstractSiteMap = siteMapParser.parseSiteMap(response.body(), new URL(url));
+        if (abstractSiteMap instanceof SiteMap siteMap) {
+
+            Collection<SiteMapURL> siteMapUrls = siteMap.getSiteMapUrls();
+
+            siteMapUrls.forEach(
+                    siteMapUrl -> {
+                        log.info("Adding url from sitemap : {}", siteMapUrl.getUrl());
+                        String loc = siteMapUrl.getUrl().toString();
+                        if (configuration.isAllowedUrl(loc)) {
+                            addUrl(loc, null);
+                        } else {
+                            log.debug("Ignoring not allowed url: {}", loc);
+                            status.addUrl(loc, URLReference.Type.PAGE, 0, false);
+                        }
+                    });
+        } else if (abstractSiteMap instanceof SiteMapIndex siteMapIndex) {
+            log.info("It is a sitemap index");
+            Collection<AbstractSiteMap> sitemaps = siteMapIndex.getSitemaps(true);
+            sitemaps.forEach(
+                    s -> {
+                        log.info("Adding this sitemap : {}", s.getUrl());
+                        status.addUrl(s.getUrl().toString(), URLReference.Type.SITEMAP, 0, true);
+                    });
+        } else {
+            log.warn("Unknown sitemap type: {}", abstractSiteMap.getClass().getName());
+        }
+    }
+
+    private HttpResponse<byte[]> downloadUrl(String url) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpResponse<byte[]> response =
+                client.send(
+                        HttpRequest.newBuilder()
+                                .uri(URI.create(url))
+                                .header("User-Agent", configuration.getUserAgent())
+                                .build(),
+                        HttpResponse.BodyHandlers.ofByteArray());
+        return response;
     }
 
     public void restartIndexing(Set<String> seedUrls) {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
@@ -30,6 +30,7 @@ public class WebCrawlerConfiguration {
     @Builder.Default private String userAgent = null;
     @Builder.Default private int minTimeBetweenRequests = 100;
     @Builder.Default private int maxUrls = 1000;
+    @Builder.Default private int maxDepth = 10;
     @Builder.Default private int httpTimeout = 10000;
     @Builder.Default private int maxErrorCount = 5;
     @Builder.Default private boolean handleCookies = true;

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
@@ -25,9 +25,12 @@ import lombok.extern.slf4j.Slf4j;
 @Builder
 @Slf4j
 public class WebCrawlerConfiguration {
+    public static final String DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (compatible; LangStream.ai/0.1; +https://langstream.ai)";
+
     @Builder.Default private Set<String> allowedDomains = Set.of();
     @Builder.Default private Set<String> forbiddenPaths = Set.of();
-    @Builder.Default private String userAgent = null;
+    @Builder.Default private String userAgent = DEFAULT_USER_AGENT;
     @Builder.Default private int minTimeBetweenRequests = 100;
     @Builder.Default private int maxUrls = 1000;
     @Builder.Default private int maxDepth = 10;

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
@@ -29,9 +29,13 @@ public class WebCrawlerConfiguration {
     @Builder.Default private Set<String> forbiddenPaths = Set.of();
     @Builder.Default private String userAgent = null;
     @Builder.Default private int minTimeBetweenRequests = 100;
+    @Builder.Default private int maxUrls = 1000;
     @Builder.Default private int httpTimeout = 10000;
     @Builder.Default private int maxErrorCount = 5;
     @Builder.Default private boolean handleCookies = true;
+    @Builder.Default private boolean handleRobotsFile = true;
+    @Builder.Default private boolean scanHtmlDocuments = true;
+
     @Builder.Default private Set<String> allowedTags = Set.of("a");
 
     public boolean isAllowedUrl(String url) {

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -170,7 +170,9 @@ public class WebCrawlerStatus {
         urls.put(url, new URLReference(url, type, depth));
 
         if (toScan && !wasThere) {
-            log.info("adding url {} to list", url);
+            if (log.isDebugEnabled()) {
+                log.debug("adding url {} to list", url);
+            }
             pendingUrls.add(url);
             remainingUrls.add(url);
         }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/WebCrawlerSourceTest.java
@@ -357,6 +357,13 @@ public class WebCrawlerSourceTest {
         assertTrue(status.getRemainingUrls().isEmpty());
         assertTrue(status.getPendingUrls().isEmpty());
         assertFalse(status.getRobotsFiles().isEmpty());
+
+        // test reload robot rules from S3
+        WebCrawlerSource agentSource2 =
+                buildAgentSource(bucket, allowed, Set.of(), url, additionalConfig);
+        WebCrawler crawler2 = agentSource.getCrawler();
+        assertEquals(crawler2.getStatus().getRobotsFiles(), status.getRobotsFiles());
+        agentSource2.close();
     }
 
     private WebCrawlerSource buildAgentSource(

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -30,34 +30,34 @@ class WebCrawlerStatusTest {
     @Test
     public void testPreventCycles() {
         WebCrawlerStatus status = new WebCrawlerStatus();
-        status.addUrl(URL1, true);
+        status.addUrl(URL1, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 1, 1);
-        status.addUrl(URL1, true);
+        status.addUrl(URL1, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 1, 1);
         String url = status.nextUrl();
         verify(status, 1, 0, 1);
         status.urlProcessed(url);
         verify(status, 1, 0, 0);
-        status.addUrl(URL1, true);
+        status.addUrl(URL1, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 0, 0);
-        status.addUrl(URL1, false);
+        status.addUrl(URL1, URLReference.Type.PAGE, 0, false);
         verify(status, 1, 0, 0);
     }
 
     @Test
     public void testPreventCyclesWithAnchors() {
         WebCrawlerStatus status = new WebCrawlerStatus();
-        status.addUrl(URL2, true);
+        status.addUrl(URL2, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 1, 1);
-        status.addUrl(URL2_ANCHOR, true);
+        status.addUrl(URL2_ANCHOR, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 1, 1);
         String url = status.nextUrl();
         verify(status, 1, 0, 1);
         status.urlProcessed(url);
         verify(status, 1, 0, 0);
-        status.addUrl(URL2, true);
+        status.addUrl(URL2, URLReference.Type.PAGE, 0, true);
         verify(status, 1, 0, 0);
-        status.addUrl(URL2_ANCHOR, false);
+        status.addUrl(URL2_ANCHOR, URLReference.Type.PAGE, 0, false);
         verify(status, 1, 0, 0);
     }
 
@@ -67,8 +67,8 @@ class WebCrawlerStatusTest {
         DummyStorage storage = new DummyStorage();
 
         WebCrawlerStatus status = new WebCrawlerStatus();
-        status.addUrl(URL1, true);
-        status.addUrl(URL2, true);
+        status.addUrl(URL1, URLReference.Type.PAGE, 0, true);
+        status.addUrl(URL2, URLReference.Type.PAGE, 0, true);
         verify(status, 2, 2, 2);
         status.persist(storage);
 
@@ -110,7 +110,7 @@ class WebCrawlerStatusTest {
 
     private static void verify(WebCrawlerStatus status, int visited, int pending, int remaining) {
         assertEquals(pending, status.getPendingUrls().size());
-        assertEquals(visited, status.getVisitedUrls().size());
+        assertEquals(visited, status.getUrls().size());
         assertEquals(remaining, status.getRemainingUrls().size());
     }
 

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatusTest.java
@@ -17,7 +17,7 @@ package ai.langstream.agents.webcrawler.crawler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +26,9 @@ class WebCrawlerStatusTest {
     static final String URL1 = "https://site/page1";
     static final String URL2 = "https://site/page2";
     static final String URL2_ANCHOR = "https://site/page2#anchor";
+    static final String URL3 = "https://site/page3";
+    static final String URL4 = "https://site/page4";
+    static final String URL5 = "https://site/page5";
 
     @Test
     public void testPreventCycles() {
@@ -59,6 +62,46 @@ class WebCrawlerStatusTest {
         verify(status, 1, 0, 0);
         status.addUrl(URL2_ANCHOR, URLReference.Type.PAGE, 0, false);
         verify(status, 1, 0, 0);
+    }
+
+    @Test
+    public void testMaxUrls() throws Exception {
+        WebCrawlerConfiguration configuration =
+                WebCrawlerConfiguration.builder().maxUrls(2).build();
+        WebCrawlerStatus status = new WebCrawlerStatus();
+        WebCrawler webCrawler = new WebCrawler(configuration, status, (__) -> {});
+        assertTrue(webCrawler.addPageUrl(URL1, null));
+        assertTrue(webCrawler.addPageUrl(URL2, null));
+        assertFalse(webCrawler.addPageUrl(URL3, null));
+
+        verify(status, 2, 2, 2);
+    }
+
+    @Test
+    public void testMaxDepth() {
+        WebCrawlerConfiguration configuration =
+                WebCrawlerConfiguration.builder().maxDepth(2).build();
+        WebCrawlerStatus status = new WebCrawlerStatus();
+        WebCrawler webCrawler = new WebCrawler(configuration, status, (__) -> {});
+        assertTrue(webCrawler.addPageUrl(URL1, null));
+        assertTrue(webCrawler.addPageUrl(URL2, status.getReference(URL1)));
+        assertTrue(webCrawler.addPageUrl(URL3, status.getReference(URL2)));
+
+        // coming from URL3, forbidden
+        assertFalse(webCrawler.addPageUrl(URL4, status.getReference(URL3)));
+        // coming from URL2, allowed
+        assertTrue(webCrawler.addPageUrl(URL5, status.getReference(URL2)));
+
+        // coming from URL2, allowed
+        assertTrue(webCrawler.addPageUrl(URL4, status.getReference(URL2)));
+
+        assertEquals(2, status.getReference(URL5).depth());
+        // now page 5 is found from URL1, so depth is changed
+        assertTrue(webCrawler.addPageUrl(URL5, status.getReference(URL1)));
+
+        assertEquals(1, status.getReference(URL5).depth());
+
+        verify(status, 5, 5, 5);
     }
 
     @Test
@@ -116,16 +159,18 @@ class WebCrawlerStatusTest {
 
     private static class DummyStorage implements StatusStorage {
 
-        private Map<String, Object> lastMetadata;
+        private Status lastMetadata;
 
         @Override
-        public void storeStatus(Map<String, Object> metadata) {
-            lastMetadata = new HashMap<>(metadata);
+        public void storeStatus(Status metadata) {
+            lastMetadata = metadata;
         }
 
         @Override
-        public Map<String, Object> getCurrentStatus() {
-            return lastMetadata != null ? new HashMap<>(lastMetadata) : Map.of();
+        public Status getCurrentStatus() {
+            return lastMetadata != null
+                    ? lastMetadata
+                    : new Status(List.of(), List.of(), null, null, Map.of());
         }
     }
 }

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
@@ -51,6 +51,7 @@ class WebCrawlerTest {
         WebCrawlerConfiguration configuration =
                 WebCrawlerConfiguration.builder()
                         .allowedDomains(Set.of(vmRuntimeInfo.getHttpBaseUrl()))
+                        .handleRobotsFile(false)
                         .maxErrorCount(5)
                         .build();
         WebCrawlerStatus status = new WebCrawlerStatus();
@@ -116,6 +117,7 @@ class WebCrawlerTest {
         WebCrawlerConfiguration configuration =
                 WebCrawlerConfiguration.builder()
                         .allowedDomains(Set.of(vmRuntimeInfo.getHttpBaseUrl()))
+                        .handleRobotsFile(false)
                         .maxErrorCount(3)
                         .build();
         WebCrawlerStatus status = new WebCrawlerStatus();
@@ -178,6 +180,7 @@ class WebCrawlerTest {
         WebCrawlerConfiguration configuration =
                 WebCrawlerConfiguration.builder()
                         .allowedDomains(Set.of(vmRuntimeInfo.getHttpBaseUrl()))
+                        .handleRobotsFile(false)
                         .build();
         WebCrawlerStatus status = new WebCrawlerStatus();
         List<Document> documents = new ArrayList<>();

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
@@ -62,25 +62,25 @@ class WebCrawlerTest {
         assertEquals(1, documents.size());
         assertEquals(vmRuntimeInfo.getHttpBaseUrl() + "/index.html", documents.get(0).url());
         assertEquals(2, status.getPendingUrls().size());
-        assertEquals(3, status.getVisitedUrls().size());
+        assertEquals(3, status.getUrls().size());
 
         // process the internalErrorPage
         crawler.runCycle();
 
         assertEquals(2, status.getPendingUrls().size());
-        assertEquals(3, status.getVisitedUrls().size());
+        assertEquals(3, status.getUrls().size());
 
         // process the notFoundPage
         crawler.runCycle();
 
         assertEquals(1, status.getPendingUrls().size());
-        assertEquals(3, status.getVisitedUrls().size());
+        assertEquals(3, status.getUrls().size());
 
         // process the internalErrorPage
         crawler.runCycle();
 
         assertEquals(1, status.getPendingUrls().size());
-        assertEquals(3, status.getVisitedUrls().size());
+        assertEquals(3, status.getUrls().size());
 
         // now the error page starts to work again
         stubFor(
@@ -96,7 +96,7 @@ class WebCrawlerTest {
         crawler.runCycle();
 
         assertEquals(0, status.getPendingUrls().size());
-        assertEquals(3, status.getVisitedUrls().size());
+        assertEquals(3, status.getUrls().size());
     }
 
     @Test
@@ -127,25 +127,25 @@ class WebCrawlerTest {
         assertEquals(1, documents.size());
         assertEquals(vmRuntimeInfo.getHttpBaseUrl() + "/index.html", documents.get(0).url());
         assertEquals(1, status.getPendingUrls().size());
-        assertEquals(2, status.getVisitedUrls().size());
+        assertEquals(2, status.getUrls().size());
 
         // process the internalErrorPage
         crawler.runCycle();
 
         assertEquals(1, status.getPendingUrls().size());
-        assertEquals(2, status.getVisitedUrls().size());
+        assertEquals(2, status.getUrls().size());
 
         // process the internalErrorPage
         crawler.runCycle();
 
         assertEquals(1, status.getPendingUrls().size());
-        assertEquals(2, status.getVisitedUrls().size());
+        assertEquals(2, status.getUrls().size());
 
         // process the internalErrorPage
         crawler.runCycle();
 
         assertEquals(0, status.getPendingUrls().size());
-        assertEquals(2, status.getVisitedUrls().size());
+        assertEquals(2, status.getUrls().size());
 
         // nothing to do
         assertFalse(crawler.runCycle());
@@ -188,12 +188,12 @@ class WebCrawlerTest {
         assertEquals(1, documents.size());
         assertEquals(vmRuntimeInfo.getHttpBaseUrl() + "/index.html", documents.get(0).url());
         assertEquals(2, status.getPendingUrls().size());
-        assertEquals(3, status.getVisitedUrls().size());
+        assertEquals(3, status.getUrls().size());
 
         // redirectToGoodWebsite
         crawler.runCycle();
         assertEquals(2, status.getPendingUrls().size());
-        assertEquals(4, status.getVisitedUrls().size());
+        assertEquals(4, status.getUrls().size());
 
         assertEquals(vmRuntimeInfo.getHttpBaseUrl() + "/index.html", documents.get(0).url());
         // the document that did the redirection is not reported to the DocumentVisitor
@@ -203,12 +203,12 @@ class WebCrawlerTest {
         crawler.runCycle();
 
         assertEquals(1, status.getPendingUrls().size());
-        assertEquals(4, status.getVisitedUrls().size());
+        assertEquals(4, status.getUrls().size());
 
         // goodWebsite
         crawler.runCycle();
         assertEquals(0, status.getPendingUrls().size());
-        assertEquals(4, status.getVisitedUrls().size());
+        assertEquals(4, status.getUrls().size());
 
         assertEquals(vmRuntimeInfo.getHttpBaseUrl() + "/index.html", documents.get(0).url());
         assertEquals(vmRuntimeInfo.getHttpBaseUrl() + "/goodWebsite.html", documents.get(1).url());


### PR DESCRIPTION
Summary:
Add a couple of improvements to webcrawler-source:
- Take into account the robots.txt file
- Download the site maps
- Add a configuration parameter to limit the overall number of urls considered by the crawler
- Add a configuration parameter to limit the depth of the crawling
- Add a configuration parameter to not scan for Links inside the documents
- Removed the "idle-time" parameter 

The new parameters are:
- max-urls: the maximum number of urls visited by the Web Crawler (defaults to 1000)
- max-depth: the maximum depth (defaults to 10)
- handle-robots-file: look for robots.txt (and then sitemaps) (defaults to true)
- scan-html-documents: scan the HTML documents in order to find links to other pages (defaults to true)


 Full configuration:
```
  - name: "Crawl the WebSite"
    type: "webcrawler-source"
    configuration:
      seed-urls: ["https://docs.langstream.ai/"]
      allowed-domains: ["https://docs.langstream.ai"]
      forbidden-paths: []
      min-time-between-requests: 500
      reindex-interval-seconds: 3600
      max-error-count: 5
      max-urls: 1000
      max-depth: 10
      handle-robots-file: true
      user-agent: "" # this is computed automatically, but you can override it
      scan-html-documents: true
      http-timeout: 10000
      handle-cookies: true
      max-unflushed-pages: 100
      bucketName: "{{{secrets.s3.bucket-name}}}"
      endpoint: "{{{secrets.s3.endpoint}}}"
      access-key: "{{{secrets.s3.access-key}}}"
      secret-key: "{{{secrets.s3.secret}}}"
      region: "{{{secrets.s3.region}}}"
```