### PR TITLE
Implement ai-text-completions for VertexAI and HuggingFace inf

### DIFF
--- a/examples/applications/vertexai-text-completions/README.md
+++ b/examples/applications/vertexai-text-completions/README.md
@@ -1,0 +1,32 @@
+# OpenAI Instruct Completions
+
+This sample application shows how to use the `text-bison` model.
+
+## Configure VertexAI
+
+```
+export VERTEX_AI_PROJECT=...
+export VERTEX_AI_TOKEN=$(gcloud auth print-access-token)
+```
+
+## Deploy the LangStream application
+```
+langstream docker run test -app https://github.com/LangStream/langstream/examples/applications/vertexai-text-completions -s https://raw.githubusercontent.com/LangStream/langstream/main/examples/secrets/secrets.yaml 
+```
+
+## Chat with the model
+
+```
+./bin/langstream gateway chat test -g chat
+```
+
+This model is optimized to run tasks. For example, you can ask it to translate a document into another language.
+
+```
+You: 
+> Translate "How are you?" in Italian
+```
+
+
+
+

--- a/examples/applications/vertexai-text-completions/configuration.yaml
+++ b/examples/applications/vertexai-text-completions/configuration.yaml
@@ -1,0 +1,28 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+configuration:
+  resources:
+    - type: "vertex-configuration"
+      name: "Google Vertex AI configuration"
+      configuration:
+        url: "{{ secrets.vertex-ai.url }}"
+        # use triple quotes in order to turn off escaping
+        serviceAccountJson: "{{{ secrets.vertex-ai.serviceAccountJson }}}"
+        token: "{{ secrets.vertex-ai.token }}"
+        region: "{{ secrets.vertex-ai.region }}"
+        project: "{{ secrets.vertex-ai.project }}"

--- a/examples/applications/vertexai-text-completions/gateways.yaml
+++ b/examples/applications/vertexai-text-completions/gateways.yaml
@@ -1,0 +1,26 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+gateways:
+  - id: chat
+    type: chat
+    chat-options:
+      answers-topic: answers
+      questions-topic: questions
+      headers:
+        - key: langstream-client-session-id
+          value-from-parameters: sessionId

--- a/examples/applications/vertexai-text-completions/pipeline.yaml
+++ b/examples/applications/vertexai-text-completions/pipeline.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+topics:
+  - name: "questions"
+    creation-mode: create-if-not-exists
+  - name: "answers"
+    creation-mode: create-if-not-exists
+pipeline:
+  - name: "convert-to-json"
+    type: "document-to-json"
+    input: "questions"
+    configuration:
+      text-field: "question"
+  - name: "ai-text-completions"
+    type: "ai-text-completions"
+    output: "answers"
+    configuration:
+      model: "{{{secrets.vertex-ai.text-completions-model}}}"
+      # on the log-topic we add a field with the answer
+      completion-field: "value.answer"
+      # we are also logging the prompt we sent to the LLM
+      log-field: "value.prompt"
+      prompt:
+        - "{{% value.question}}"

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -39,6 +39,8 @@ secrets:
       serviceAccountJson: "${VERTEX_AI_JSON:-}"
       region: "${VERTEX_AI_REGION:-us-central1}"
       project: "${VERTEX_AI_PROJECT:-}"
+      chat-completions-model: "${VERTEX_AI_CHAT_COMPLETIONS_MODEL:-chat-bison}"
+      text-completions-model: "${VERTEX_AI_TEXT_COMPLETIONS_MODEL:-text-bison}"
   - id: hugging-face
     data:
       access-key: ${HUGGING_FACE_ACCESS_KEY:-}

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/HuggingFaceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/HuggingFaceProvider.java
@@ -168,8 +168,7 @@ public class HuggingFaceProvider implements ServiceProviderProvider {
                     List<String> prompt,
                     StreamingChunksConsumer streamingChunksConsumer,
                     Map<String, Object> options) {
-                return callHFService(prompt, options)
-                        .thenApply(r -> r.get(0).sequence);
+                return callHFService(prompt, options).thenApply(r -> r.get(0).sequence);
             }
 
             @Override
