### PR TITLE
Fix topics runtime classloader

### DIFF
--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
@@ -146,6 +146,9 @@ public record TopicConnectionsRuntimeAndLoader(
                         code ->
                                 code.createReader(
                                         streamingCluster, configuration, initialPosition));
+                if (topicReaderImpl == null) {
+                    return null;
+                }
 
                 return new TopicReader() {
                     @Override
@@ -173,6 +176,9 @@ public record TopicConnectionsRuntimeAndLoader(
                     Map<String, Object> configuration) {
                 final TopicProducer topicProducerImpl = callNoExceptionWithContextClassloader(
                         code -> code.createProducer(agentId, streamingCluster, configuration));
+                if (topicProducerImpl == null) {
+                    return null;
+                }
 
                 return wrapTopicProducer(topicProducerImpl);
 
@@ -217,10 +223,14 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                return wrapTopicProducer(callNoExceptionWithContextClassloader(
+                final TopicProducer producerImpl = callNoExceptionWithContextClassloader(
                         code ->
                                 code.createDeadletterTopicProducer(
-                                        agentId, streamingCluster, configuration)));
+                                        agentId, streamingCluster, configuration));
+                if (producerImpl == null) {
+                    return null;
+                }
+                return wrapTopicProducer(producerImpl);
             }
 
             @Override
@@ -230,6 +240,9 @@ public record TopicConnectionsRuntimeAndLoader(
                     Map<String, Object> configuration) {
                 final TopicAdmin topicAdminImpl = callNoExceptionWithContextClassloader(
                         code -> code.createTopicAdmin(agentId, streamingCluster, configuration));
+                if (topicAdminImpl == null) {
+                    return null;
+                }
                 return new TopicAdmin() {
                     @Override
                     public void start() {

--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
@@ -16,8 +16,11 @@
 package ai.langstream.api.runner.topics;
 
 import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runtime.ExecutionPlan;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public record TopicConnectionsRuntimeAndLoader(
         TopicConnectionsRuntime connectionsRuntime, ClassLoader classLoader) {
@@ -91,8 +94,47 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                return callNoExceptionWithContextClassloader(
+
+
+                final TopicConsumer topicConsumerImpl = (TopicConsumer) callNoExceptionWithContextClassloader(
                         code -> code.createConsumer(agentId, streamingCluster, configuration));
+                return new TopicConsumer() {
+                    @Override
+                    public long getTotalOut() {
+                        return callNoExceptionWithContextClassloader(ignore -> topicConsumerImpl.getTotalOut());
+                    }
+
+                    @Override
+                    public Object getNativeConsumer() {
+                        return callNoExceptionWithContextClassloader(ignore -> topicConsumerImpl.getNativeConsumer());
+                    }
+
+                    @Override
+                    public void start() throws Exception {
+                        executeWithContextClassloader(ignore -> topicConsumerImpl.start());
+                    }
+
+                    @Override
+                    public void close() throws Exception {
+                        executeWithContextClassloader(ignore -> topicConsumerImpl.close());
+                    }
+
+                    @Override
+                    public List<Record> read() throws Exception {
+                        return callWithContextClassloader(ignore -> topicConsumerImpl.read());
+                    }
+
+                    @Override
+                    public void commit(List<Record> records) throws Exception {
+                        executeWithContextClassloader(ignore -> topicConsumerImpl.commit(records));
+                    }
+
+                    @Override
+                    public Map<String, Object> getInfo() {
+                        return callNoExceptionWithContextClassloader(ignore -> topicConsumerImpl.getNativeConsumer());
+                    }
+                };
+
             }
 
             @Override
@@ -100,10 +142,28 @@ public record TopicConnectionsRuntimeAndLoader(
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration,
                     TopicOffsetPosition initialPosition) {
-                return callNoExceptionWithContextClassloader(
+                TopicReader topicReaderImpl = callNoExceptionWithContextClassloader(
                         code ->
                                 code.createReader(
                                         streamingCluster, configuration, initialPosition));
+
+                return new TopicReader() {
+                    @Override
+                    public void start() throws Exception {
+                        executeWithContextClassloader(ignore -> topicReaderImpl.start());
+                    }
+
+                    @Override
+                    public void close() throws Exception {
+                        executeWithContextClassloader(ignore -> topicReaderImpl.close());
+                    }
+
+                    @Override
+                    public TopicReadResult read() throws Exception {
+                        return callWithContextClassloader(ignore -> topicReaderImpl.read());
+                    }
+                };
+
             }
 
             @Override
@@ -111,8 +171,45 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                return callNoExceptionWithContextClassloader(
+                final TopicProducer topicProducerImpl = callNoExceptionWithContextClassloader(
                         code -> code.createProducer(agentId, streamingCluster, configuration));
+
+                return wrapTopicProducer(topicProducerImpl);
+
+            }
+
+            private TopicProducer wrapTopicProducer(TopicProducer topicProducerImpl) {
+                return new TopicProducer() {
+                    @Override
+                    public long getTotalIn() {
+                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.getTotalIn());
+                    }
+
+                    @Override
+                    public void start() {
+                        executeNoExceptionWithContextClassloader(ignore -> topicProducerImpl.start());
+                    }
+
+                    @Override
+                    public void close() {
+                        executeNoExceptionWithContextClassloader(ignore -> topicProducerImpl.close());
+                    }
+
+                    @Override
+                    public CompletableFuture<?> write(Record record) {
+                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.write(record));
+                    }
+
+                    @Override
+                    public Object getNativeProducer() {
+                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.getNativeProducer());
+                    }
+
+                    @Override
+                    public Object getInfo() {
+                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.getInfo());
+                    }
+                };
             }
 
             @Override
@@ -120,10 +217,10 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                return callNoExceptionWithContextClassloader(
+                return wrapTopicProducer(callNoExceptionWithContextClassloader(
                         code ->
                                 code.createDeadletterTopicProducer(
-                                        agentId, streamingCluster, configuration));
+                                        agentId, streamingCluster, configuration)));
             }
 
             @Override
