### PR TITLE
[compute-ai-embeddings] Compute Embeddings Agent: execute calls asynchronously and in batches while preserving per-key ordering 

### DIFF
--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
@@ -15,9 +15,9 @@
  */
 package com.datastax.oss.streaming.ai;
 
+import ai.langstream.api.util.BatchExecutor;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
 import com.datastax.oss.streaming.ai.model.JsonRecord;
-import com.datastax.oss.streaming.ai.util.TransformFunctionUtil;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public class ComputeAIEmbeddingsStep implements TransformStep {
     private final String embeddingsFieldName;
     private final EmbeddingsService embeddingsService;
 
-    private final TransformFunctionUtil.BatchExecutor<RecordHolder> batchExecutor;
+    private final BatchExecutor<RecordHolder> batchExecutor;
 
     private final ScheduledExecutorService executorService;
     private final Map<org.apache.avro.Schema, org.apache.avro.Schema> avroValueSchemaCache =
@@ -60,8 +60,7 @@ public class ComputeAIEmbeddingsStep implements TransformStep {
         this.executorService =
                 flushInterval > 0 ? Executors.newSingleThreadScheduledExecutor() : null;
         this.batchExecutor =
-                new TransformFunctionUtil.BatchExecutor<>(
-                        batchSize, this::processBatch, flushInterval, executorService);
+                new BatchExecutor<>(batchSize, this::processBatch, flushInterval, executorService);
     }
 
     @Override

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
@@ -59,13 +59,14 @@ public class ComputeAIEmbeddingsStep implements TransformStep {
             String embeddingsFieldName,
             int batchSize,
             long flushInterval,
+            int concurrency,
             EmbeddingsService embeddingsService) {
         this.template = Mustache.compiler().compile(text);
         this.embeddingsFieldName = embeddingsFieldName;
         this.embeddingsService = embeddingsService;
         this.executorService =
                 flushInterval > 0 ? Executors.newSingleThreadScheduledExecutor() : null;
-        int numBuckets = 4;
+        int numBuckets = concurrency > 0 ? concurrency : 1;
         this.batchExecutor =
                 new OrderedAsyncBatchExecutor<>(
                         batchSize,

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsStep.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.oss.streaming.ai;
 
-import ai.langstream.api.util.BatchExecutor;
+import ai.langstream.api.util.OrderedAsyncBatchExecutor;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
 import com.datastax.oss.streaming.ai.model.JsonRecord;
 import com.samskivert.mustache.Mustache;
@@ -23,23 +23,29 @@ import com.samskivert.mustache.Template;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 
 /**
  * Compute AI Embeddings from a template filled with the received message fields and metadata and
  * put the value into a new or existing field.
  */
+@Slf4j
 public class ComputeAIEmbeddingsStep implements TransformStep {
+
+    static final Random RANDOM = new Random();
 
     private final Template template;
     private final String embeddingsFieldName;
     private final EmbeddingsService embeddingsService;
 
-    private final BatchExecutor<RecordHolder> batchExecutor;
+    private final OrderedAsyncBatchExecutor<RecordHolder> batchExecutor;
 
     private final ScheduledExecutorService executorService;
     private final Map<org.apache.avro.Schema, org.apache.avro.Schema> avroValueSchemaCache =
@@ -59,8 +65,24 @@ public class ComputeAIEmbeddingsStep implements TransformStep {
         this.embeddingsService = embeddingsService;
         this.executorService =
                 flushInterval > 0 ? Executors.newSingleThreadScheduledExecutor() : null;
+        int numBuckets = 4;
         this.batchExecutor =
-                new BatchExecutor<>(batchSize, this::processBatch, flushInterval, executorService);
+                new OrderedAsyncBatchExecutor<>(
+                        batchSize,
+                        this::processBatch,
+                        flushInterval,
+                        numBuckets,
+                        ComputeAIEmbeddingsStep::computeHashForRecord,
+                        executorService);
+    }
+
+    private static int computeHashForRecord(RecordHolder record) {
+        Object key = record.transformContext.getKeyObject();
+        if (key != null) {
+            return Objects.hashCode(key);
+        } else {
+            return RANDOM.nextInt();
+        }
     }
 
     @Override
@@ -68,43 +90,61 @@ public class ComputeAIEmbeddingsStep implements TransformStep {
         batchExecutor.start();
     }
 
-    private void processBatch(List<RecordHolder> records) {
+    private void processBatch(List<RecordHolder> records, CompletableFuture<?> completionHandle) {
 
         // prepare batch API call
         List<String> texts = new ArrayList<>();
-        for (RecordHolder holder : records) {
-            TransformContext transformContext = holder.transformContext();
-            JsonRecord jsonRecord = transformContext.toJsonRecord();
-            String text = template.execute(jsonRecord);
-            texts.add(text);
+
+        try {
+            for (RecordHolder holder : records) {
+                TransformContext transformContext = holder.transformContext();
+                JsonRecord jsonRecord = transformContext.toJsonRecord();
+                String text = template.execute(jsonRecord);
+                texts.add(text);
+            }
+        } catch (Throwable error) {
+            // we cannot fail only some records, because we must keep the order
+            log.error(
+                    "At least one error failed the conversion to JSON, failing the whole batch",
+                    error);
+            errorForAll(records, error);
+            completionHandle.complete(null);
+            return;
         }
 
         CompletableFuture<List<List<Double>>> embeddings =
                 embeddingsService.computeEmbeddings(texts);
 
-        embeddings.whenComplete(
-                (result, error) -> {
-                    if (error != null) {
-                        for (int i = 0; i < records.size(); i++) {
-                            RecordHolder holder = records.get(i);
-                            holder.handle.completeExceptionally(error);
-                        }
-                        return;
-                    }
+        embeddings
+                .whenComplete(
+                        (result, error) -> {
+                            if (error != null) {
+                                errorForAll(records, error);
+                            } else {
+                                for (int i = 0; i < records.size(); i++) {
+                                    RecordHolder holder = records.get(i);
+                                    TransformContext transformContext = holder.transformContext();
+                                    List<Double> embeddingsForText = result.get(i);
+                                    transformContext.setResultField(
+                                            embeddingsForText,
+                                            embeddingsFieldName,
+                                            Schema.createArray(Schema.create(Schema.Type.DOUBLE)),
+                                            avroKeySchemaCache,
+                                            avroValueSchemaCache);
+                                    holder.handle().complete(null);
+                                }
+                            }
+                        })
+                .whenComplete(
+                        (a, b) -> {
+                            completionHandle.complete(null);
+                        });
+    }
 
-                    for (int i = 0; i < records.size(); i++) {
-                        RecordHolder holder = records.get(i);
-                        TransformContext transformContext = holder.transformContext();
-                        List<Double> embeddingsForText = result.get(i);
-                        transformContext.setResultField(
-                                embeddingsForText,
-                                embeddingsFieldName,
-                                Schema.createArray(Schema.create(Schema.Type.DOUBLE)),
-                                avroKeySchemaCache,
-                                avroValueSchemaCache);
-                        holder.handle().complete(null);
-                    }
-                });
+    private static void errorForAll(List<RecordHolder> records, Throwable error) {
+        for (RecordHolder holder : records) {
+            holder.handle.completeExceptionally(error);
+        }
     }
 
     @Override

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
@@ -37,24 +37,15 @@ public class OpenAIEmbeddingsService implements EmbeddingsService {
     public CompletableFuture<List<List<Double>>> computeEmbeddings(List<String> texts) {
         try {
             EmbeddingsOptions embeddingsOptions = new EmbeddingsOptions(texts);
-            CompletableFuture<List<List<Double>>> result =
-                    openAIClient
-                            .getEmbeddings(model, embeddingsOptions)
-                            .toFuture()
-                            .thenApply(
-                                    embeddings ->
-                                            embeddings.getData().stream()
-                                                    .map(embedding -> embedding.getEmbedding())
-                                                    .collect(Collectors.toList()));
+            return openAIClient
+                    .getEmbeddings(model, embeddingsOptions)
+                    .toFuture()
+                    .thenApply(
+                            embeddings ->
+                                    embeddings.getData().stream()
+                                            .map(embedding -> embedding.getEmbedding())
+                                            .collect(Collectors.toList()));
 
-            // we need to wait, in order to guarantee ordering
-            // TODO: we should not wait, but instead use an ordered executor (per key)
-            try {
-                result.join();
-            } catch (Throwable err) {
-                log.error("Cannot compute embeddings", err);
-            }
-            return result;
         } catch (RuntimeException err) {
             log.error("Cannot compute embeddings", err);
             return CompletableFuture.failedFuture(err);

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeAIEmbeddingsConfig.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/config/ComputeAIEmbeddingsConfig.java
@@ -34,6 +34,9 @@ public class ComputeAIEmbeddingsConfig extends StepConfig {
     @JsonProperty("batch-size")
     private int batchSize = 10;
 
+    @JsonProperty("concurrency")
+    private int concurrency = 4;
+
     // we disable flushing by default in order to avoid latency spikes
     // you should enable this feature in the case of background processing
     @JsonProperty("flush-interval")

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -78,10 +78,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -566,80 +562,6 @@ public class TransformFunctionUtil {
 
             public X509Certificate[] getAcceptedIssuers() {
                 return new X509Certificate[0];
-            }
-        }
-    }
-
-    /**
-     * Aggregate records in batches, depending on a batch size and a maximum idle time.
-     *
-     * @param <T>
-     */
-    public static class BatchExecutor<T> {
-        private final int batchSize;
-        private List<T> batch;
-        private long flushInterval;
-        private ScheduledExecutorService scheduledExecutorService;
-
-        private ScheduledFuture<?> scheduledFuture;
-
-        private final Consumer<List<T>> processor;
-
-        public BatchExecutor(
-                int batchSize,
-                Consumer<List<T>> processor,
-                long maxIdleTime,
-                ScheduledExecutorService scheduledExecutorService) {
-            this.batchSize = batchSize;
-            this.batch = new ArrayList<>(batchSize);
-            this.processor = processor;
-            this.flushInterval = maxIdleTime;
-            this.scheduledExecutorService = scheduledExecutorService;
-        }
-
-        public void start() {
-            if (flushInterval > 0) {
-                scheduledFuture =
-                        scheduledExecutorService.scheduleWithFixedDelay(
-                                this::flush, flushInterval, flushInterval, TimeUnit.MILLISECONDS);
-            }
-        }
-
-        public void stop() {
-            if (scheduledFuture != null) {
-                scheduledFuture.cancel(false);
-            }
-            flush();
-        }
-
-        private void flush() {
-            List<T> batchToProcess = null;
-            synchronized (this) {
-                if (batch.isEmpty()) {
-                    return;
-                }
-                if (!batch.isEmpty()) {
-                    batchToProcess = batch;
-                    batch = new ArrayList<>(batchSize);
-                }
-            }
-            // execute the processor our of the synchronized block
-            processor.accept(batchToProcess);
-        }
-
-        public void add(T t) {
-            List<T> batchToProcess = null;
-            synchronized (this) {
-                batch.add(t);
-                if (batch.size() >= batchSize || flushInterval <= 0) {
-                    batchToProcess = batch;
-                    batch = new ArrayList<>(batchSize);
-                }
-            }
-
-            // execute the processor our of the synchronized block
-            if (batchToProcess != null) {
-                processor.accept(batchToProcess);
             }
         }
     }

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -306,6 +306,7 @@ public class TransformFunctionUtil {
                 config.getEmbeddingsFieldName(),
                 config.getBatchSize(),
                 config.getFlushInterval(),
+                config.getConcurrency(),
                 embeddingsService);
     }
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/ComputeAIEmbeddingsTest.java
@@ -66,6 +66,7 @@ public class ComputeAIEmbeddingsTest {
                         "value.newField",
                         1,
                         500,
+                        1,
                         mockService);
 
         Record<?> outputRecord = Utils.process(record, step);
@@ -84,7 +85,7 @@ public class ComputeAIEmbeddingsTest {
         mockService.setEmbeddingsForText("key1", expectedEmbeddings);
         ComputeAIEmbeddingsStep step =
                 new ComputeAIEmbeddingsStep(
-                        "{{ key.keyField1 }}", "value.newField", 1, 500, mockService);
+                        "{{ key.keyField1 }}", "value.newField", 1, 500, 1, mockService);
 
         Record<?> outputRecord = Utils.process(Utils.createTestAvroKeyValueRecord(), step);
         KeyValueSchema<?, ?> messageSchema = (KeyValueSchema<?, ?>) outputRecord.getSchema();
@@ -123,6 +124,7 @@ public class ComputeAIEmbeddingsTest {
                         "value.newField",
                         1,
                         500,
+                        1,
                         mockService);
 
         Record<?> outputRecord = Utils.process(record, step);

--- a/langstream-api/src/main/java/ai/langstream/api/util/BatchExecutor.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/BatchExecutor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Aggregate records in batches, depending on a batch size and a maximum idle time.
+ *
+ * @param <T>
+ */
+public class BatchExecutor<T> {
+    private final int batchSize;
+    private List<T> batch;
+    private long flushInterval;
+    private ScheduledExecutorService scheduledExecutorService;
+
+    private ScheduledFuture<?> scheduledFuture;
+
+    private final Consumer<List<T>> processor;
+
+    public BatchExecutor(
+            int batchSize,
+            Consumer<List<T>> processor,
+            long maxIdleTime,
+            ScheduledExecutorService scheduledExecutorService) {
+        this.batchSize = batchSize;
+        this.batch = new ArrayList<>(batchSize);
+        this.processor = processor;
+        this.flushInterval = maxIdleTime;
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    public void start() {
+        if (flushInterval > 0) {
+            scheduledFuture =
+                    scheduledExecutorService.scheduleWithFixedDelay(
+                            this::flush, flushInterval, flushInterval, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    public void stop() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
+        }
+        flush();
+    }
+
+    private void flush() {
+        List<T> batchToProcess = null;
+        synchronized (this) {
+            if (batch.isEmpty()) {
+                return;
+            }
+            batchToProcess = batch;
+            batch = new ArrayList<>(batchSize);
+        }
+        // execute the processor out of the synchronized block
+        processor.accept(batchToProcess);
+    }
+
+    public void add(T t) {
+        List<T> batchToProcess = null;
+        synchronized (this) {
+            batch.add(t);
+            if (batch.size() >= batchSize || flushInterval <= 0) {
+                batchToProcess = batch;
+                batch = new ArrayList<>(batchSize);
+            }
+        }
+
+        // execute the processor out of the synchronized block
+        if (batchToProcess != null) {
+            processor.accept(batchToProcess);
+        }
+    }
+}

--- a/langstream-api/src/main/java/ai/langstream/api/util/OrderedAsyncBatchExecutor.java
+++ b/langstream-api/src/main/java/ai/langstream/api/util/OrderedAsyncBatchExecutor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api.util;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Aggregate records in batches, depending on a batch size and a maximum idle time.
+ *
+ * @param <T>
+ */
+public class OrderedAsyncBatchExecutor<T> {
+    private final int batchSize;
+    private final Map<Integer, Bucket> buckets;
+    private final int numBuckets;
+    private long flushInterval;
+    private ScheduledExecutorService scheduledExecutorService;
+
+    private ScheduledFuture<?> scheduledFuture;
+
+    private final BiConsumer<List<T>, CompletableFuture<?>> processor;
+
+    private final Function<T, Integer> hashFunction;
+
+    public OrderedAsyncBatchExecutor(
+            int batchSize,
+            BiConsumer<List<T>, CompletableFuture<?>> processor,
+            long maxIdleTime,
+            int numBuckets,
+            Function<T, Integer> hashFunction,
+            ScheduledExecutorService scheduledExecutorService) {
+        this.numBuckets = numBuckets;
+        this.hashFunction = hashFunction;
+        this.buckets = new HashMap<>();
+        for (int i = 0; i < numBuckets; i++) {
+            buckets.put(i, new Bucket());
+        }
+        this.batchSize = batchSize;
+        this.processor = processor;
+        this.flushInterval = maxIdleTime;
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    public void start() {
+        if (flushInterval > 0) {
+            scheduledFuture =
+                    scheduledExecutorService.scheduleWithFixedDelay(
+                            this::flush, flushInterval, flushInterval, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    public void stop() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
+        }
+        flush();
+    }
+
+    private void flush() {
+
+        buckets.values().forEach(Bucket::flush);
+    }
+
+    private Bucket bucket(int bucket) {
+        return buckets.get(Math.abs(bucket % numBuckets));
+    }
+
+    public void add(T t) {
+        int bucketIndex = hashFunction.apply(t);
+        Bucket bucket = bucket(bucketIndex);
+        bucket.add(t);
+    }
+
+    private class Bucket {
+        private final Queue<List<T>> pendingBatches = new ArrayDeque<>();
+        private final List<T> currentBatch = new ArrayList<>();
+
+        synchronized void add(T t) {
+            currentBatch.add(t);
+            if (currentBatch.size() >= batchSize || flushInterval <= 0) {
+                scheduleCurrentBatchExecution();
+            }
+        }
+
+        private synchronized void scheduleCurrentBatchExecution() {
+            if (currentBatch.isEmpty()) {
+                return;
+            }
+            List<T> batchToProcess = new ArrayList<>(currentBatch);
+            currentBatch.clear();
+            addToPendingBatches(batchToProcess);
+        }
+
+        private synchronized void processNextBatch() {
+            if (pendingBatches.isEmpty()) {
+                return;
+            }
+            List<T> nextBatch = pendingBatches.poll();
+            executeBatch(nextBatch);
+        }
+
+        private synchronized void addToPendingBatches(List<T> batchToProcess) {
+            if (pendingBatches.isEmpty()) {
+                executeBatch(batchToProcess);
+            } else {
+                pendingBatches.add(batchToProcess);
+            }
+        }
+
+        private void executeBatch(List<T> batchToProcess) {
+            CompletableFuture<?> currentBatchHandle = new CompletableFuture<>();
+            currentBatchHandle.whenComplete(
+                    (result, error) -> {
+                        processNextBatch();
+                    });
+            processor.accept(batchToProcess, currentBatchHandle);
+        }
+
+        private synchronized void flush() {
+            scheduleCurrentBatchExecution();
+        }
+    }
+}

--- a/langstream-api/src/test/java/ai/langstream/api/BatchExecutorTest.java
+++ b/langstream-api/src/test/java/ai/langstream/api/BatchExecutorTest.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.streaming.ai.util;
+package ai.langstream.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.langstream.api.util.BatchExecutor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -26,7 +27,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class TransformFunctionUtilTest {
+class BatchExecutorTest {
 
     static Object[][] batchSizes() {
         return new Object[][] {
@@ -50,8 +51,8 @@ class TransformFunctionUtilTest {
             records.add("text " + i);
         }
         List<String> result = new CopyOnWriteArrayList<>();
-        TransformFunctionUtil.BatchExecutor<String> executor =
-                new TransformFunctionUtil.BatchExecutor<>(
+        BatchExecutor<String> executor =
+                new BatchExecutor<>(
                         batchSize,
                         (batch) -> {
                             result.addAll(batch);
@@ -77,8 +78,8 @@ class TransformFunctionUtilTest {
             records.add("text " + i);
         }
         List<String> result = new CopyOnWriteArrayList<>();
-        TransformFunctionUtil.BatchExecutor<String> executor =
-                new TransformFunctionUtil.BatchExecutor<>(
+        BatchExecutor<String> executor =
+                new BatchExecutor<>(
                         batchSize,
                         (batch) -> {
                             result.addAll(batch);

--- a/langstream-api/src/test/java/ai/langstream/api/OrderedAsyncBatchExecutorTest.java
+++ b/langstream-api/src/test/java/ai/langstream/api/OrderedAsyncBatchExecutorTest.java
@@ -179,7 +179,8 @@ class OrderedAsyncBatchExecutorTest {
                         (batch, future) -> {
                             for (KeyValue record : batch) {
                                 List<KeyValue> resultsForKey =
-                                        results.computeIfAbsent(record.key, l -> new ArrayList<>());
+                                        results.computeIfAbsent(
+                                                record.key, l -> new CopyOnWriteArrayList<>());
                                 resultsForKey.add(record);
                             }
                             if (delay == 0) {
@@ -256,7 +257,8 @@ class OrderedAsyncBatchExecutorTest {
                         (batch, future) -> {
                             for (KeyValue record : batch) {
                                 List<KeyValue> resultsForKey =
-                                        results.computeIfAbsent(record.key, l -> new ArrayList<>());
+                                        results.computeIfAbsent(
+                                                record.key, l -> new CopyOnWriteArrayList<>());
                                 resultsForKey.add(record);
                             }
                             if (delay == 0) {

--- a/langstream-api/src/test/java/ai/langstream/api/OrderedAsyncBatchExecutorTest.java
+++ b/langstream-api/src/test/java/ai/langstream/api/OrderedAsyncBatchExecutorTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.langstream.api.util.OrderedAsyncBatchExecutor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Slf4j
+class OrderedAsyncBatchExecutorTest {
+
+    static Object[][] batchSizes() {
+        return new Object[][] {
+            new Object[] {0, 1},
+            new Object[] {1, 1},
+            new Object[] {1, 2},
+            new Object[] {2, 1},
+            new Object[] {2, 2},
+            new Object[] {3, 5},
+            new Object[] {5, 3}
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("batchSizes")
+    void executeInBatchesTestWithFlushInterval(int numRecords, int batchSize) {
+        long flushInterval = 1000;
+        int numBuckets = 4;
+        Function<String, Integer> hashFunction = String::hashCode;
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            records.add("text " + i);
+        }
+
+        List<String> result = new CopyOnWriteArrayList<>();
+        OrderedAsyncBatchExecutor<String> executor =
+                new OrderedAsyncBatchExecutor<>(
+                        batchSize,
+                        (batch, future) -> {
+                            result.addAll(batch);
+                            future.complete(null);
+                        },
+                        flushInterval,
+                        numBuckets,
+                        hashFunction,
+                        executorService);
+        executor.start();
+        records.forEach(executor::add);
+        // this may happen after some time
+        Awaitility.await().untilAsserted(() -> assertEqualsInAnyOrder(records, result));
+        executor.stop();
+        executorService.shutdown();
+    }
+
+    private static <T> void assertEqualsInAnyOrder(List<T> a, List<T> b) {
+        if (a.size() != b.size()) {
+            throw new AssertionError("Lists have different sizes");
+        }
+        assertEquals(new HashSet<>(a), new HashSet<>(b));
+    }
+
+    @ParameterizedTest
+    @MethodSource("batchSizes")
+    void executeInBatchesTestWithNoFlushInterval(int numRecords, int batchSize) {
+        long flushInterval = 0;
+        int numBuckets = 4;
+        Function<String, Integer> hashFunction = String::hashCode;
+        // this is not needed
+        ScheduledExecutorService executorService = null;
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < numRecords; i++) {
+            records.add("text " + i);
+        }
+        List<String> result = new CopyOnWriteArrayList<>();
+        OrderedAsyncBatchExecutor<String> executor =
+                new OrderedAsyncBatchExecutor<>(
+                        batchSize,
+                        (batch, future) -> {
+                            result.addAll(batch);
+                            future.complete(null);
+                        },
+                        flushInterval,
+                        numBuckets,
+                        hashFunction,
+                        executorService);
+        executor.start();
+        records.forEach(executor::add);
+        // this may happen after some time
+        Awaitility.await().untilAsserted(() -> assertEquals(records, result));
+        executor.stop();
+    }
+
+    static Object[][] batchSizesAndDelays() {
+        return new Object[][] {
+            new Object[] {0, 1, 0},
+            new Object[] {1, 1, 0},
+            new Object[] {1, 2, 0},
+            new Object[] {2, 1, 0},
+            new Object[] {2, 2, 0},
+            new Object[] {3, 5, 0},
+            new Object[] {5, 3, 0},
+            new Object[] {37, 5, 0},
+            new Object[] {50, 3, 0},
+            new Object[] {0, 1, 200},
+            new Object[] {1, 1, 200},
+            new Object[] {1, 2, 200},
+            new Object[] {2, 1, 200},
+            new Object[] {2, 2, 200},
+            new Object[] {3, 5, 200},
+            new Object[] {5, 3, 200},
+            new Object[] {37, 5, 200},
+            new Object[] {50, 3, 200}
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("batchSizesAndDelays")
+    void executeInBatchesTestWithKeyOrdering(int numRecords, int batchSize, long delay) {
+
+        record KeyValue(int key, String value) {}
+
+        long flushInterval = 1000;
+        int numBuckets = 4;
+        Function<KeyValue, Integer> hashFunction = KeyValue::key;
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        ScheduledExecutorService completionsExecutorService = Executors.newScheduledThreadPool(4);
+
+        List<KeyValue> records = new ArrayList<>();
+        Map<Integer, List<KeyValue>> recordsByKey = new HashMap<>();
+
+        for (int i = 0; i < numRecords; i++) {
+            int key = i % 7;
+            KeyValue record = new KeyValue(key, "text " + i);
+            records.add(record);
+            List<KeyValue> valuesForKey =
+                    recordsByKey.computeIfAbsent(record.key, l -> new ArrayList<>());
+            valuesForKey.add(record);
+        }
+
+        Random random = new Random();
+
+        Map<Integer, List<KeyValue>> results = new ConcurrentHashMap<>();
+        OrderedAsyncBatchExecutor<KeyValue> executor =
+                new OrderedAsyncBatchExecutor<>(
+                        batchSize,
+                        (batch, future) -> {
+                            for (KeyValue record : batch) {
+                                List<KeyValue> resultsForKey =
+                                        results.computeIfAbsent(record.key, l -> new ArrayList<>());
+                                resultsForKey.add(record);
+                            }
+                            if (delay == 0) {
+                                // execute the completions in the same thread
+                                future.complete(null);
+                            } else {
+                                // delay the completion of the future, and do it in a separate
+                                // thread
+                                long delayMillis = random.nextInt((int) delay);
+                                completionsExecutorService.schedule(
+                                        () -> future.complete(null),
+                                        delayMillis,
+                                        TimeUnit.MILLISECONDS);
+                            }
+                        },
+                        flushInterval,
+                        numBuckets,
+                        hashFunction,
+                        executorService);
+        executor.start();
+        records.forEach(executor::add);
+        // this may happen after some time
+        Awaitility.await()
+                .untilAsserted(
+                        () -> {
+                            recordsByKey.forEach(
+                                    (key, values) -> {
+                                        List<KeyValue> resultsForKey = results.get(key);
+                                        log.info(
+                                                "key: {}, values: {}, results: {}",
+                                                key,
+                                                values,
+                                                resultsForKey);
+                                        // the order must be preserved
+                                        assertEquals(values, resultsForKey);
+                                    });
+                        });
+        executor.stop();
+        executorService.shutdown();
+        completionsExecutorService.shutdown();
+    }
+}

--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
@@ -173,6 +173,12 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
                                             step,
                                             agentConfiguration,
                                             originalConfiguration,
+                                            "concurrency",
+                                            null);
+                                    optionalField(
+                                            step,
+                                            agentConfiguration,
+                                            originalConfiguration,
                                             "flush-interval",
                                             null);
                                     requiredField(

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -416,7 +416,7 @@
         <executions>
           <execution>
             <id>copy</id>
-            <phase>package</phase>
+            <phase>generate-test-sources</phase>
             <goals>
               <goal>copy</goal>
             </goals>

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ComputeEmbeddingsIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/ComputeEmbeddingsIT.java
@@ -219,6 +219,7 @@ class ComputeEmbeddingsIT extends AbstractApplicationRunner {
                                       model: "%s"
                                       embeddings-field: "value.embeddings"
                                       text: "something to embed"
+                                      concurrency: 1
                                       flush-interval: 0
                                 """
                                 .formatted(
@@ -361,6 +362,7 @@ class ComputeEmbeddingsIT extends AbstractApplicationRunner {
                                       embeddings-field: "value.embeddings"
                                       text: "something to embed"
                                       batch-size: 3
+                                      concurrency: 4
                                       flush-interval: 10000
                                 """
                                 .formatted(


### PR DESCRIPTION
Summary:

This patch comes with two contributions:
- OrderedAsyncBatchExecutor
- Using OrderedAsyncBatchExecutor in the Compute Embeddings Agent


## OrderedAsyncBatchExecutor

This  patch introduces an utility to implement batch computations, OrderedAsyncBatchExecutor, but with asynchronous completion and strict ordering guarantees.
This utility will be used by all the async agents, especially the ComputeEmbedding agent, the AI Chat completions, the Query  agents and the Vector DB Sink agents.

The idea is that for each record we compute an hash function that maps the record to a bucket. 
Each bucket processes the record in order by passing them in batches to an external processor.

The processor is supposed to be asynchronous and it must acknowledge the completion of the execution for the current batch (by completing a CompletableFuture).

OrderedAsyncBatchExecutor will never send two concurrent batches for the same bucket to the Processor, it always waits for the Processor to finish before submitting the next batch.


This patch also moves TransformFunctionUtil.BatchExecutor to a common module, in order to be used by other components, next to OrderedAsyncBatchExecutor

## Compute Embeddings Agent

The new utility is now used by the "compute-embeddings". The agent already sent batches of texts to the API, but before this patch it waited for each call to complete before sending the next batch.

The default behaviour, with flush-interval = 0, sends only one text at a time, and this is perfect for realtime chat.
When the flush-interval is greater than zero the texts are grouped, taking into consideration the key of the message, then they are sent to the API.

The new parameter "concurrency", with default = 4, defines how many concurrent APIs calls the agent can issue at a time. This works because we use the concurrency parameter to define the number of "buckets" for the underlying  OrderedAsyncBatchExecutor

