### PR TITLE
[local mode] Add examples about how to deploy HerdDB in minikube

### DIFF
--- a/dev/start-local.sh
+++ b/dev/start-local.sh
@@ -57,6 +57,9 @@ fi
 # Start MinIO (S3 blobstorage)
 kubectl apply -f helm/examples/minio-dev.yaml
 
+# Start HerdDB (Simple Vector Database)
+kubectl apply -f helm/examples/herddb-dev.yaml
+
 # Start LangStream
 helm repo add langstream https://langstream.github.io/charts
 helm repo update

--- a/examples/applications/docker-chatbot/configuration.yaml
+++ b/examples/applications/docker-chatbot/configuration.yaml
@@ -22,7 +22,9 @@ configuration:
       configuration:
         service: "jdbc"
         driverClass: "herddb.jdbc.Driver"
-        url: "jdbc:herddb:server:localhost:7000"
+        url: "{{secrets.herddb.url}}"
+        user: "{{secrets.herddb.user}}"
+        password: "{{secrets.herddb.password}}"
     - type: "open-ai-configuration"
       name: "OpenAI Azure configuration"
       configuration:

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -61,6 +61,11 @@ secrets:
       secure-connect-bundle: "${CASSANDRA_SECURE_BUNDLE:-}"
       contact-points: "${CASSANDRA_CONTACT_POINTS:-}"
       load-balancing-loadDc: "${CASSANDRA_LOAD_BALANCING_LOCALDC:-}"
+  - id: herddb
+    data:
+      url: ${HERDDB_URL:jdbc:herddb:server:localhost:7000}
+      user: ${HERDDB_USER:-herd}
+      password: ${HERDDB_PASSWORD:hda}
   - id: s3
     data:
       bucket-name: "${S3_BUCKET_NAME:-documents}"

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -63,7 +63,7 @@ secrets:
       load-balancing-loadDc: "${CASSANDRA_LOAD_BALANCING_LOCALDC:-}"
   - id: herddb
     data:
-      url: ${HERDDB_URL:jdbc:herddb:server:localhost:7000}
+      url: ${HERDDB_URL:jdbc:herddb:server:herddb.herddb-dev:7000}
       user: ${HERDDB_USER:-herd}
       password: ${HERDDB_PASSWORD:hda}
   - id: s3

--- a/helm/examples/herddb-dev.yaml
+++ b/helm/examples/herddb-dev.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: herddb-dev
+  labels:
+    name: herddb-dev
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: herddb
+  name: herddb
+  namespace: herddb-dev
+spec:
+  containers:
+  - name: herddb
+    image: herddb/herddb:0.28.0
+    ports:
+      -  containerPort: 7000
+         protocol: TCP
+         name: herddb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: herddb
+  name: herddb
+  namespace: herddb-dev # Change this value to match the namespace metadata.name
+spec:
+  ports:
+    - port: 7000
+      protocol: TCP
+      targetPort: 7000
+      name: herddb
+  selector:
+    app: herddb

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -265,10 +265,15 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
             commandLine.add("-v");
             commandLine.add(tmpSecretsFile.getAbsolutePath() + ":/code/secrets.yaml");
         }
+
+        // with this tricks K8S examples work on Docker seamlessly
         commandLine.add("--add-host");
         commandLine.add("minio.minio-dev.svc.cluster.local:127.0.0.1");
         commandLine.add("--add-host");
+        commandLine.add("herddb.herddb-dev.svc.cluster.local:127.0.0.1");
+        commandLine.add("--add-host");
         commandLine.add("my-cluster-kafka-bootstrap.kafka:127.0.0.1");
+
         // gateway
         commandLine.add("-p");
         commandLine.add("8091:8091");


### PR DESCRIPTION
Summary:
- add a simple YAML K8S manifest  similar to the Minio manifest to start a single pod HerdDB service
- change the secrets file to use the K8S name for HerdDB
- register the same name as an alias for localhost, like we do for Kafka and Minio, in "docker-run" mode