@@ -131,8 +228,24 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                return callNoExceptionWithContextClassloader(
+                final TopicAdmin topicAdminImpl = callNoExceptionWithContextClassloader(
                         code -> code.createTopicAdmin(agentId, streamingCluster, configuration));
+                return new TopicAdmin() {
+                    @Override
+                    public void start() {
+                        executeNoExceptionWithContextClassloader(ignore -> topicAdminImpl.start());
+                    }
+
+                    @Override
+                    public void close() {
+                        executeNoExceptionWithContextClassloader(ignore -> topicAdminImpl.close());
+                    }
+
+                    @Override
+                    public Object getNativeTopicAdmin() {
+                        return callNoExceptionWithContextClassloader(ignore -> topicAdminImpl.getNativeTopicAdmin());
+                    }
+                };
             }
         };
     }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
@@ -95,18 +95,23 @@ public record TopicConnectionsRuntimeAndLoader(
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
 
-
-                final TopicConsumer topicConsumerImpl = (TopicConsumer) callNoExceptionWithContextClassloader(
-                        code -> code.createConsumer(agentId, streamingCluster, configuration));
+                final TopicConsumer topicConsumerImpl =
+                        (TopicConsumer)
+                                callNoExceptionWithContextClassloader(
+                                        code ->
+                                                code.createConsumer(
+                                                        agentId, streamingCluster, configuration));
                 return new TopicConsumer() {
                     @Override
                     public long getTotalOut() {
-                        return callNoExceptionWithContextClassloader(ignore -> topicConsumerImpl.getTotalOut());
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicConsumerImpl.getTotalOut());
                     }
 
                     @Override
                     public Object getNativeConsumer() {
-                        return callNoExceptionWithContextClassloader(ignore -> topicConsumerImpl.getNativeConsumer());
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicConsumerImpl.getNativeConsumer());
                     }
 
                     @Override
@@ -131,10 +136,10 @@ public record TopicConnectionsRuntimeAndLoader(
 
                     @Override
                     public Map<String, Object> getInfo() {
-                        return callNoExceptionWithContextClassloader(ignore -> topicConsumerImpl.getNativeConsumer());
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicConsumerImpl.getNativeConsumer());
                     }
                 };
-
             }
 
             @Override
@@ -142,10 +147,11 @@ public record TopicConnectionsRuntimeAndLoader(
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration,
                     TopicOffsetPosition initialPosition) {
-                TopicReader topicReaderImpl = callNoExceptionWithContextClassloader(
-                        code ->
-                                code.createReader(
-                                        streamingCluster, configuration, initialPosition));
+                TopicReader topicReaderImpl =
+                        callNoExceptionWithContextClassloader(
+                                code ->
+                                        code.createReader(
+                                                streamingCluster, configuration, initialPosition));
                 if (topicReaderImpl == null) {
                     return null;
                 }
@@ -166,7 +172,6 @@ public record TopicConnectionsRuntimeAndLoader(
                         return callWithContextClassloader(ignore -> topicReaderImpl.read());
                     }
                 };
