### PR TITLE
CLI: Allow updates to the default profile

### DIFF
--- a/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLIConfig.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLIConfig.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.cli;
 
+import ai.langstream.cli.commands.profiles.BaseProfileCmd;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Map;
 import java.util.TreeMap;
 import lombok.Getter;
@@ -26,5 +28,17 @@ public class LangStreamCLIConfig extends Profile {
 
     private Map<String, NamedProfile> profiles = new TreeMap<>();
 
-    private String currentProfile = "default";
+    private String currentProfile = BaseProfileCmd.DEFAULT_PROFILE_NAME;
+
+    @JsonIgnore
+    public void updateProfile(String name, NamedProfile namedProfile) {
+        if (name.equals(BaseProfileCmd.DEFAULT_PROFILE_NAME)) {
+            setTenant(namedProfile.getTenant());
+            setToken(namedProfile.getToken());
+            setWebServiceUrl(namedProfile.getWebServiceUrl());
+            setApiGatewayUrl(namedProfile.getApiGatewayUrl());
+        } else {
+            profiles.put(name, namedProfile);
+        }
+    }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/BaseProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/BaseProfileCmd.java
@@ -60,11 +60,16 @@ public abstract class BaseProfileCmd extends BaseCmd {
         return all;
     }
 
-    protected NamedProfile getProfileOrThrow(String name) {
+    protected NamedProfile getProfile(String name) {
         if (DEFAULT_PROFILE_NAME.equals(name)) {
             return getDefaultProfile();
         }
         final NamedProfile profile = getConfig().getProfiles().get(name);
+        return profile;
+    }
+
+    protected NamedProfile getProfileOrThrow(String name) {
+        final NamedProfile profile = getProfile(name);
         if (profile == null) {
             throw new IllegalArgumentException(getProfileNotFoundMessage(name));
         }
@@ -80,9 +85,4 @@ public abstract class BaseProfileCmd extends BaseCmd {
                         .collect(Collectors.joining(", ")));
     }
 
-    protected void checkProfileName(String name) {
-        if (DEFAULT_PROFILE_NAME.equals(name)) {
-            throw new IllegalArgumentException(String.format("Profile name %s is reserved", name));
-        }
-    }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/BaseProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/BaseProfileCmd.java
@@ -84,5 +84,4 @@ public abstract class BaseProfileCmd extends BaseCmd {
                         .map(NamedProfile::getName)
                         .collect(Collectors.joining(", ")));
     }
-
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/CreateUpdateProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/CreateUpdateProfileCmd.java
@@ -53,9 +53,8 @@ public abstract class CreateUpdateProfileCmd extends BaseProfileCmd {
     @SneakyThrows
     public void run() {
         checkGlobalFlags();
-        checkProfileName(name);
 
-        NamedProfile profile = getConfig().getProfiles().get(name);
+        NamedProfile profile = getProfile(name);
         if (isCreate()) {
             if (profile != null) {
                 throw new IllegalArgumentException(
@@ -87,7 +86,7 @@ public abstract class CreateUpdateProfileCmd extends BaseProfileCmd {
 
         updateConfig(
                 langStreamCLIConfig -> {
-                    langStreamCLIConfig.getProfiles().put(name, finalProfile);
+                    langStreamCLIConfig.updateProfile(name, finalProfile);
                     if (isCreate()) {
                         log(String.format("profile %s created", name));
                     } else {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/DeleteProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/DeleteProfileCmd.java
@@ -28,7 +28,9 @@ public class DeleteProfileCmd extends BaseProfileCmd {
     @SneakyThrows
     public void run() {
         checkGlobalFlags();
-        checkProfileName(name);
+        if (DEFAULT_PROFILE_NAME.equals(name)) {
+            throw new IllegalArgumentException(String.format("Profile name %s can't be deleted", name));
+        }
         getProfileOrThrow(name);
         updateConfig(
                 langStreamCLIConfig -> {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/DeleteProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/DeleteProfileCmd.java
@@ -29,7 +29,8 @@ public class DeleteProfileCmd extends BaseProfileCmd {
     public void run() {
         checkGlobalFlags();
         if (DEFAULT_PROFILE_NAME.equals(name)) {
-            throw new IllegalArgumentException(String.format("Profile name %s can't be deleted", name));
+            throw new IllegalArgumentException(
+                    String.format("Profile name %s can't be deleted", name));
         }
         getProfileOrThrow(name);
         updateConfig(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ImportProfileCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/profiles/ImportProfileCmd.java
@@ -42,7 +42,8 @@ public class ImportProfileCmd extends BaseProfileCmd {
 
     @CommandLine.Option(
             names = {"-u", "--update"},
-            description = "Allow updating the profile if it already exists. Note that the configuration will be overwritten and NOT merged")
+            description =
+                    "Allow updating the profile if it already exists. Note that the configuration will be overwritten and NOT merged")
     private boolean allowUpdate;
 
     @CommandLine.Option(
@@ -96,10 +97,8 @@ public class ImportProfileCmd extends BaseProfileCmd {
         validateProfile(newProfile);
         final NamedProfile existing = getProfile(name);
         if (!allowUpdate && existing != null) {
-            throw new IllegalArgumentException(
-                    String.format("Profile %s already exists", name));
+            throw new IllegalArgumentException(String.format("Profile %s already exists", name));
         }
-
 
         updateConfig(
                 langStreamCLIConfig -> {

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
@@ -286,7 +286,17 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("Profile default already exists", result.err());
         assertEquals("", result.out());
 
-        result = executeCommand("profiles", "update", "default", "--token", "tok2", "--web-service-url", "http://my.localhost:8080", "--api-gateway-url", "ws://my.localhost:8091");
+        result =
+                executeCommand(
+                        "profiles",
+                        "update",
+                        "default",
+                        "--token",
+                        "tok2",
+                        "--web-service-url",
+                        "http://my.localhost:8080",
+                        "--api-gateway-url",
+                        "ws://my.localhost:8091");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("profile default updated", result.out());
@@ -295,7 +305,14 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("http://my.localhost:8080", getConfig().getWebServiceUrl());
         assertEquals("ws://my.localhost:8091", getConfig().getApiGatewayUrl());
 
-        result = executeCommand("profiles", "import", "default", "--inline", "{\"webServiceUrl\":\"http://my0.localhost/ls\",\"tenant\":\"a-new\"}", "-u");
+        result =
+                executeCommand(
+                        "profiles",
+                        "import",
+                        "default",
+                        "--inline",
+                        "{\"webServiceUrl\":\"http://my0.localhost/ls\",\"tenant\":\"a-new\"}",
+                        "-u");
         assertEquals(0, result.exitCode());
         assertEquals("", result.err());
         assertEquals("profile default updated", result.out());
@@ -303,7 +320,6 @@ class ProfilesCmdTest extends CommandTestBase {
         assertEquals("http://my0.localhost/ls", getConfig().getWebServiceUrl());
         assertNull(getConfig().getToken());
         assertNull(getConfig().getApiGatewayUrl());
-
 
         result = executeCommand("profiles", "delete", "default");
         assertEquals(1, result.exitCode());

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/ProfilesCmdTest.java
@@ -283,22 +283,31 @@ class ProfilesCmdTest extends CommandTestBase {
 
         result = executeCommand("profiles", "create", "default");
         assertEquals(1, result.exitCode());
-        assertEquals("Profile name default is reserved", result.err());
+        assertEquals("Profile default already exists", result.err());
         assertEquals("", result.out());
 
-        result = executeCommand("profiles", "update", "default");
-        assertEquals(1, result.exitCode());
-        assertEquals("Profile name default is reserved", result.err());
-        assertEquals("", result.out());
+        result = executeCommand("profiles", "update", "default", "--token", "tok2", "--web-service-url", "http://my.localhost:8080", "--api-gateway-url", "ws://my.localhost:8091");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile default updated", result.out());
+        assertEquals("tok2", getConfig().getToken());
+        assertEquals("my-tenant", getConfig().getTenant());
+        assertEquals("http://my.localhost:8080", getConfig().getWebServiceUrl());
+        assertEquals("ws://my.localhost:8091", getConfig().getApiGatewayUrl());
 
-        result = executeCommand("profiles", "import", "default");
-        assertEquals(1, result.exitCode());
-        assertEquals("Profile name default is reserved", result.err());
-        assertEquals("", result.out());
+        result = executeCommand("profiles", "import", "default", "--inline", "{\"webServiceUrl\":\"http://my0.localhost/ls\",\"tenant\":\"a-new\"}", "-u");
+        assertEquals(0, result.exitCode());
+        assertEquals("", result.err());
+        assertEquals("profile default updated", result.out());
+        assertEquals("a-new", getConfig().getTenant());
+        assertEquals("http://my0.localhost/ls", getConfig().getWebServiceUrl());
+        assertNull(getConfig().getToken());
+        assertNull(getConfig().getApiGatewayUrl());
+
 
         result = executeCommand("profiles", "delete", "default");
         assertEquals(1, result.exitCode());
-        assertEquals("Profile name default is reserved", result.err());
+        assertEquals("Profile name default can't be deleted", result.err());
         assertEquals("", result.out());
     }
 


### PR DESCRIPTION
Currently it's not possible to update the default profile. This is not very handy. There's no strong reason to block the update
Changes:
* Now the default profile can be modified with `update` and `import`. It still cannot be deleted
