### PR TITLE
[vector-db-sink] Implement support for writing to JDBC services

### DIFF
--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/QueryStepDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/QueryStepDataSource.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 public interface QueryStepDataSource extends AutoCloseable {
 
-    default void initialize(Map<String, Object> config) {}
+    default void initialize(Map<String, Object> config) throws Exception {}
 
     default List<Map<String, String>> fetchData(String query, List<Object> params) {
         return Collections.emptyList();

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/util/TransformFunctionUtil.java
@@ -151,6 +151,7 @@ public class TransformFunctionUtil {
         return openAIClientBuilder.buildAsyncClient();
     }
 
+    @SneakyThrows
     public static QueryStepDataSource buildDataSource(Map<String, Object> dataSourceConfig) {
         if (dataSourceConfig == null) {
             return new QueryStepDataSource() {};

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/datasource/JdbcDataSourceProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/datasource/JdbcDataSourceProviderTest.java
@@ -44,6 +44,7 @@ public class JdbcDataSourceProviderTest {
                                 "sa",
                                 "driverClass",
                                 "org.h2.Driver"));
+        implementation.initialize(null);
 
         try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test", "sa", "sa");
                 Statement statement = conn.createStatement()) {

--- a/langstream-agents/langstream-vector-agents/pom.xml
+++ b/langstream-agents/langstream-vector-agents/pom.xml
@@ -43,6 +43,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.herddb</groupId>
+      <artifactId>herddb-jdbc</artifactId>
+      <version>0.27.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- DataStax Cassandra Connector for Apache Kafka -->
       <groupId>com.datastax.oss</groupId>
       <artifactId>messaging-connectors-commons-core</artifactId>

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/QueryVectorDBAgent.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/QueryVectorDBAgent.java
@@ -45,7 +45,7 @@ public class QueryVectorDBAgent extends SingleRecordAgentProcessor {
     private Collection<StepPredicatePair> steps;
 
     @Override
-    public void init(Map<String, Object> configuration) {
+    public void init(Map<String, Object> configuration) throws Exception {
 
         Map<String, Object> datasourceConfiguration =
                 (Map<String, Object>) configuration.get("datasource");

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/jdbc/JdbcWriter.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/jdbc/JdbcWriter.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.vector.jdbc;
+
+import ai.langstream.ai.agents.GenAIToolKitAgent;
+import ai.langstream.ai.agents.datasource.impl.JdbcDataSourceProvider;
+import ai.langstream.api.database.VectorDatabaseWriter;
+import ai.langstream.api.database.VectorDatabaseWriterProvider;
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.util.ConfigurationUtils;
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.jstl.JstlEvaluator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JdbcWriter implements VectorDatabaseWriterProvider {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Override
+    public boolean supports(Map<String, Object> dataSourceConfig) {
+        return "jdbc".equals(dataSourceConfig.get("service"));
+    }
+
+    @Override
+    public JdbcVectorDatabaseWriter createImplementation(Map<String, Object> datasourceConfig) {
+        return new JdbcVectorDatabaseWriter(datasourceConfig);
+    }
+
+    public static class JdbcVectorDatabaseWriter implements VectorDatabaseWriter, AutoCloseable {
+
+        private Connection connection;
+
+        private String tableName;
+        private final LinkedHashMap<String, JstlEvaluator> primaryKey = new LinkedHashMap<>();
+        private final LinkedHashMap<String, JstlEvaluator> columns = new LinkedHashMap<>();
+
+        private PreparedStatement insert;
+        private PreparedStatement update;
+        private PreparedStatement delete;
+        private Map<String, Object> datasourceConfig;
+
+        public JdbcVectorDatabaseWriter(Map<String, Object> datasourceConfig) {
+            this.datasourceConfig = datasourceConfig;
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+
+        @Override
+        public void initialise(Map<String, Object> agentConfiguration) throws Exception {
+
+            this.connection = JdbcDataSourceProvider.buildConnection(datasourceConfig);
+            this.tableName = ConfigurationUtils.getString("table-name", null, agentConfiguration);
+
+            List<Map<String, Object>> fields =
+                    (List<Map<String, Object>>)
+                            agentConfiguration.getOrDefault("fields", List.of());
+            fields.forEach(
+                    field -> {
+                        boolean primaryKey =
+                                ConfigurationUtils.getBoolean("primary-key", false, field);
+                        if (primaryKey) {
+                            this.primaryKey.put(
+                                    field.get("name").toString(),
+                                    buildEvaluator(field, "expression", Object.class));
+                        } else {
+                            this.columns.put(
+                                    field.get("name").toString(),
+                                    buildEvaluator(field, "expression", Object.class));
+                        }
+                    });
+
+            int numParameters = columns.size() + primaryKey.size();
+            StringBuilder values = new StringBuilder();
+            for (int i = 0; i < numParameters; i++) {
+                if (i > 0) {
+                    values.append(",");
+                }
+                values.append("?");
+            }
+            String insertQuery =
+                    "INSERT INTO "
+                            + tableName
+                            + " ("
+                            + String.join(", ", primaryKey.keySet())
+                            + ","
+                            + String.join(", ", columns.keySet())
+                            + ") VALUES ("
+                            + values
+                            + ")";
+            log.info("insertQuery {}", insertQuery);
+            insert = connection.prepareStatement(insertQuery);
+
+            String updateQuery =
+                    "UPDATE "
+                            + tableName
+                            + " SET "
+                            + String.join("=?, ", columns.keySet())
+                            + " = ? WHERE "
+                            + String.join("=? AND ", primaryKey.keySet())
+                            + "=?";
+            update = connection.prepareStatement(updateQuery);
+            log.info("updateQuery {}", updateQuery);
+
+            String deleteQuery =
+                    "DELETE FROM "
+                            + tableName
+                            + " WHERE "
+                            + String.join("=? AND ", primaryKey.keySet())
+                            + "=?";
+            delete = connection.prepareStatement(deleteQuery);
+            log.info("deleteQuery {}", deleteQuery);
+        }
+
+        @Override
+        public synchronized CompletableFuture<?> upsert(
+                Record record, Map<String, Object> context) {
+            CompletableFuture<?> handle = new CompletableFuture<>();
+            try {
+                TransformContext transformContext =
+                        GenAIToolKitAgent.recordToTransformContext(record, true);
+
+                List<Object> primaryKeyValues = prepareValueList(transformContext, primaryKey);
+                List<Object> otherValues = prepareValueList(transformContext, columns);
+                if (record.value() != null) {
+                    int i = 1;
+                    for (Object value : otherValues) {
+                        update.setObject(i++, value);
+                    }
+                    for (Object value : primaryKeyValues) {
+                        update.setObject(i++, value);
+                    }
+                    int count = update.executeUpdate();
+                    if (count == 0) {
+                        i = 1;
+                        for (Object value : primaryKeyValues) {
+                            insert.setObject(i++, value);
+                        }
+                        for (Object value : otherValues) {
+                            insert.setObject(i++, value);
+                        }
+                        insert.executeUpdate();
+                    }
+                } else {
+                    int i = 1;
+                    for (Object value : primaryKeyValues) {
+                        delete.setObject(i++, value);
+                    }
+                    delete.executeUpdate();
+                }
+                handle.complete(null);
+            } catch (Exception e) {
+                handle.completeExceptionally(e);
+            }
+            return handle;
+        }
+
+        private List<Object> prepareValueList(
+                TransformContext transformContext, Map<String, JstlEvaluator> primaryKey) {
+            List<Object> result = new ArrayList<>();
+            primaryKey.forEach(
+                    (name, evaluator) -> {
+                        Object value = evaluator.evaluate(transformContext);
+                        if (log.isDebugEnabled()) {
+                            log.debug(
+                                    "setting value {} ({}) for field {}",
+                                    value,
+                                    value.getClass(),
+                                    name);
+                        }
+                        result.add(value);
+                    });
+            return result;
+        }
+
+        private static JstlEvaluator buildEvaluator(
+                Map<String, Object> agentConfiguration, String param, Class type) {
+            String expression = agentConfiguration.getOrDefault(param, "").toString();
+            if (expression == null || expression.isEmpty()) {
+                return null;
+            }
+            return new JstlEvaluator("${" + expression + "}", type);
+        }
+    }
+}

--- a/langstream-agents/langstream-vector-agents/src/main/resources/META-INF/services/ai.langstream.api.database.VectorDatabaseWriterProvider
+++ b/langstream-agents/langstream-vector-agents/src/main/resources/META-INF/services/ai.langstream.api.database.VectorDatabaseWriterProvider
@@ -1,3 +1,4 @@
 ai.langstream.agents.vector.pinecone.PineconeWriter
 ai.langstream.agents.vector.cassandra.CassandraWriter
 ai.langstream.agents.vector.milvus.MilvusWriter
+ai.langstream.agents.vector.jdbc.JdbcWriter

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/JdbcWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/JdbcWriterTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.vector.datasource.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.langstream.agents.vector.jdbc.JdbcWriter;
+import ai.langstream.ai.agents.datasource.impl.JdbcDataSourceProvider;
+import ai.langstream.api.runner.code.SimpleRecord;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+@Disabled("Waiting for HerdDB 2.28.0 release")
+public class JdbcWriterTest {
+
+    static final String CREATE_TABLE =
+            "CREATE TABLE DOCUMENTS (\n"
+                    + "  NAME string,\n"
+                    + "  CHUNK_ID int,  \n"
+                    + "  TEXT string,  \n"
+                    + "  vector floata, \n"
+                    + "  PRIMARY KEY(NAME, CHUNK_ID) \n"
+                    + ")";
+
+    @Test
+    void testWrite() throws Exception {
+        JdbcDataSourceProvider dataSourceProvider = new JdbcDataSourceProvider();
+        Map<String, Object> config =
+                Map.of("url", "jdbc:herddb:local", "driverClass", "herddb.jdbc.Driver");
+
+        String tableName = "documents";
+        int dimension = 32;
+        List<Float> vector = new ArrayList<>();
+        List<Float> vector2 = new ArrayList<>();
+        for (int i = 0; i < dimension; i++) {
+            vector.add(i * 1f / dimension);
+            vector2.add((i + 1) * 1f / dimension);
+        }
+        String vectorAsString = vector.toString();
+        String vector2AsString = vector2.toString();
+
+        try (JdbcDataSourceProvider.JdbcDataSourceImpl datasource =
+                        dataSourceProvider.createDataSourceImplementation(config);
+                JdbcWriter.JdbcVectorDatabaseWriter writer =
+                        new JdbcWriter().createImplementation(config)) {
+            datasource.initialize(null);
+
+            try (Statement statement = datasource.getConnection().createStatement(); ) {
+                statement.execute(CREATE_TABLE);
+            }
+
+            List<Map<String, Object>> fields =
+                    List.of(
+                            Map.of("name", "name", "expression", "key.name", "primary-key", true),
+                            Map.of(
+                                    "name",
+                                    "chunk_id",
+                                    "expression",
+                                    "key.chunk_id",
+                                    "primary-key",
+                                    true),
+                            Map.of(
+                                    "name",
+                                    "vector",
+                                    "expression",
+                                    "fn:toListOfFloat(value.vector)"),
+                            Map.of("name", "text", "expression", "value.text"));
+
+            writer.initialise(Map.of("table-name", tableName, "fields", fields));
+
+            // the PK contains a single quote in order to test escaping values in deletion
+            SimpleRecord record =
+                    SimpleRecord.of(
+                            "{\"name\": \"do'c1\", \"chunk_id\": 1}",
+                            """
+                                    {
+                                        "vector": %s,
+                                        "text": "Lorem ipsum..."
+                                    }
+                                    """
+                                    .formatted(vectorAsString));
+            writer.upsert(record, Map.of()).get();
+
+            String query =
+                    "SELECT name,text from documents order by cosine_similarity(vector,cast(? as float array)) DESC";
+            List<Object> params = List.of(vector);
+            List<Map<String, String>> results = datasource.fetchData(query, params);
+            log.info("Results: {}", results);
+
+            assertEquals(1, results.size());
+            assertEquals("do'c1", results.get(0).get("name"));
+            assertEquals("Lorem ipsum...", results.get(0).get("text"));
+
+            SimpleRecord recordUpdated =
+                    SimpleRecord.of(
+                            "{\"name\": \"do'c1\", \"chunk_id\": 1}",
+                            """
+                                    {
+                                        "vector": %s,
+                                        "text": "Lorem ipsum changed..."
+                                    }
+                                    """
+                                    .formatted(vector2AsString));
+            writer.upsert(recordUpdated, Map.of()).get();
+
+            List<Object> params2 = List.of(vector2);
+            List<Map<String, String>> results2 = datasource.fetchData(query, params2);
+            log.info("Results: {}", results2);
+
+            assertEquals(1, results2.size());
+            assertEquals("do'c1", results2.get(0).get("name"));
+            assertEquals("Lorem ipsum changed...", results2.get(0).get("text"));
+
+            SimpleRecord recordDelete =
+                    SimpleRecord.of("{\"name\": \"do'c1\", \"chunk_id\": 1}", null);
+            writer.upsert(recordDelete, Map.of()).get();
+
+            List<Map<String, String>> results3 = datasource.fetchData(query, params2);
+            log.info("Results: {}", results3);
+            assertEquals(0, results3.size());
+        }
+    }
+}

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
@@ -28,7 +28,7 @@ class PineconeDataSourceTest {
 
     @Test
     @Disabled
-    void testPineconeQuery() {
+    void testPineconeQuery() throws Exception {
         PineconeDataSource dataSource = new PineconeDataSource();
         Map<String, Object> config =
                 Map.of(
@@ -53,7 +53,7 @@ class PineconeDataSourceTest {
 
     @Test
     @Disabled
-    void testPineconeQueryWithFilter() {
+    void testPineconeQueryWithFilter() throws Exception {
         PineconeDataSource dataSource = new PineconeDataSource();
         Map<String, Object> config =
                 Map.of(


### PR DESCRIPTION
Summary:
- add support for writing to SQL database in the "vector-db-sink" agent
- we are going to use HerdDB embedded database for the unit tests, as it will support Vector search in the next 0.28.0 release (coming soon), the test is currently disable, we can enable it as soon as the new release is out
- please note that we are not importing any third party JDBC Driver (it is only a test dependency) in the docker images