### PR TITLE
Load app code in the setup job

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -233,8 +233,8 @@ public class AppResourcesFactory {
                 resolveContainerImagePullPolicy(imagePullPolicy, spec);
 
         final ApplicationSetupConfiguration config =
-                new ApplicationSetupConfiguration(applicationId, tenant, spec.getApplication(), spec.getCodeArchiveId());
-
+                new ApplicationSetupConfiguration(
+                        applicationId, tenant, spec.getApplication(), spec.getCodeArchiveId());
 
         Map<String, Object> initContainerConfigs = new LinkedHashMap<>();
         initContainerConfigs.put(appConfigVolumeName, config);

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/apps/AppResourcesFactory.java
@@ -226,13 +226,15 @@ public class AppResourcesFactory {
 
         final String clusterRuntimeConfigVolumeName = "cluster-runtime-config";
         final String appConfigVolumeName = "app-config";
+        final String clusterConfigVolume = "cluster-config";
 
         final String containerImage = resolveContainerImage(image, spec);
         final String containerImagePullPolicy =
                 resolveContainerImagePullPolicy(imagePullPolicy, spec);
 
         final ApplicationSetupConfiguration config =
-                new ApplicationSetupConfiguration(applicationId, tenant, spec.getApplication());
+                new ApplicationSetupConfiguration(applicationId, tenant, spec.getApplication(), spec.getCodeArchiveId());
+
 
         Map<String, Object> initContainerConfigs = new LinkedHashMap<>();
         initContainerConfigs.put(appConfigVolumeName, config);
@@ -256,6 +258,10 @@ public class AppResourcesFactory {
                         new VolumeMountBuilder()
                                 .withName(clusterRuntimeConfigVolumeName)
                                 .withMountPath("/%s".formatted(clusterRuntimeConfigVolumeName))
+                                .build(),
+                        new VolumeMountBuilder()
+                                .withName(clusterConfigVolume)
+                                .withMountPath("/cluster-config")
                                 .build());
         final List<EnvVar> envVars =
                 List.of(
@@ -270,6 +276,14 @@ public class AppResourcesFactory {
                         new EnvVarBuilder()
                                 .withName(ApplicationSetupConstants.APP_SECRETS_ENV)
                                 .withValue("/app-secrets/secrets")
+                                .build(),
+                        new EnvVarBuilder()
+                                .withName(ApplicationSetupConstants.CLUSTER_CONFIG_ENV)
+                                .withValue("/cluster-config/config")
+                                .build(),
+                        new EnvVarBuilder()
+                                .withName(ApplicationSetupConstants.TOKEN_ENV)
+                                .withValue("/var/run/secrets/kubernetes.io/serviceaccount/token")
                                 .build());
         final String cmd = isDeleteJob ? "cleanup" : "deploy";
 
@@ -300,6 +314,19 @@ public class AppResourcesFactory {
                         new VolumeBuilder()
                                 .withName(clusterRuntimeConfigVolumeName)
                                 .withEmptyDir(new EmptyDirVolumeSource())
+                                .build(),
+                        new VolumeBuilder()
+                                .withName(clusterConfigVolume)
+                                .withNewSecret()
+                                .withSecretName(CRDConstants.TENANT_CLUSTER_CONFIG_SECRET)
+                                .withItems(
+                                        new KeyToPathBuilder()
+                                                .withKey(
+                                                        CRDConstants
+                                                                .TENANT_CLUSTER_CONFIG_SECRET_KEY)
+                                                .withPath("config")
+                                                .build())
+                                .endSecret()
                                 .build());
         final String jobName = getSetupJobName(applicationId, isDeleteJob);
 

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/test/java/ai/langstream/deployer/k8s/apps/AppResourcesFactoryTest.java
@@ -306,6 +306,10 @@ class AppResourcesFactoryTest {
                                   value: /cluster-runtime-config/config
                                 - name: LANGSTREAM_APPLICATION_SETUP_APP_SECRETS
                                   value: /app-secrets/secrets
+                                - name: LANGSTREAM_APPLICATION_SETUP_CLUSTER_CONFIGURATION
+                                  value: /cluster-config/config
+                                - name: LANGSTREAM_APPLICATION_SETUP_TOKEN
+                                  value: /var/run/secrets/kubernetes.io/serviceaccount/token
                                 image: ubuntu
                                 imagePullPolicy: Always
                                 name: setup
@@ -321,9 +325,11 @@ class AppResourcesFactoryTest {
                                   name: app-secrets
                                 - mountPath: /cluster-runtime-config
                                   name: cluster-runtime-config
+                                - mountPath: /cluster-config
+                                  name: cluster-config
                               initContainers:
                               - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\"}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
+                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeArchiveId\\":\\"iiii\\"}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
                                 command:
                                 - bash
                                 - -c
@@ -345,6 +351,12 @@ class AppResourcesFactoryTest {
                                   secretName: test-'app
                               - emptyDir: {}
                                 name: cluster-runtime-config
+                              - name: cluster-config
+                                secret:
+                                  items:
+                                  - key: cluster-config
+                                    path: config
+                                  secretName: langstream-cluster-config
                         """,
                 SerializationUtil.writeAsYaml(
                         AppResourcesFactory.generateSetupJob(
@@ -390,6 +402,10 @@ class AppResourcesFactoryTest {
                                   value: /cluster-runtime-config/config
                                 - name: LANGSTREAM_APPLICATION_SETUP_APP_SECRETS
                                   value: /app-secrets/secrets
+                                - name: LANGSTREAM_APPLICATION_SETUP_CLUSTER_CONFIGURATION
+                                  value: /cluster-config/config
+                                - name: LANGSTREAM_APPLICATION_SETUP_TOKEN
+                                  value: /var/run/secrets/kubernetes.io/serviceaccount/token
                                 image: ubuntu
                                 imagePullPolicy: Always
                                 name: setup
@@ -405,9 +421,11 @@ class AppResourcesFactoryTest {
                                   name: app-secrets
                                 - mountPath: /cluster-runtime-config
                                   name: cluster-runtime-config
+                                - mountPath: /cluster-config
+                                  name: cluster-config
                               initContainers:
                               - args:
-                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\"}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
+                                - "echo '{\\"applicationId\\":\\"test-'\\"'\\"'app\\",\\"tenant\\":\\"my-tenant\\",\\"application\\":\\"{app: true}\\",\\"codeArchiveId\\":\\"iiii\\"}' > /app-config/config && echo '{}' > /cluster-runtime-config/config"
                                 command:
                                 - bash
                                 - -c
@@ -429,6 +447,12 @@ class AppResourcesFactoryTest {
                                   secretName: test-'app
                               - emptyDir: {}
                                 name: cluster-runtime-config
+                              - name: cluster-config
+                                secret:
+                                  items:
+                                  - key: cluster-config
+                                    path: config
+                                  secretName: langstream-cluster-config
                         """,
                 SerializationUtil.writeAsYaml(
                         AppResourcesFactory.generateSetupJob(

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -293,9 +293,8 @@ public class AppControllerIT {
         assertEquals("bash", initContainer.getCommand().get(0));
         assertEquals("-c", initContainer.getCommand().get(1));
         assertEquals(
-                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\","
-                        + "\"application\":\"{\\\"modules\\\": {}}\"}' > /app-config/config && echo '{}' > "
-                        + "/cluster-runtime-config/config",
+                "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": "
+                + "{}}\",\"codeArchiveId\":null}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
                 initContainer.getArgs().get(0));
     }
 
@@ -369,8 +368,8 @@ public class AppControllerIT {
         assertEquals("-c", initContainer.getCommand().get(1));
         assertEquals(
                 "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": "
-                        + "{}}\",\"codeStorageArchiveId\":null}' > /app-config/config && echo '{}' > "
-                        + "/cluster-runtime-config/config",
+                + "{}}\",\"codeStorageArchiveId\":null}' > /app-config/config && echo '{}' > "
+                + "/cluster-runtime-config/config",
                 initContainer.getArgs().get(0));
     }
 

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -294,7 +294,7 @@ public class AppControllerIT {
         assertEquals("-c", initContainer.getCommand().get(1));
         assertEquals(
                 "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": "
-                + "{}}\",\"codeArchiveId\":null}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
+                        + "{}}\",\"codeArchiveId\":null}' > /app-config/config && echo '{}' > /cluster-runtime-config/config",
                 initContainer.getArgs().get(0));
     }
 
@@ -368,8 +368,8 @@ public class AppControllerIT {
         assertEquals("-c", initContainer.getCommand().get(1));
         assertEquals(
                 "echo '{\"applicationId\":\"my-app\",\"tenant\":\"my-tenant\",\"application\":\"{\\\"modules\\\": "
-                + "{}}\",\"codeStorageArchiveId\":null}' > /app-config/config && echo '{}' > "
-                + "/cluster-runtime-config/config",
+                        + "{}}\",\"codeStorageArchiveId\":null}' > /app-config/config && echo '{}' > "
+                        + "/cluster-runtime-config/config",
                 initContainer.getArgs().get(0));
     }
 

--- a/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/application/ApplicationSetupConfiguration.java
+++ b/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/application/ApplicationSetupConfiguration.java
@@ -26,4 +26,5 @@ public class ApplicationSetupConfiguration {
     private String applicationId;
     private String tenant;
     private String application;
+    private String codeArchiveId;
 }

--- a/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/application/ApplicationSetupConstants.java
+++ b/langstream-runtime/langstream-runtime-api/src/main/java/ai/langstream/runtime/api/application/ApplicationSetupConstants.java
@@ -25,10 +25,14 @@ public class ApplicationSetupConstants {
     public static final String APP_CONFIG_ENV = "LANGSTREAM_APPLICATION_SETUP_APP_CONFIGURATION";
     public static final String APP_CONFIG_ENV_DEFAULT = "/app-config/config";
 
-    public static final String DOWNLOADED_CODE_PATH_ENV = "LANGSTREAM_AGENT_RUNNER_CODE_PATH";
-    public static final String DOWNLOADED_CODE_PATH_ENV_DEFAULT = "/app-code-download";
-
     public static final String APP_SECRETS_ENV = "LANGSTREAM_APPLICATION_SETUP_APP_SECRETS";
     public static final String AGENTS_ENV = "LANGSTREAM_APPLICATION_SETUP_AGENTS";
     public static final String AGENTS_ENV_DEFAULT = "/app/agents";
+
+    public static final String CLUSTER_CONFIG_ENV =
+            "LANGSTREAM_APPLICATION_SETUP_CLUSTER_CONFIGURATION";
+    public static final String CLUSTER_CONFIG_ENV_DEFAULT = "/cluster-config/config";
+    public static final String TOKEN_ENV = "LANGSTREAM_APPLICATION_SETUP_TOKEN";
+    public static final String TOKEN_ENV_DEFAULT =
+            "/var/run/secrets/kubernetes.io/serviceaccount/token";
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -46,8 +46,6 @@ import ai.langstream.runtime.agent.api.MetricsHttpServlet;
 import ai.langstream.runtime.agent.python.PythonCodeAgentProvider;
 import ai.langstream.runtime.agent.simple.IdentityAgentProvider;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.prometheus.client.hotspot.DefaultExports;
 import jakarta.servlet.Servlet;
 import java.io.IOException;

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -84,8 +84,6 @@ import org.eclipse.jetty.servlet.ServletHolder;
 /** This is the main entry point for the pods that run the LangStream runtime and Java code. */
 @Slf4j
 public class AgentRunner {
-    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
-
     private static MainErrorHandler mainErrorHandler =
             error -> {
                 log.error("Unexpected error", error);

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/application/ApplicationSetupRunnerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/application/ApplicationSetupRunnerStarter.java
@@ -111,7 +111,8 @@ public class ApplicationSetupRunnerStarter extends RuntimeStarter {
     }
 
     @SneakyThrows
-    private Path downloadApplicationCode(ApplicationSetupConfiguration applicationSetupConfiguration) {
+    private Path downloadApplicationCode(
+            ApplicationSetupConfiguration applicationSetupConfiguration) {
         if (applicationSetupConfiguration.getCodeArchiveId() == null) {
             log.warn(
                     "No code archive id provided, skipping download of application code. This might be an old version of the deployer/runtime.");
@@ -146,12 +147,16 @@ public class ApplicationSetupRunnerStarter extends RuntimeStarter {
         AgentCodeDownloader downloader = new AgentCodeDownloader();
 
         final DownloadAgentCodeConfiguration downloadConfig =
-                new DownloadAgentCodeConfiguration(downloadDirectory.toFile().getAbsolutePath(),
+                new DownloadAgentCodeConfiguration(
+                        downloadDirectory.toFile().getAbsolutePath(),
                         applicationSetupConfiguration.getTenant(),
                         applicationSetupConfiguration.getApplicationId(),
                         applicationSetupConfiguration.getCodeArchiveId());
 
-        log.info("Downloading application code {} with cluster config {}", downloadConfig, clusterConfiguration);
+        log.info(
+                "Downloading application code {} with cluster config {}",
+                downloadConfig,
+                clusterConfiguration);
         downloader.downloadCustomCode(clusterConfiguration, token, downloadConfig);
         log.info("Downloaded application code to {}", downloadDirectory);
         return downloadDirectory;


### PR DESCRIPTION
Follow up of #490 

The setup job loads the application code and use it during the assets creation if needed. 
This unblocks the Postgres example to use the assets