### PR TITLE
[kafka] Fix passing the replication-factor to create topics

### DIFF
--- a/langstream-core/src/test/resources/application1/pipeline1.yaml
+++ b/langstream-core/src/test/resources/application1/pipeline1.yaml
@@ -23,7 +23,21 @@ topics:
     creation-mode: create-if-not-exists
     schema:
       type: avro
-      schema: '{"type":"record","namespace":"examples","name":"Product","fields":[{"name":"id","type":"string"},{"name":"name","type":"string"},{"name":"description","type":"string"},{"name":"price","type":"double"},{"name":"category","type":"string"},{"name":"item-vector","type":"bytes"}]}}'
+      schema: |
+          {
+            "type":"record",
+            "namespace":"examples",
+            "name":"Product",
+            "fields":
+              [
+                {"name":"id","type":"string"},
+                {"name":"name","type":"string"},
+                {"name":"description","type":"string"},
+                {"name":"price","type":"double"},
+                {"name":"category","type":"string"},
+                {"name":"itemvector","type":"bytes"}
+             ]
+          }
 pipeline:
   - name: "Compute Vector using Embeddings API"
     type: "compute-embeddings"
@@ -31,9 +45,9 @@ pipeline:
     configuration:
       model: "gpt-3"
       template: "{{% name}} {{% description}}"
-      embeddings-field: "item-vector"
+      embeddings-field: "itemvector"
   - name: "Write to Database"
     type: "cassandra-sink"
     configuration:
       table: "{{globals.tableName}}"
-      mappings: "id=value.id,name=value.name,description=value.description,item_vector=value.item_vector"
+      mappings: "id=value.id,name=value.name,description=value.description,itemvector=value.itemvector"

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/KafkaTopicConnectionsRuntime.java
@@ -184,7 +184,11 @@ public class KafkaTopicConnectionsRuntime implements TopicConnectionsRuntime {
             switch (topic.createMode()) {
                 case TopicDefinition.CREATE_MODE_CREATE_IF_NOT_EXISTS -> {
                     log.info("Creating Kafka topic {}", topic.name());
-                    NewTopic newTopic = new NewTopic(topic.name(), topic.partitions(), (short) 1);
+                    NewTopic newTopic =
+                            new NewTopic(
+                                    topic.name(),
+                                    topic.partitions(),
+                                    (short) topic.replicationFactor());
                     if (topic.config() != null) {
                         newTopic.configs(
                                 topic.config().entrySet().stream()


### PR DESCRIPTION
Summary:
- fix passing the replication-factor option to the creation of Kafka topics
- enhance some examples about AVRO schemas