-
             }
 
             @Override
@@ -174,46 +179,54 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                final TopicProducer topicProducerImpl = callNoExceptionWithContextClassloader(
-                        code -> code.createProducer(agentId, streamingCluster, configuration));
+                final TopicProducer topicProducerImpl =
+                        callNoExceptionWithContextClassloader(
+                                code ->
+                                        code.createProducer(
+                                                agentId, streamingCluster, configuration));
                 if (topicProducerImpl == null) {
                     return null;
                 }
 
                 return wrapTopicProducer(topicProducerImpl);
-
             }
 
             private TopicProducer wrapTopicProducer(TopicProducer topicProducerImpl) {
                 return new TopicProducer() {
                     @Override
                     public long getTotalIn() {
-                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.getTotalIn());
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicProducerImpl.getTotalIn());
                     }
 
                     @Override
                     public void start() {
-                        executeNoExceptionWithContextClassloader(ignore -> topicProducerImpl.start());
+                        executeNoExceptionWithContextClassloader(
+                                ignore -> topicProducerImpl.start());
                     }
 
                     @Override
                     public void close() {
-                        executeNoExceptionWithContextClassloader(ignore -> topicProducerImpl.close());
+                        executeNoExceptionWithContextClassloader(
+                                ignore -> topicProducerImpl.close());
                     }
 
                     @Override
                     public CompletableFuture<?> write(Record record) {
-                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.write(record));
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicProducerImpl.write(record));
                     }
 
                     @Override
                     public Object getNativeProducer() {
-                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.getNativeProducer());
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicProducerImpl.getNativeProducer());
                     }
 
                     @Override
                     public Object getInfo() {
-                        return callNoExceptionWithContextClassloader(ignore -> topicProducerImpl.getInfo());
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicProducerImpl.getInfo());
                     }
                 };
             }
@@ -223,10 +236,11 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                final TopicProducer producerImpl = callNoExceptionWithContextClassloader(
-                        code ->
-                                code.createDeadletterTopicProducer(
-                                        agentId, streamingCluster, configuration));
+                final TopicProducer producerImpl =
+                        callNoExceptionWithContextClassloader(
+                                code ->
+                                        code.createDeadletterTopicProducer(
+                                                agentId, streamingCluster, configuration));
                 if (producerImpl == null) {
                     return null;
                 }
@@ -238,8 +252,11 @@ public record TopicConnectionsRuntimeAndLoader(
                     String agentId,
                     StreamingCluster streamingCluster,
                     Map<String, Object> configuration) {
-                final TopicAdmin topicAdminImpl = callNoExceptionWithContextClassloader(
-                        code -> code.createTopicAdmin(agentId, streamingCluster, configuration));
+                final TopicAdmin topicAdminImpl =
+                        callNoExceptionWithContextClassloader(
+                                code ->
+                                        code.createTopicAdmin(
+                                                agentId, streamingCluster, configuration));
                 if (topicAdminImpl == null) {
                     return null;
                 }
@@ -256,7 +273,8 @@ public record TopicConnectionsRuntimeAndLoader(
 
                     @Override
                     public Object getNativeTopicAdmin() {
-                        return callNoExceptionWithContextClassloader(ignore -> topicAdminImpl.getNativeTopicAdmin());
+                        return callNoExceptionWithContextClassloader(
+                                ignore -> topicAdminImpl.getNativeTopicAdmin());
                     }
                 };
             }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/topics/TopicConnectionsRuntimeAndLoader.java
@@ -137,7 +137,7 @@ public record TopicConnectionsRuntimeAndLoader(
                     @Override
                     public Map<String, Object> getInfo() {
                         return callNoExceptionWithContextClassloader(
-                                ignore -> topicConsumerImpl.getNativeConsumer());
+                                ignore -> topicConsumerImpl.getInfo());
                     }
                 };
             }

