### PR TITLE
[docker run] Fix loading of OpenAI Async client - use the Netty provider instead of okhttp

### DIFF
--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAICompletionService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAICompletionService.java
@@ -88,13 +88,14 @@ public class OpenAICompletionService implements CompletionsService {
                     new ChatCompletionsConsumer(
                             streamingChunksConsumer, minChunksPerMessage, finished);
 
-            flux.subscribe(chatCompletionsConsumer);
-
             flux.doOnError(
-                    error -> {
-                        log.error("Internal error while processing the streaming response", error);
-                        finished.completeExceptionally(error);
-                    });
+                            error -> {
+                                log.error(
+                                        "Internal error while processing the streaming response",
+                                        error);
+                                finished.completeExceptionally(error);
+                            })
+                    .subscribe(chatCompletionsConsumer);
 
             return finished.thenApply(
                     ___ -> {

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAICompletionService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAICompletionService.java
@@ -95,7 +95,8 @@ public class OpenAICompletionService implements CompletionsService {
                                         error);
                                 finished.completeExceptionally(error);
                             })
-                    .subscribe(chatCompletionsConsumer);
+                    .doOnNext(chatCompletionsConsumer)
+                    .subscribe();
 
             return finished.thenApply(
                     ___ -> {
@@ -109,8 +110,7 @@ public class OpenAICompletionService implements CompletionsService {
         } else {
             com.azure.ai.openai.models.ChatCompletions chatCompletions =
                     client.getChatCompletions((String) options.get("model"), chatCompletionsOptions)
-                            .toFuture()
-                            .get();
+                            .block();
             result.setChoices(
                     chatCompletions.getChoices().stream()
                             .map(c -> new ChatChoice(convertMessage(c)))

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAICompletionService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAICompletionService.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -84,11 +83,19 @@ public class OpenAICompletionService implements CompletionsService {
             Flux<com.azure.ai.openai.models.ChatCompletions> flux =
                     client.getChatCompletionsStream(
                             (String) options.get("model"), chatCompletionsOptions);
-            Stream<com.azure.ai.openai.models.ChatCompletions> model = flux.toStream();
+
             ChatCompletionsConsumer chatCompletionsConsumer =
                     new ChatCompletionsConsumer(
                             streamingChunksConsumer, minChunksPerMessage, finished);
-            model.forEach(chatCompletionsConsumer);
+
+            flux.subscribe(chatCompletionsConsumer);
+
+            flux.doOnError(
+                    error -> {
+                        log.error("Internal error while processing the streaming response", error);
+                        finished.completeExceptionally(error);
+                    });
+
             return finished.thenApply(
                     ___ -> {
                         result.setChoices(

--- a/langstream-runtime/langstream-runtime-tester/pom.xml
+++ b/langstream-runtime/langstream-runtime-tester/pom.xml
@@ -47,6 +47,10 @@
           <groupId>${project.groupId}</groupId>
           <artifactId>langstream-pulsar-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>langstream-codestorage-azure-blob-storage</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -54,6 +58,12 @@
       <artifactId>langstream-webservice</artifactId>
       <version>${project.version}</version>
       <classifier>original</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>langstream-codestorage-azure-blob-storage</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Fixes #439 

Summary:
- remove the Azure Blob dependency from the docker-runtime-tester, as it bring the Azure SDK that generate conflicts with the OpenAI Async client