### PR TITLE
Fix compile warning

### DIFF
--- a/langstream-api-gateway/pom.xml
+++ b/langstream-api-gateway/pom.xml
@@ -285,7 +285,7 @@
 						<paths>
 							<path>src/main/docker/jib</path>
 							<path>
-								<from>${pom.build.directory}/agents</from>
+								<from>${project.build.directory}/agents</from>
 								<into>/app/agents</into>
 							</path>
 						</paths>


### PR DESCRIPTION
```
Warning:  Some problems were encountered while building the effective model for ai.langstream:langstream-api-gateway:jar:0.0.22-SNAPSHOT
Warning:  The expression $***pom.build.directory*** is deprecated. Please use $***project.build.directory*** instead.
```