### PR TITLE
Executor pod: set liveness and readiness probe

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
@@ -32,4 +32,12 @@ public class AgentResourceUnitConfiguration {
     private int maxInstanceUnits = 8;
 
     private int defaultMaxTotalResourceUnitsPerTenant = 0;
+
+    private int livenessProbeInitialDelaySeconds = 10;
+    private int livenessProbePeriodSeconds = 30;
+    private int livenessProbeTimeoutSeconds = 5;
+
+    private int readinessProbeInitialDelaySeconds = 10;
+    private int readinessProbePeriodSeconds = 30;
+    private int readinessProbeTimeoutSeconds = 5;
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourceUnitConfiguration.java
@@ -33,10 +33,12 @@ public class AgentResourceUnitConfiguration {
 
     private int defaultMaxTotalResourceUnitsPerTenant = 0;
 
+    private boolean enableLivenessProbe = true;
     private int livenessProbeInitialDelaySeconds = 10;
     private int livenessProbePeriodSeconds = 30;
     private int livenessProbeTimeoutSeconds = 5;
 
+    private boolean enableReadinessProbe = true;
     private int readinessProbeInitialDelaySeconds = 10;
     private int readinessProbePeriodSeconds = 30;
     private int readinessProbeTimeoutSeconds = 5;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
@@ -327,6 +327,9 @@ public class AgentResourcesFactory {
 
     private static Probe createLivenessProbe(
             AgentResourceUnitConfiguration agentResourceUnitConfiguration) {
+        if (!agentResourceUnitConfiguration.isEnableLivenessProbe()) {
+            return null;
+        }
         return new ProbeBuilder()
                 .withNewHttpGet()
                 .withNewPort()
@@ -343,6 +346,9 @@ public class AgentResourcesFactory {
 
     private static Probe createReadinessProbe(
             AgentResourceUnitConfiguration agentResourceUnitConfiguration) {
+        if (!agentResourceUnitConfiguration.isEnableReadinessProbe()) {
+            return null;
+        }
         return new ProbeBuilder()
                 .withNewHttpGet()
                 .withNewPort()

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactory.java
@@ -213,10 +213,8 @@ public class AgentResourcesFactory {
                         .withTerminationMessagePolicy("FallbackToLogsOnError")
                         .build();
 
-        final ContainerPort port = new ContainerPortBuilder()
-                .withName("http")
-                .withContainerPort(8080)
-                .build();
+        final ContainerPort port =
+                new ContainerPortBuilder().withName("http").withContainerPort(8080).build();
 
         final Container container =
                 new ContainerBuilder()
@@ -327,7 +325,8 @@ public class AgentResourcesFactory {
                 .build();
     }
 
-    private static Probe createLivenessProbe(AgentResourceUnitConfiguration agentResourceUnitConfiguration) {
+    private static Probe createLivenessProbe(
+            AgentResourceUnitConfiguration agentResourceUnitConfiguration) {
         return new ProbeBuilder()
                 .withNewHttpGet()
                 .withNewPort()
@@ -336,13 +335,14 @@ public class AgentResourcesFactory {
                 .withPath("/metrics")
                 .endHttpGet()
                 .withTimeoutSeconds(agentResourceUnitConfiguration.getLivenessProbeTimeoutSeconds())
-                .withInitialDelaySeconds(agentResourceUnitConfiguration.getLivenessProbeInitialDelaySeconds())
+                .withInitialDelaySeconds(
+                        agentResourceUnitConfiguration.getLivenessProbeInitialDelaySeconds())
                 .withPeriodSeconds(agentResourceUnitConfiguration.getLivenessProbePeriodSeconds())
                 .build();
     }
 
-
-    private static Probe createReadinessProbe(AgentResourceUnitConfiguration agentResourceUnitConfiguration) {
+    private static Probe createReadinessProbe(
+            AgentResourceUnitConfiguration agentResourceUnitConfiguration) {
         return new ProbeBuilder()
                 .withNewHttpGet()
                 .withNewPort()
@@ -350,8 +350,10 @@ public class AgentResourcesFactory {
                 .endPort()
                 .withPath("/metrics")
                 .endHttpGet()
-                .withTimeoutSeconds(agentResourceUnitConfiguration.getReadinessProbeTimeoutSeconds())
-                .withInitialDelaySeconds(agentResourceUnitConfiguration.getReadinessProbeInitialDelaySeconds())
+                .withTimeoutSeconds(
+                        agentResourceUnitConfiguration.getReadinessProbeTimeoutSeconds())
+                .withInitialDelaySeconds(
+                        agentResourceUnitConfiguration.getReadinessProbeInitialDelaySeconds())
                 .withPeriodSeconds(agentResourceUnitConfiguration.getReadinessProbePeriodSeconds())
                 .build();
     }
@@ -464,14 +466,14 @@ public class AgentResourcesFactory {
                         "%f"
                                 .formatted(
                                         memCpuUnits
-                                        * agentResourceUnitConfiguration.getCpuPerUnit())));
+                                                * agentResourceUnitConfiguration.getCpuPerUnit())));
         quantities.put(
                 "memory",
                 Quantity.parse(
                         "%dM"
                                 .formatted(
                                         memCpuUnits
-                                        * agentResourceUnitConfiguration.getMemPerUnit())));
+                                                * agentResourceUnitConfiguration.getMemPerUnit())));
 
         return new ResourceRequirementsBuilder()
                 .withRequests(quantities)
@@ -610,8 +612,8 @@ public class AgentResourcesFactory {
                                                 agentsStatus);
                                         ApplicationStatus.AgentWorkerStatus
                                                 agentWorkerStatusWithInfo =
-                                                agentWorkerStatus.applyAgentStatus(
-                                                        agentsStatus);
+                                                        agentWorkerStatus.applyAgentStatus(
+                                                                agentsStatus);
                                         result.complete(agentWorkerStatusWithInfo);
                                     } else {
                                         log.warn(
@@ -707,9 +709,9 @@ public class AgentResourcesFactory {
                                                 podStatus.getUrl(), podStatus.getMessage());
                                         default -> throw new RuntimeException(
                                                 "Unexpected pod state: "
-                                                + podStatus.getState()
-                                                + " "
-                                                + e.getKey());
+                                                        + podStatus.getState()
+                                                        + " "
+                                                        + e.getKey());
                                     };
                             if (agentRunnerSpec != null) {
                                 status =
@@ -752,7 +754,7 @@ public class AgentResourcesFactory {
         if (!CRDConstants.RESOURCE_NAME_PATTERN.matcher(fullAgentId).matches()) {
             throw new IllegalArgumentException(
                     ("Agent id '%s' (computed as '%s') contains illegal characters. "
-                     + "Allowed characters are alphanumeric and dash. To fully control the agent id, you can set the 'id' field.")
+                                    + "Allowed characters are alphanumeric and dash. To fully control the agent id, you can set the 'id' field.")
                             .formatted(agentId, fullAgentId));
         }
         if (agentId.length() > MAX_AGENT_ID_LENGTH) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -281,7 +281,6 @@ class AgentResourcesFactoryTest {
                 statefulSet.getSpec().getTemplate().getMetadata().getAnnotations().get("ann1"));
     }
 
-
     @Test
     void testProbes() {
         final AgentCustomResource resource =
@@ -314,17 +313,24 @@ class AgentResourcesFactoryTest {
                                 .agentCustomResource(resource)
                                 .agentResourceUnitConfiguration(config)
                                 .build());
-        assertNull(statefulSet.getSpec().getTemplate().getSpec()
-                .getContainers()
-                .get(0)
-                .getReadinessProbe());
-        assertNotNull(statefulSet.getSpec().getTemplate().getSpec()
-                .getContainers()
-                .get(0)
-                .getLivenessProbe());
+        assertNull(
+                statefulSet
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getContainers()
+                        .get(0)
+                        .getReadinessProbe());
+        assertNotNull(
+                statefulSet
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getContainers()
+                        .get(0)
+                        .getLivenessProbe());
         config.setEnableReadinessProbe(true);
         config.setEnableLivenessProbe(false);
-
 
         statefulSet =
                 AgentResourcesFactory.generateStatefulSet(
@@ -333,14 +339,22 @@ class AgentResourcesFactoryTest {
                                 .agentResourceUnitConfiguration(config)
                                 .build());
 
-        assertNull(statefulSet.getSpec().getTemplate().getSpec()
-                .getContainers()
-                .get(0)
-                .getLivenessProbe());
-        assertNotNull(statefulSet.getSpec().getTemplate().getSpec()
-                .getContainers()
-                .get(0)
-                .getReadinessProbe());
+        assertNull(
+                statefulSet
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getContainers()
+                        .get(0)
+                        .getLivenessProbe());
+        assertNotNull(
+                statefulSet
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getContainers()
+                        .get(0)
+                        .getReadinessProbe());
 
         config.setEnableLivenessProbe(true);
         config.setLivenessProbeInitialDelaySeconds(25);
@@ -358,26 +372,32 @@ class AgentResourcesFactoryTest {
                                 .agentResourceUnitConfiguration(config)
                                 .build());
 
-        final Probe liveness = statefulSet.getSpec().getTemplate().getSpec()
-                .getContainers()
-                .get(0)
-                .getLivenessProbe();
+        final Probe liveness =
+                statefulSet
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getContainers()
+                        .get(0)
+                        .getLivenessProbe();
 
         assertEquals(25, liveness.getInitialDelaySeconds());
         assertEquals(10, liveness.getTimeoutSeconds());
         assertEquals(60, liveness.getPeriodSeconds());
 
-
-        final Probe readiness = statefulSet.getSpec().getTemplate().getSpec()
-                .getContainers()
-                .get(0)
-                .getReadinessProbe();
+        final Probe readiness =
+                statefulSet
+                        .getSpec()
+                        .getTemplate()
+                        .getSpec()
+                        .getContainers()
+                        .get(0)
+                        .getReadinessProbe();
 
         assertEquals(35, readiness.getInitialDelaySeconds());
         assertEquals(8, readiness.getTimeoutSeconds());
         assertEquals(80, readiness.getPeriodSeconds());
     }
-
 
     private AgentCustomResource getCr(String yaml) {
         return SerializationUtil.readYaml(yaml, AgentCustomResource.class);

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/agents/AgentResourcesFactoryTest.java
@@ -21,6 +21,7 @@ import ai.langstream.deployer.k8s.PodTemplate;
 import ai.langstream.deployer.k8s.api.crds.agents.AgentCustomResource;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.TolerationBuilder;
@@ -105,11 +106,24 @@ class AgentResourcesFactoryTest {
                                   value: /app-code-download
                                 image: busybox
                                 imagePullPolicy: Never
+                                livenessProbe:
+                                  httpGet:
+                                    path: /metrics
+                                    port: http
+                                  initialDelaySeconds: 10
+                                  periodSeconds: 30
+                                  timeoutSeconds: 5
                                 name: runtime
                                 ports:
                                 - containerPort: 8080
                                   name: http
-                                  protocol: TCP
+                                readinessProbe:
+                                  httpGet:
+                                    path: /metrics
+                                    port: http
+                                  initialDelaySeconds: 10
+                                  periodSeconds: 30
+                                  timeoutSeconds: 5
                                 resources:
                                   limits:
                                     cpu: 0.500000
@@ -266,6 +280,104 @@ class AgentResourcesFactoryTest {
                 "value1",
                 statefulSet.getSpec().getTemplate().getMetadata().getAnnotations().get("ann1"));
     }
+
+
+    @Test
+    void testProbes() {
+        final AgentCustomResource resource =
+                getCr(
+                        """
+                apiVersion: langstream.ai/v1alpha1
+                kind: Agent
+                metadata:
+                  name: test-agent1
+                  namespace: default
+                spec:
+                    image: busybox
+                    imagePullPolicy: Never
+                    agentConfigSecretRef: agent-config
+                    agentConfigSecretRefChecksum: xx
+                    tenant: my-tenant
+                    applicationId: the-'app
+                    agentId: my-agent
+                    resources:
+                        parallelism: 2
+                        size: 4
+                """);
+
+        final AgentResourceUnitConfiguration config = new AgentResourceUnitConfiguration();
+        config.setEnableReadinessProbe(false);
+
+        StatefulSet statefulSet =
+                AgentResourcesFactory.generateStatefulSet(
+                        AgentResourcesFactory.GenerateStatefulsetParams.builder()
+                                .agentCustomResource(resource)
+                                .agentResourceUnitConfiguration(config)
+                                .build());
+        assertNull(statefulSet.getSpec().getTemplate().getSpec()
+                .getContainers()
+                .get(0)
+                .getReadinessProbe());
+        assertNotNull(statefulSet.getSpec().getTemplate().getSpec()
+                .getContainers()
+                .get(0)
+                .getLivenessProbe());
+        config.setEnableReadinessProbe(true);
+        config.setEnableLivenessProbe(false);
+
+
+        statefulSet =
+                AgentResourcesFactory.generateStatefulSet(
+                        AgentResourcesFactory.GenerateStatefulsetParams.builder()
+                                .agentCustomResource(resource)
+                                .agentResourceUnitConfiguration(config)
+                                .build());
+
+        assertNull(statefulSet.getSpec().getTemplate().getSpec()
+                .getContainers()
+                .get(0)
+                .getLivenessProbe());
+        assertNotNull(statefulSet.getSpec().getTemplate().getSpec()
+                .getContainers()
+                .get(0)
+                .getReadinessProbe());
+
+        config.setEnableLivenessProbe(true);
+        config.setLivenessProbeInitialDelaySeconds(25);
+        config.setLivenessProbeTimeoutSeconds(10);
+        config.setLivenessProbePeriodSeconds(60);
+
+        config.setReadinessProbeInitialDelaySeconds(35);
+        config.setReadinessProbeTimeoutSeconds(8);
+        config.setReadinessProbePeriodSeconds(80);
+
+        statefulSet =
+                AgentResourcesFactory.generateStatefulSet(
+                        AgentResourcesFactory.GenerateStatefulsetParams.builder()
+                                .agentCustomResource(resource)
+                                .agentResourceUnitConfiguration(config)
+                                .build());
+
+        final Probe liveness = statefulSet.getSpec().getTemplate().getSpec()
+                .getContainers()
+                .get(0)
+                .getLivenessProbe();
+
+        assertEquals(25, liveness.getInitialDelaySeconds());
+        assertEquals(10, liveness.getTimeoutSeconds());
+        assertEquals(60, liveness.getPeriodSeconds());
+
+
+        final Probe readiness = statefulSet.getSpec().getTemplate().getSpec()
+                .getContainers()
+                .get(0)
+                .getReadinessProbe();
+
+        assertEquals(35, readiness.getInitialDelaySeconds());
+        assertEquals(8, readiness.getTimeoutSeconds());
+        assertEquals(80, readiness.getPeriodSeconds());
+    }
+
 
     private AgentCustomResource getCr(String yaml) {
         return SerializationUtil.readYaml(yaml, AgentCustomResource.class);


### PR DESCRIPTION
Currently the executor doesn't have any readiness/liveness probe. 
The main problem is that the application status relies on the statefulset ready status. Therefore an app goes into DEPLOYED even if the executor has not started to consume messages yet.
This problem is more evident with the latest improvements on the classpath. The extraction of NAR agents/streaming runtime can take time in low-resource environments.

As user I'd expect that if an app is DEPLOYED, then I can use gateways and get answers in relevant time. 

Changes:
* This solution introduces readiness/liveness probes that check the metrics endpoint. The http server is setup only after all the executor unpackaging has been done and right before creating the streaming consumer.
* The values are configurable in the deployer configuration


 