### PR TITLE
Allow to configure more than one AI service

### DIFF
--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
@@ -369,11 +369,12 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
 
     private void generateAIProvidersConfiguration(
             Application applicationInstance,
+            Map<String, Object> originalConfiguration,
             Map<String, Object> configuration,
             ComputeClusterRuntime clusterRuntime,
             PluginsRegistry pluginsRegistry) {
         // let the user force the provider or detect it automatically
-        String service = (String) configuration.remove("service");
+        String service = (String) originalConfiguration.get("service");
         for (Resource resource : applicationInstance.getResources().values()) {
             Map<String, Object> configurationCopy =
                     clusterRuntime.getResourceImplementation(resource, pluginsRegistry);
@@ -382,7 +383,6 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
                     if (service == null || service.equals("vertex")) {
                         configuration.put("vertex", configurationCopy);
                     }
-                    configuration.put("vertex", configurationCopy);
                     break;
                 case "hugging-face-configuration":
                     if (service == null || service.equals("hugging-face")) {
@@ -443,7 +443,9 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
         Map<String, Object> configuration = new HashMap<>();
 
         generateAIProvidersConfiguration(
-                executionPlan.getApplication(), configuration, clusterRuntime, pluginsRegistry);
+                executionPlan.getApplication(),
+                originalConfiguration,
+                configuration, clusterRuntime, pluginsRegistry);
 
         generateSteps(
                 module,

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -298,7 +298,7 @@ public class ModelBuilder {
                             id = r.name();
                         }
                         if (id == null) {
-                            throw new RuntimeException("Resource 'name' is required");
+                            throw new RuntimeException("Resource 'name' or 'id' is required");
                         }
                         application.getResources().put(id, r);
                     });

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/AIProvidersResourceProvider.java
@@ -36,6 +36,7 @@ public class AIProvidersResourceProvider implements ResourceNodeProvider {
 
     private static final Set<String> SUPPORTED_TYPES =
             Set.of("open-ai-configuration", "hugging-face-configuration", "vertex-configuration");
+    protected static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Override
     public Map<String, Object> createImplementation(
@@ -77,7 +78,7 @@ public class AIProvidersResourceProvider implements ResourceNodeProvider {
         }
         if (!serviceAccountJson.isEmpty()) {
             try {
-                new ObjectMapper().readValue(serviceAccountJson, Map.class);
+                MAPPER.readValue(serviceAccountJson, Map.class);
             } catch (Exception e) {
                 throw new IllegalArgumentException(
                         "Invalid JSON for field serviceAccountJson in " + describe(resource).get(),

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/TextCompletionsIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/TextCompletionsIT.java
@@ -36,13 +36,24 @@ public class TextCompletionsIT extends BaseEndToEndTest {
 
     @BeforeAll
     public static void checkCredentials() {
-        appEnv =
+        try {
+            appEnv =
+                    getAppEnvMapFromSystem(
+                            List.of("OPEN_AI_ACCESS_KEY", "OPEN_AI_URL", "OPEN_AI_PROVIDER"));
+        } catch (Throwable t) {
+            // no openai - try vertex
+            appEnv =
+                    getAppEnvMapFromSystem(
+                            List.of(
+                                    "VERTEX_AI_URL",
+                                    "VERTEX_AI_TOKEN",
+                                    "VERTEX_AI_REGION",
+                                    "VERTEX_AI_PROJECT"));
+        }
+
+        appEnv.putAll(
                 getAppEnvMapFromSystem(
-                        List.of(
-                                "OPEN_AI_ACCESS_KEY",
-                                "OPEN_AI_URL",
-                                "OPEN_AI_TEXT_COMPLETIONS_MODEL",
-                                "OPEN_AI_PROVIDER"));
+                        List.of("TEXT_COMPLETIONS_MODEL", "TEXT_COMPLETIONS_SERVICE")));
     }
 
     @Test

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/kafka/RemoteKafkaProvider.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/kafka/RemoteKafkaProvider.java
@@ -63,12 +63,10 @@ public class RemoteKafkaProvider implements StreamingClusterProvider {
         final List<String> topics = getTopics();
         if (!topics.isEmpty()) {
             log.info("Deleting topics: {}", topics);
-            for (String topic : topics) {
-                admin.deleteTopics(List.of(topic)).all().get();
-            }
-
-            // admin.deleteTopics(topics).all().get();
+            admin.deleteTopics(topics).all().get();
+            log.info("Deleted topics: {}", topics);
         }
+        log.info("Topics after cleanup: {}", getTopics());
     }
 
     @Override

--- a/langstream-e2e-tests/src/test/resources/apps/text-completions/configuration.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/text-completions/configuration.yaml
@@ -23,3 +23,10 @@ configuration:
         url: "{{ secrets.open-ai.url }}"
         access-key: "{{ secrets.open-ai.access-key }}"
         provider: "{{ secrets.open-ai.provider }}"
+    - type: "vertex-configuration"
+      name: "Google Vertex AI configuration"
+      configuration:
+        url: "{{ secrets.vertex-ai.url }}"
+        token: "{{ secrets.vertex-ai.token }}"
+        region: "{{ secrets.vertex-ai.region }}"
+        project: "{{ secrets.vertex-ai.project }}"

--- a/langstream-e2e-tests/src/test/resources/apps/text-completions/configuration.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/text-completions/configuration.yaml
@@ -25,6 +25,7 @@ configuration:
         provider: "{{ secrets.open-ai.provider }}"
     - type: "vertex-configuration"
       name: "Google Vertex AI configuration"
+      id: "vertex"
       configuration:
         url: "{{ secrets.vertex-ai.url }}"
         token: "{{ secrets.vertex-ai.token }}"

--- a/langstream-e2e-tests/src/test/resources/apps/text-completions/pipeline.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/text-completions/pipeline.yaml
@@ -31,7 +31,7 @@ pipeline:
     type: "ai-text-completions"
     output: "ls-test-history-topic"
     configuration:
-      service: "{{{secrets.text-completions.service}}}"
+      ai-service: "{{{secrets.text-completions.service}}}"
       model: "{{{secrets.text-completions.model}}}"
       completion-field: "value.answer"
       log-field: "value.prompt"

--- a/langstream-e2e-tests/src/test/resources/apps/text-completions/pipeline.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/text-completions/pipeline.yaml
@@ -31,12 +31,12 @@ pipeline:
     type: "ai-text-completions"
     output: "ls-test-history-topic"
     configuration:
-      model: "{{{secrets.open-ai.text-completions-model}}}"
+      service: "{{{secrets.text-completions.service}}}"
+      model: "{{{secrets.text-completions.model}}}"
       completion-field: "value.answer"
       log-field: "value.prompt"
       stream-to-topic: "ls-test-output-topic"
       stream-response-completion-field: "value"
       min-chunks-per-message: 20
-      messages:
-        - role: user
-          content: "{{% value.question}}"
+      prompt:
+        - "{{% value.question}}"

--- a/langstream-e2e-tests/src/test/resources/secrets/secret1.yaml
+++ b/langstream-e2e-tests/src/test/resources/secrets/secret1.yaml
@@ -20,6 +20,12 @@ secrets:
     id: secret1
     data:
       value-key: "${SECRET1_VK}"
+  - name: text-completions
+    id: text-completions
+    data:
+      model: "${TEXT_COMPLETIONS_MODEL}"
+      service: "${TEXT_COMPLETIONS_SERVICE}"
+
   - name: cassandra
     id: cassandra
     data:
@@ -28,12 +34,17 @@ secrets:
       port: "${CASSANDRA_PORT}"
   - id: open-ai
     data:
-      access-key: "${OPEN_AI_ACCESS_KEY}"
-      url: "${OPEN_AI_URL}"
-      provider: "${OPEN_AI_PROVIDER}"
-      embeddings-model: "${OPEN_AI_EMBEDDINGS_MODEL}"
-      chat-completions-model: "${OPEN_AI_CHAT_COMPLETIONS_MODEL}"
-      text-completions-model: "${OPEN_AI_TEXT_COMPLETIONS_MODEL}"
+      access-key: "${OPEN_AI_ACCESS_KEY:-}"
+      url: "${OPEN_AI_URL:-}"
+      provider: "${OPEN_AI_PROVIDER:-openai}"
+      embeddings-model: "${OPEN_AI_EMBEDDINGS_MODEL:-}"
+      chat-completions-model: "${OPEN_AI_CHAT_COMPLETIONS_MODEL:-}"
+  - id: vertex-ai
+    data:
+      url: "${VERTEX_AI_URL:-}"
+      token: "${VERTEX_AI_TOKEN:-}"
+      region: "${VERTEX_AI_REGION:-}"
+      project: "${VERTEX_AI_PROJECT:-}"
   - id: astra
     data:
       clientId: "${ASTRA_CLIENT_ID}"

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/GenAIAgentsTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/GenAIAgentsTest.java
@@ -770,7 +770,7 @@ class GenAIAgentsTest {
                                         url: "http://something"
                                         access-key: "xxcxcxc"
                                         provider: "azure"
-                                    - name: vertex
+                                    - name: my-vertex
                                       type: vertex-configuration
                                       configuration:
                                         url: "http://something"
@@ -793,7 +793,7 @@ class GenAIAgentsTest {
                                     input: "input-topic"
                                     output: "output-topic"
                                     configuration:
-                                      service: "vertex"
+                                      ai-service: "my-vertex"
                                       model: "text-embedding-ada-002"
                                       embeddings-field: "value.embeddings"
                                       text: "{{% value.name }} {{% value.description }}"
@@ -803,10 +803,10 @@ class GenAIAgentsTest {
                         .getApplication();
 
         try (ApplicationDeployer deployer =
-                     ApplicationDeployer.builder()
-                             .registry(new ClusterRuntimeRegistry())
-                             .pluginsRegistry(new PluginsRegistry())
-                             .build()) {
+                ApplicationDeployer.builder()
+                        .registry(new ClusterRuntimeRegistry())
+                        .pluginsRegistry(new PluginsRegistry())
+                        .build()) {
 
             Module module = applicationInstance.getModule("module-1");
 


### PR DESCRIPTION
Currently if you configure both open-ai and vertex-ai as AI resources, the AI Agent will use the first one loaded at runtime. 

Changes:
* Added support for specifying the service type using `ai-service: x` where x must match a provider id/name

Example:

```yaml
configuration:
  resources:
    - name: open-ai
      type: open-ai-configuration
      configuration:
        url: "http://something"
        access-key: "xxcxcxc"
        provider: "azure"
    - name: my-vertex
      type: vertex-configuration
      configuration:
        url: "http://something"
        token: xx
        project: yy
```

```yaml
module: "module-1"
id: "pipeline-1"
topics:
  - name: "input-topic"
    creation-mode: create-if-not-exists
  - name: "output-topic"
    creation-mode: create-if-not-exists
pipeline:
  - name: "compute-embeddings"
    id: "step1"
    type: "compute-ai-embeddings"
    input: "input-topic"
    output: "output-topic"
    configuration:
      ai-service: "my-vertex" # refer to the ai-service
      model: "text-embedding-ada-002"
      embeddings-field: "value.embeddings"
      text: "{{% value.name }} {{% value.description }}"
```