### PR TITLE
[webcrawler] Do not fail in case of unknown properties in the JSON file (handle backward compatibility)

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -108,7 +108,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         allowedDomains = getSet("allowed-domains", configuration);
         forbiddenPaths = getSet("forbidden-paths", configuration);
         maxUrls = getInt("max-urls", 1000, configuration);
-        int maxDepth = getInt("max-depth", 10, configuration);
+        int maxDepth = getInt("max-depth", 50, configuration);
         handleRobotsFile = getBoolean("handle-robots-file", true, configuration);
         scanHtmlDocuments = getBoolean("scan-html-documents", true, configuration);
         seedUrls = getSet("seed-urls", configuration);

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -32,6 +32,7 @@ import ai.langstream.api.runner.code.AgentSource;
 import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.minio.BucketExistsArgs;
 import io.minio.GetObjectArgs;
@@ -368,7 +369,9 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
     }
 
     private class S3StatusStorage implements StatusStorage {
-        private static final ObjectMapper MAPPER = new ObjectMapper();
+        private static final ObjectMapper MAPPER =
+                new ObjectMapper()
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         @Override
         public void storeStatus(Status status) throws Exception {


### PR DESCRIPTION
Summary:
- we recently changed the format of the JSON file with the status of the Web Crawler, this broke compatibility and you cannot easily upgrade the application to the newer version
- with this change in case of a broken JSON file (or with an incompatible format) we ignore the file and start from scratch

For docs:
- change the default of max-depth to 50