### PR TITLE
Fix typo in error message

### DIFF
--- a/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/common/AbstractAssetProvider.java
@@ -121,7 +121,7 @@ public abstract class AbstractAssetProvider implements AssetNodeProvider {
 
     protected static Supplier<String> describe(AssetDefinition assetDefinition) {
         return () ->
-                " assert definition, type="
+                "asset definition, type="
                         + assetDefinition.getAssetType()
                         + ", name="
                         + assetDefinition.getName()


### PR DESCRIPTION
Based on this error message:

  "detail" : "Missing required field 'token' in  assert definition, type=astra-keyspace, name=keyspace, id=keyspace",

Fixing extra space and spelling.