@@ -179,15 +178,16 @@ public class HuggingFaceProvider implements ServiceProviderProvider {
                     StreamingChunksConsumer streamingChunksConsumer,
                     Map<String, Object> map) {
 
-
-                return callHFService(list.stream()
-                        .map(ChatMessage::getContent)
-                        .collect(Collectors.toList()), map)
+                return callHFService(
+                                list.stream()
+                                        .map(ChatMessage::getContent)
+                                        .collect(Collectors.toList()),
+                                map)
                         .thenApply(r -> responseBeanToChatCompletions(r));
             }
 
-            private CompletableFuture<List<ResponseBean>> callHFService(List<String> content, Map<String, Object> map)
-                    throws JsonProcessingException {
+            private CompletableFuture<List<ResponseBean>> callHFService(
+                    List<String> content, Map<String, Object> map) throws JsonProcessingException {
                 String model = (String) map.get("model");
                 // https://huggingface.co/docs/api-inference/quicktour
                 String url = this.url + "/models/%s";
@@ -204,8 +204,7 @@ public class HuggingFaceProvider implements ServiceProviderProvider {
                                         .POST(HttpRequest.BodyPublishers.ofString(request))
                                         .build(),
                                 HttpResponse.BodyHandlers.ofString());
-                return responseHandle.thenApply(
-                        response -> convertResponse(response));
+                return responseHandle.thenApply(response -> convertResponse(response));
             }
 
             @SneakyThrows
@@ -218,7 +217,8 @@ public class HuggingFaceProvider implements ServiceProviderProvider {
                 return responseBeans;
             }
 
-            private static ChatCompletions responseBeanToChatCompletions(List<ResponseBean> responseBeans) {
+            private static ChatCompletions responseBeanToChatCompletions(
+                    List<ResponseBean> responseBeans) {
                 ChatCompletions result = new ChatCompletions();
                 result.setChoices(
                         responseBeans.stream()

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/VertexAIProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/VertexAIProvider.java
@@ -275,7 +275,6 @@ public class VertexAIProvider implements ServiceProviderProvider {
                 request.instances.add(instance);
                 appendRequestParameters(additionalConfiguration, request);
 
-
                 CompletableFuture<ChatPredictions> predictionsResult =
                         executeVertexCall(request, ChatPredictions.class, model);
                 return predictionsResult.thenApply(
@@ -312,7 +311,8 @@ public class VertexAIProvider implements ServiceProviderProvider {
                         });
             }
 
-            private void appendRequestParameters(Map<String, Object> additionalConfiguration, CompletionRequest request) {
+            private void appendRequestParameters(
+                    Map<String, Object> additionalConfiguration, CompletionRequest request) {
                 request.parameters = new HashMap<>();
 
                 if (additionalConfiguration.containsKey("temperature")) {
@@ -377,7 +377,6 @@ public class VertexAIProvider implements ServiceProviderProvider {
                 CompletionRequest request = new CompletionRequest();
                 request.instances.add(instance);
                 appendRequestParameters(options, request);
-
 
                 CompletableFuture<TextPredictions> predictionsResult =
                         executeVertexCall(request, TextPredictions.class, model);

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/VertexAIProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/VertexAIProvider.java
@@ -192,13 +192,19 @@ public class VertexAIProvider implements ServiceProviderProvider {
 
         @Override
         public CompletionsService getCompletionsService(Map<String, Object> map) throws Exception {
-            String model = (String) map.getOrDefault("model", "chat-bison");
+            String model = (String) map.get("model");
+            if (model == null) {
+                throw new IllegalArgumentException("'model' is required for completions service");
+            }
             return new VertexAICompletionsService(model);
         }
 
         @Override
         public EmbeddingsService getEmbeddingsService(Map<String, Object> map) throws Exception {
-            String model = (String) map.getOrDefault("model", "textembedding-gecko");
+            String model = (String) map.get("model");
+            if (model == null) {
+                throw new IllegalArgumentException("'model' is required for embeddings service");
+            }
             return new VertexAIEmbeddingsService(model);
         }
 
@@ -227,7 +233,11 @@ public class VertexAIProvider implements ServiceProviderProvider {
         }
 
         @Override
-        public void close() {}
+        public void close() {
+            if (refreshTokenExecutor != null) {
+                refreshTokenExecutor.shutdownNow();
+            }
+        }
 
         private class VertexAICompletionsService implements CompletionsService {
             private final String model;
@@ -243,42 +253,27 @@ public class VertexAIProvider implements ServiceProviderProvider {
                     StreamingChunksConsumer streamingChunksConsumer,
                     Map<String, Object> additionalConfiguration) {
                 // https://cloud.google.com/vertex-ai/docs/generative-ai/chat/chat-prompts
-                CompletionRequest request = new CompletionRequest();
-                CompletionRequest.Instance instance = new CompletionRequest.Instance();
-                request.instances.add(instance);
-                request.parameters = new HashMap<>();
-
-                if (additionalConfiguration.containsKey("temperature")) {
-                    request.parameters.put(
-                            "temperature", additionalConfiguration.get("temperature"));
-                }
-                if (additionalConfiguration.containsKey("max-tokens")) {
-                    request.parameters.put(
-                            "maxOutputTokens", additionalConfiguration.get("max-tokens"));
-                }
-                if (additionalConfiguration.containsKey("topP")) {
-                    request.parameters.put("topP", additionalConfiguration.get("topP"));
-                }
-                if (additionalConfiguration.containsKey("topK")) {
-                    request.parameters.put("topK", additionalConfiguration.get("topK"));
-                }
-
+                CompletionRequest.ChatInstance instance = new CompletionRequest.ChatInstance();
                 instance.context = "";
                 instance.examples = new ArrayList<>();
                 instance.messages =
                         list.stream()
                                 .map(
                                         m -> {
-                                            CompletionRequest.Message message =
-                                                    new CompletionRequest.Message();
+                                            CompletionRequest.ChatMessage message =
+                                                    new CompletionRequest.ChatMessage();
                                             message.content = m.getContent();
                                             message.author = m.getRole();
                                             return message;
                                         })
                                 .collect(Collectors.toList());
+                CompletionRequest request = new CompletionRequest();
+                request.instances.add(instance);
+                appendRequestParameters(additionalConfiguration, request);
 
-                CompletableFuture<Predictions> predictionsResult =
-                        executeVertexCall(request, Predictions.class, model);
+
+                CompletableFuture<ChatPredictions> predictionsResult =
+                        executeVertexCall(request, ChatPredictions.class, model);
                 return predictionsResult.thenApply(
                         predictions -> {
                             ChatCompletions completions = new ChatCompletions();
@@ -313,43 +308,82 @@ public class VertexAIProvider implements ServiceProviderProvider {
                         });
             }
 
+            private void appendRequestParameters(Map<String, Object> additionalConfiguration, CompletionRequest request) {
+                request.parameters = new HashMap<>();
+
+                if (additionalConfiguration.containsKey("temperature")) {
+                    request.parameters.put(
+                            "temperature", additionalConfiguration.get("temperature"));
+                }
+                if (additionalConfiguration.containsKey("max-tokens")) {
+                    request.parameters.put(
+                            "maxOutputTokens", additionalConfiguration.get("max-tokens"));
+                }
+                if (additionalConfiguration.containsKey("topP")) {
+                    request.parameters.put("topP", additionalConfiguration.get("topP"));
+                }
+                if (additionalConfiguration.containsKey("topK")) {
+                    request.parameters.put("topK", additionalConfiguration.get("topK"));
+                }
+            }
+
             @Data
             static class CompletionRequest {
                 Map<String, Object> parameters;
 
-                List<Instance> instances = new ArrayList<>();
+                List<Object> instances = new ArrayList<>();
 
                 @Data
-                static class Instance {
+                static class ChatInstance {
                     String context;
-                    List<Example> examples = new ArrayList<>();
-                    List<Message> messages = new ArrayList<>();
+                    List<ChatInstanceExample> examples = new ArrayList<>();
+                    List<ChatMessage> messages = new ArrayList<>();
                 }
 
                 @Data
-                static class Example {
+                static class ChatInstanceExample {
                     Map<String, Object> input;
                     Map<String, Object> output;
                 }
 
                 @Data
-                static class Message {
+                static class ChatMessage {
                     String author;
                     String content;
+                }
+
+                @Data
+                static class TextInstance {
+                    String prompt;
                 }
             }
 
             @Override
+            @SneakyThrows
             public CompletableFuture<String> getTextCompletions(
                     List<String> prompt,
                     StreamingChunksConsumer streamingChunksConsumer,
                     Map<String, Object> options) {
-                return CompletableFuture.failedFuture(
-                        new UnsupportedOperationException("Not implemented"));
+                if (prompt.size() != 1) {
+                    throw new IllegalArgumentException(
+                            "Vertex AI only supports a single prompt for text completions.");
+                }
+                // https://cloud.google.com/vertex-ai/docs/generative-ai/chat/chat-prompts
+                CompletionRequest.TextInstance instance = new CompletionRequest.TextInstance();
+                instance.prompt = prompt.get(0);
+                CompletionRequest request = new CompletionRequest();
+                request.instances.add(instance);
+                appendRequestParameters(options, request);
+
+
+                CompletableFuture<TextPredictions> predictionsResult =
+                        executeVertexCall(request, TextPredictions.class, model);
+                return predictionsResult.thenApply(
+                        predictions -> predictions.predictions.get(0).content);
             }
 
             @Data
-            static class Predictions {
+            static class ChatPredictions {
 
                 List<Prediction> predictions;
 
@@ -363,6 +397,18 @@ public class VertexAIProvider implements ServiceProviderProvider {
                         String author;
                         String content;
                     }
+                }
+            }
+
+            @Data
+            static class TextPredictions {
+
+                List<Prediction> predictions;
+
+                @Data
+                static class Prediction {
+
+                    String content;
                 }
             }
         }
@@ -424,6 +470,10 @@ public class VertexAIProvider implements ServiceProviderProvider {
 
     @SneakyThrows
     private static <T> T handleResponse(Class<T> responseType, HttpResponse<String> response) {
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException(
+                    "Unexpected status code: " + response.statusCode() + " " + response.body());
+        }
         String body = response.body();
         log.info("Response: {}", body);
         return MAPPER.readValue(body, responseType);

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/VertexAIProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/VertexAIProviderTest.java
@@ -41,7 +41,7 @@ class VertexAIProviderTest {
     void testCallEmbeddings(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(
                 post("/v1/projects/the-project/locations/us-central1/publishers/google/models/textembedding-gecko"
-                     + ":predict")
+                                + ":predict")
                         .willReturn(
                                 okJson(
                                         """
@@ -168,7 +168,6 @@ class VertexAIProviderTest {
                 chatCompletions.getChoices().get(0).getMessage().getContent());
     }
 
-
     @Test
     void testCallTextCompletion(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(
@@ -225,10 +224,7 @@ class VertexAIProviderTest {
                                 "top-k",
                                 3.0));
         String textCompletions =
-                service.getTextCompletions(
-                                List.of("explain a car"),
-                                null,
-                                Map.of("max_tokens", 3))
+                service.getTextCompletions(List.of("explain a car"), null, Map.of("max_tokens", 3))
                         .get();
         log.info("result: {}", textCompletions);
         assertEquals(

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/VertexAIProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/VertexAIProviderTest.java
@@ -40,24 +40,25 @@ class VertexAIProviderTest {
     @Test
     void testCallEmbeddings(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(
-                post("/v1/projects/the-project/locations/us-central1/publishers/google/models/textembedding-gecko:predict")
+                post("/v1/projects/the-project/locations/us-central1/publishers/google/models/textembedding-gecko"
+                     + ":predict")
                         .willReturn(
                                 okJson(
                                         """
-                   {
-                      "predictions": [
-                        {
-                          "embeddings": {
-                            "statistics": {
-                              "truncated": false,
-                              "token_count": 6
-                            },
-                            "values": [ 1.0, 5.4, 8.7]
-                          }
-                        }
-                      ]
-                    }
-                """)));
+                                                   {
+                                                      "predictions": [
+                                                        {
+                                                          "embeddings": {
+                                                            "statistics": {
+                                                              "truncated": false,
+                                                              "token_count": 6
+                                                            },
+                                                            "values": [ 1.0, 5.4, 8.7]
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                """)));
 
         VertexAIProvider provider = new VertexAIProvider();
         ServiceProvider implementation =
@@ -90,43 +91,43 @@ class VertexAIProviderTest {
                         .willReturn(
                                 okJson(
                                         """
-                   {
-                     "predictions": [
-                       {
-                         "safetyAttributes": [
-                           {
-                             "blocked": false,
-                             "scores": [],
-                             "categories": []
-                           }
-                         ],
-                         "citationMetadata": [
-                           {
-                             "citations": []
-                           }
-                         ],
-                         "candidates": [
-                           {
-                             "author": "1",
-                             "content": "A car is a wheeled, self-propelled motor vehicle used for transportation."
-                           }
-                         ]
-                       }
-                     ],
-                     "metadata": {
-                       "tokenMetadata": {
-                         "inputTokenCount": {
-                           "totalTokens": 5,
-                           "totalBillableCharacters": 11
-                         },
-                         "outputTokenCount": {
-                           "totalBillableCharacters": 63,
-                           "totalTokens": 15
-                         }
-                       }
-                     }
-                   }
-                """)));
+                                                   {
+                                                     "predictions": [
+                                                       {
+                                                         "safetyAttributes": [
+                                                           {
+                                                             "blocked": false,
+                                                             "scores": [],
+                                                             "categories": []
+                                                           }
+                                                         ],
+                                                         "citationMetadata": [
+                                                           {
+                                                             "citations": []
+                                                           }
+                                                         ],
+                                                         "candidates": [
+                                                           {
+                                                             "author": "1",
+                                                             "content": "A car is a wheeled, self-propelled motor vehicle used for transportation."
+                                                           }
+                                                         ]
+                                                       }
+                                                     ],
+                                                     "metadata": {
+                                                       "tokenMetadata": {
+                                                         "inputTokenCount": {
+                                                           "totalTokens": 5,
+                                                           "totalBillableCharacters": 11
+                                                         },
+                                                         "outputTokenCount": {
+                                                           "totalBillableCharacters": 63,
+                                                           "totalTokens": 15
+                                                         }
+                                                       }
+                                                     }
+                                                   }
+                                                """)));
 
         VertexAIProvider provider = new VertexAIProvider();
         ServiceProvider implementation =
@@ -165,6 +166,74 @@ class VertexAIProviderTest {
         assertEquals(
                 "A car is a wheeled, self-propelled motor vehicle used for transportation.",
                 chatCompletions.getChoices().get(0).getMessage().getContent());
+    }
+
+
+    @Test
+    void testCallTextCompletion(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(
+                post("/v1/projects/the-project/locations/us-central1/publishers/google/models/text-bison:predict")
+                        .willReturn(
+                                okJson(
+                                        """
+                                                   {
+                                                                                     "predictions": [
+                                                                                       {
+                                                                                         "citationMetadata": {
+                                                                                           "citations": []
+                                                                                         },
+                                                                                         "safetyAttributes": {
+                                                                                           "scores": [
+                                                                                             0.1
+                                                                                           ],
+                                                                                           "categories": [
+                                                                                             "Finance"
+                                                                                           ],
+                                                                                           "blocked": false
+                                                                                         },
+                                                                                         "content": "A car is a wheeled, self-propelled motor vehicle used for transportation."
+                                                                                       }
+                                                                                     ]
+                                                                                   }
+                                                """)));
+
+        VertexAIProvider provider = new VertexAIProvider();
+        ServiceProvider implementation =
+                provider.createImplementation(
+                        Map.of(
+                                "vertex",
+                                Map.of(
+                                        "url",
+                                        wmRuntimeInfo.getHttpBaseUrl(),
+                                        "project",
+                                        "the-project",
+                                        "region",
+                                        "us-central1",
+                                        "token",
+                                        "xxxx")));
+        CompletionsService service =
+                implementation.getCompletionsService(
+                        Map.of(
+                                "model",
+                                "text-bison",
+                                "max-tokens",
+                                3,
+                                "temperature",
+                                0.5,
+                                "top-p",
+                                1.0,
+                                "top-k",
+                                3.0));
+        String textCompletions =
+                service.getTextCompletions(
+                                List.of("explain a car"),
+                                null,
+                                Map.of("max_tokens", 3))
+                        .get();
+        log.info("result: {}", textCompletions);
+        assertEquals(
+                "A car is a wheeled, self-propelled motor vehicle used for transportation.",
+                textCompletions);
     }
 
     @Test


### PR DESCRIPTION
* Implemented `ai-text-completions` agent for vertexAI. Only one prompt must be specified. The API is the same and Vertex inference the response depending on the model. Using a text model in the chat agent will cause runtime errors. Using a chat model in the text agent will cause runtime errors.
* Implemented `ai-text-completions` agent for Hugging face. The API is the same as the chat-completions but in this way we support switching between providers while doing tests