--- a/langstream-core/src/main/java/ai/langstream/impl/nar/NarFileHandler.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/nar/NarFileHandler.java
@@ -66,6 +66,9 @@ public class NarFileHandler
     }
 
     private static void deleteDirectory(Path dir) throws Exception {
+        if (!dir.toFile().exists()) {
+            return;
+        }
         try (DirectoryStream<Path> all = Files.newDirectoryStream(dir)) {
             for (Path file : all) {
                 if (Files.isDirectory(file)) {

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
@@ -69,10 +69,7 @@ public class KafkaConsumerWrapper implements TopicConsumer, ConsumerRebalanceLis
 
     @Override
     public synchronized void start() {
-        try (var context =
-                ClassloaderUtils.withContextClassloader(this.getClass().getClassLoader())) {
-            consumer = new KafkaConsumer(configuration);
-        }
+        consumer = new KafkaConsumer(configuration);
         if (topicName != null) {
             log.info("Subscribing consumer to {}", topicName);
             consumer.subscribe(List.of(topicName), this);

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaConsumerWrapper.java
@@ -17,7 +17,6 @@ package ai.langstream.kafka.runner;
 
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.topics.TopicConsumer;
-import ai.langstream.api.util.ClassloaderUtils;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaProducerWrapper.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaProducerWrapper.java
@@ -21,7 +21,6 @@ import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_
 import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.topics.TopicProducer;
-import ai.langstream.api.util.ClassloaderUtils;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaProducerWrapper.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaProducerWrapper.java
@@ -123,10 +123,7 @@ class KafkaProducerWrapper implements TopicProducer {
 
     @Override
     public void start() {
-        try (var context =
-                ClassloaderUtils.withContextClassloader(this.getClass().getClassLoader())) {
-            producer = new KafkaProducer<>(copy);
-        }
+        producer = new KafkaProducer<>(copy);
     }
 
     @Override

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -165,6 +165,11 @@ public abstract class AbstractApplicationRunner {
                     configuration:
                       admin:
                         bootstrap.servers: "%s"
+                        security.protocol: SASL_PLAINTEXT
+                        sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username='user' password='token: xxx';"
+                        sasl.mechanism: PLAIN
+                        session.timeout.ms: "45000"
+                        
                   computeCluster:
                      type: "kubernetes"
                 """

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -165,11 +165,6 @@ public abstract class AbstractApplicationRunner {
                     configuration:
                       admin:
                         bootstrap.servers: "%s"
-                        security.protocol: SASL_PLAINTEXT
-                        sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username='user' password='token: xxx';"
-                        sasl.mechanism: PLAIN
-                        session.timeout.ms: "45000"
-                        
                   computeCluster:
                      type: "kubernetes"
                 """


### PR DESCRIPTION
Fixes this error 
```
20:09:54.047 [main] INFO  a.l.runtime.agent.AgentRunnerStarter -- Error, NOW SLEEPING                                                  │
│ runtime org.apache.kafka.common.KafkaException: Failed to create new KafkaAdminClient                                                          │
│ runtime     at org.apache.kafka.clients.admin.KafkaAdminClient.createInternal(KafkaAdminClient.java:551)                                       │
│ runtime     at org.apache.kafka.clients.admin.Admin.create(Admin.java:144)                                                                     │
│ runtime     at org.apache.kafka.connect.util.TopicAdmin.<init>(TopicAdmin.java:282)                                                            │
│ runtime     at ai.langstream.kafka.runner.KafkaTopicConnectionsRuntime$1.start(KafkaTopicConnectionsRuntime.java:147)                          │
│ runtime     at ai.langstream.runtime.agent.AgentRunner.runJavaAgent(AgentRunner.java:374)                                                      │
│ runtime     at ai.langstream.runtime.agent.AgentRunner.run(AgentRunner.java:190)                                                               │
│ runtime     at ai.langstream.runtime.agent.AgentRunnerStarter.start(AgentRunnerStarter.java:111)                                               │
│ runtime     at ai.langstream.runtime.agent.AgentRunnerStarter.main(AgentRunnerStarter.java:53)                                                 │
│ runtime     at ai.langstream.runtime.Main.main(Main.java:42)                                                                                   │
│ runtime Caused by: org.apache.kafka.common.KafkaException: javax.security.auth.login.LoginException: No LoginModule found for org.apache.kafka │
│ .common.security.plain.PlainLoginModule                                                                                                        │
│ runtime     at org.apache.kafka.common.network.SaslChannelBuilder.configure(SaslChannelBuilder.java:184)                                       │
│ runtime     at org.apache.kafka.common.network.ChannelBuilders.create(ChannelBuilders.java:192)                                                │
│ runtime     at org.apache.kafka.common.network.ChannelBuilders.clientChannelBuilder(ChannelBuilders.java:81)                                   │
│ runtime     at org.apache.kafka.clients.ClientUtils.createChannelBuilder(ClientUtils.java:105)                                                 │
│ runtime     at org.apache.kafka.clients.admin.KafkaAdminClient.createInternal(KafkaAdminClient.java:522)                                       │
│ runtime     ... 8 common frames omitted
```