### PR TITLE
Add support for Milvus Cloud - Zillis

### DIFF
--- a/examples/applications/query-milvus/configuration.yaml
+++ b/examples/applications/query-milvus/configuration.yaml
@@ -27,8 +27,14 @@ configuration:
     name: "MilvusDatasource"
     configuration:
       service: "milvus"
+      ## OSS Milvus
       username: "{{{ secrets.milvus.username }}}"
       password: "{{{ secrets.milvus.password }}}"
       host: "{{{ secrets.milvus.host }}}"
       port: "{{{ secrets.milvus.port }}}"
+      ## Set to "upsert" for OSS Milvus, on Zills use "delete-insert"
+      write-mode: "{{{ secrets.milvus.write-mode }}}"
+      ## Zillis
+      url: "{{{ secrets.milvus.url }}}"
+      token: "{{{ secrets.milvus.token }}}"
 

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -88,3 +88,6 @@ secrets:
       password: "${MILVUS_PASSWORD:-}"
       host: "${MILVUS_HOST:-}"
       port: "${MILVUS_PORT:-19530}"
+      url: "${MILVUS_URL:-}"
+      token: "${MILVUS_TOKEN:-}"
+      write-mode: "${MILVUS_WRITE_MODE:-upsert}"

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/milvus/MilvusAssetsManagerProvider.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/milvus/MilvusAssetsManagerProvider.java
@@ -118,13 +118,14 @@ public class MilvusAssetsManagerProvider implements AssetManagerProvider {
             execStatements(statements);
 
             MilvusServiceClient milvusClient = datasource.getMilvusClient();
+            DescribeCollectionParam.Builder builder =
+                    DescribeCollectionParam.newBuilder().withCollectionName(getCollectionName());
+            String databaseName = getDatabaseName();
+            if (databaseName != null && !databaseName.isEmpty()) {
+                builder.withDatabaseName(databaseName);
+            }
             R<DescribeCollectionResponse> describeCollectionResponse =
-                    milvusClient.describeCollection(
-                            DescribeCollectionParam.newBuilder()
-                                    .withCollectionName(getCollectionName())
-                                    .withDatabaseName(getDatabaseName())
-                                    .build());
-
+                    milvusClient.describeCollection(builder.build());
             MilvusModel.handleException(describeCollectionResponse);
 
             log.info(

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/milvus/MilvusDataSource.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/milvus/MilvusDataSource.java
@@ -48,14 +48,24 @@ public class MilvusDataSource implements DataSourceProvider {
     @Data
     public static final class MilvusConfig {
 
-        @JsonProperty(value = "user", required = true)
+        // Milvus OSS
+
+        @JsonProperty(value = "user")
         private String user = "default";
 
-        @JsonProperty(value = "password", required = true)
+        @JsonProperty(value = "password")
         private String password;
 
-        @JsonProperty(value = "host", required = true)
+        @JsonProperty(value = "host")
         private String host;
+
+        // Zillis service
+
+        @JsonProperty(value = "url")
+        private String url;
+
+        @JsonProperty(value = "token")
+        private String token;
 
         @JsonProperty(value = "port")
         private int port = 19530;
@@ -81,13 +91,24 @@ public class MilvusDataSource implements DataSourceProvider {
 
         @Override
         public void initialize(Map<String, Object> config) {
-            this.milvusClient =
-                    new MilvusServiceClient(
-                            ConnectParam.newBuilder()
-                                    .withHost(clientConfig.host)
-                                    .withPort(clientConfig.port)
-                                    .withAuthorization(clientConfig.user, clientConfig.password)
-                                    .build());
+            if (clientConfig.url != null && !clientConfig.url.isEmpty()) {
+                log.info("Connecting to Milvus service at {}", clientConfig.url);
+                this.milvusClient =
+                        new MilvusServiceClient(
+                                ConnectParam.newBuilder()
+                                        .withUri(clientConfig.url)
+                                        .withToken(clientConfig.token)
+                                        .build());
+            } else {
+                log.info("Connecting to Milvus at {}:{}", clientConfig.host, clientConfig.port);
+                this.milvusClient =
+                        new MilvusServiceClient(
+                                ConnectParam.newBuilder()
+                                        .withHost(clientConfig.host)
+                                        .withPort(clientConfig.port)
+                                        .withAuthorization(clientConfig.user, clientConfig.password)
+                                        .build());
+            }
         }
 
         @Override


### PR DESCRIPTION
Summary:
- add support for Milvus Cloud
- allow to configure url and token (instead of username/password/host/port)
- allow to configure write-mode: upsert|delete-insert because the service still doesn't support Upserts