### PR TITLE
[apps] Allow to specify default values for globals in configuration.yaml

### DIFF
--- a/examples/applications/docker-chatbot/configuration.yaml
+++ b/examples/applications/docker-chatbot/configuration.yaml
@@ -18,7 +18,7 @@
 configuration:
   defaults:
     globals:
-      - website: "https://docs.langstream.ai/"
+       website: "https://docs.langstream.ai/"
   resources:
     - type: "datasource"
       name: "JdbcDatasource"

--- a/examples/applications/docker-chatbot/configuration.yaml
+++ b/examples/applications/docker-chatbot/configuration.yaml
@@ -16,6 +16,9 @@
 #
 
 configuration:
+  defaults:
+    globals:
+      - website: "https://docs.langstream.ai/"
   resources:
     - type: "datasource"
       name: "JdbcDatasource"

--- a/examples/applications/docker-chatbot/crawler.yaml
+++ b/examples/applications/docker-chatbot/crawler.yaml
@@ -41,8 +41,8 @@ pipeline:
   - name: "Crawl the WebSite"
     type: "webcrawler-source"
     configuration:
-      seed-urls: ["https://docs.langstream.ai/"]
-      allowed-domains: ["https://docs.langstream.ai"]
+      seed-urls: ["{{{globals.website}}}"]
+      allowed-domains: ["{{{globals.website}}}"]
       forbidden-paths: []
       min-time-between-requests: 500
       reindex-interval-seconds: 3600

--- a/langstream-core/src/test/resources/application1/configuration.yaml
+++ b/langstream-core/src/test/resources/application1/configuration.yaml
@@ -16,6 +16,13 @@
 #
 
 configuration:
+  defaults:
+    globals:
+      website: "https://docs.langstream.ai/"
+      table-name: "documents"
+      var1: default-value1
+      var2: default-value2
+      var3: default-value3
   resources:
     - type: "open-ai-configuration"
       name: "OpenAI Azure configuration"

--- a/langstream-core/src/test/resources/application1/configuration.yaml
+++ b/langstream-core/src/test/resources/application1/configuration.yaml
@@ -23,6 +23,9 @@ configuration:
       var1: default-value1
       var2: default-value2
       var3: default-value3
+      var-array1: [default-value1, default-value2, default-value3]
+      var-array2: [default-value1, default-value2, default-value3]
+      var-array3: [default-value1, default-value2, default-value3]
   resources:
     - type: "open-ai-configuration"
       name: "OpenAI Azure configuration"


### PR DESCRIPTION
Summary:
With this new feature you can define the default values of the "global variables" in the configuration.yaml,
this is very handy because now you don't need to use special instance.yaml files when you are using global variables.

Global variables are useful when you want to make your application parametric, but as soon as you start using them you need to craft dedicated instance.yaml files otherwise your application won't work.

Example for this new feature:

configuration.yaml
```yaml
   configuration:
      defaults:
         globals:
            website: https://langstream.ai
   resources:
      ...
```

instance.yaml
```yaml
   instance:
      globals:
         website: https://langstream.ai
```
