### PR TITLE
[ai-agents] Introduce the re-rank agent with MMR ranking

### DIFF
--- a/examples/applications/docker-chatbot/chatbot.yaml
+++ b/examples/applications/docker-chatbot/chatbot.yaml
@@ -40,10 +40,24 @@ pipeline:
     type: "query-vector-db"
     configuration:
       datasource: "JdbcDatasource"
-      query: "SELECT text FROM documents ORDER BY cosine_similarity(embeddings_vector, CAST(? as FLOAT ARRAY)) DESC LIMIT 5"
+      query: "SELECT text,embeddings_vector FROM documents ORDER BY cosine_similarity(embeddings_vector, CAST(? as FLOAT ARRAY)) DESC LIMIT 5"
       fields:
         - "value.question_embeddings"
       output-field: "value.related_documents"
+  - name: "re-rank documents with MMR"
+    type: "re-rank"
+    configuration:
+      field: "value.related_documents"
+      query-field: "value.question"
+      query-embeddings: "value.question_embeddings"
+      output-field: "value.related_documents"
+      query-text: "value.query"
+      text-field: "record.text"
+      embeddings-field: "record.embeddings_vector"
+      algorithm: "MMR"
+      lambda: 0.5
+      k1: 1.5
+      b: 0.7
   - name: "ai-chat-completions"
     type: "ai-chat-completions"
 

--- a/examples/applications/docker-chatbot/chatbot.yaml
+++ b/examples/applications/docker-chatbot/chatbot.yaml
@@ -40,18 +40,18 @@ pipeline:
     type: "query-vector-db"
     configuration:
       datasource: "JdbcDatasource"
-      query: "SELECT text,embeddings_vector FROM documents ORDER BY cosine_similarity(embeddings_vector, CAST(? as FLOAT ARRAY)) DESC LIMIT 5"
+      query: "SELECT text,embeddings_vector FROM documents ORDER BY cosine_similarity(embeddings_vector, CAST(? as FLOAT ARRAY)) DESC LIMIT 20"
       fields:
         - "value.question_embeddings"
       output-field: "value.related_documents"
   - name: "re-rank documents with MMR"
     type: "re-rank"
     configuration:
+      max: 5 # keep only the top 5 documents, because we have an hard limit on the prompt size
       field: "value.related_documents"
-      query-field: "value.question"
+      query-text: "value.question"
       query-embeddings: "value.question_embeddings"
       output-field: "value.related_documents"
-      query-text: "value.query"
       text-field: "record.text"
       embeddings-field: "record.embeddings_vector"
       algorithm: "MMR"

--- a/examples/applications/webcrawler-source/chatbot.yaml
+++ b/examples/applications/webcrawler-source/chatbot.yaml
@@ -40,13 +40,26 @@ pipeline:
     type: "query"
     configuration:
       datasource: "AstraDatasource"
-      query: "SELECT text FROM documents.documents ORDER BY embeddings_vector ANN OF ? LIMIT 5"
+      query: "SELECT text,embeddings_vector FROM documents.documents ORDER BY embeddings_vector ANN OF ? LIMIT 20"
       fields:
         - "value.question_embeddings"
       output-field: "value.related_documents"
+  - name: "re-rank documents with MMR"
+    type: "re-rank"
+    configuration:
+      max: 5 # keep only the top 5 documents, because we have an hard limit on the prompt size
+      field: "value.related_documents"
+      query-text: "value.question"
+      query-embeddings: "value.question_embeddings"
+      output-field: "value.related_documents"
+      text-field: "record.text"
+      embeddings-field: "record.embeddings_vector"
+      algorithm: "MMR"
+      lambda: 0.5
+      k1: 1.5
+      b: 0.7
   - name: "ai-chat-completions"
     type: "ai-chat-completions"
-
     configuration:
       model: "{{{secrets.open-ai.chat-completions-model}}}" # This needs to be set to the model deployment name, not the base name
       # on the log-topic we add a field with the answer

--- a/examples/applications/webcrawler-source/chatbot.yaml
+++ b/examples/applications/webcrawler-source/chatbot.yaml
@@ -53,7 +53,7 @@ pipeline:
       query-embeddings: "value.question_embeddings"
       output-field: "value.related_documents"
       text-field: "record.text"
-      embeddings-field: "record.embeddings_vector"
+      embeddings-field: "record.embeddings_vector.values"
       algorithm: "MMR"
       lambda: 0.5
       k1: 1.5

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
@@ -338,6 +338,9 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
         if (JsonNode.class.isAssignableFrom(javaType)) {
             return TransformSchemaType.JSON;
         }
+        if (Map.class.isAssignableFrom(javaType)) {
+            return TransformSchemaType.MAP;
+        }
         throw new IllegalArgumentException("Unsupported data type: " + javaType);
     }
 

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/ReRankAgentCodeProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/ReRankAgentCodeProvider.java
@@ -15,25 +15,14 @@
  */
 package ai.langstream.ai.agents;
 
+import ai.langstream.ai.agents.rerank.ReRankAgent;
 import ai.langstream.api.runner.code.AgentCode;
 import ai.langstream.api.runner.code.AgentCodeProvider;
 import java.util.Set;
 
-public class GenAIAgentCodeProvider implements AgentCodeProvider {
+public class ReRankAgentCodeProvider implements AgentCodeProvider {
 
-    private static final Set<String> STEP_TYPES =
-            Set.of(
-                    "drop-fields",
-                    "merge-key-value",
-                    "unwrap-key-value",
-                    "cast",
-                    "flatten",
-                    "drop",
-                    "compute",
-                    "compute-ai-embeddings",
-                    "query",
-                    "ai-chat-completions",
-                    "ai-text-completions");
+    private static final Set<String> STEP_TYPES = Set.of("re-rank");
 
     @Override
     public boolean supports(String agentType) {
@@ -42,6 +31,6 @@ public class GenAIAgentCodeProvider implements AgentCodeProvider {
 
     @Override
     public AgentCode createInstance(String agentType) {
-        return new GenAIToolKitAgent();
+        return new ReRankAgent();
     }
 }

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/impl/JdbcDataSourceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/datasource/impl/JdbcDataSourceProvider.java
@@ -66,7 +66,7 @@ public class JdbcDataSourceProvider implements DataSourceProvider {
 
         @Override
         @SneakyThrows
-        public List<Map<String, String>> fetchData(String query, List<Object> params) {
+        public List<Map<String, Object>> fetchData(String query, List<Object> params) {
             PreparedStatement ps = connection.prepareStatement(query);
             for (int i = 0; i < params.size(); i++) {
                 ps.setObject(i + 1, params.get(i));
@@ -74,13 +74,12 @@ public class JdbcDataSourceProvider implements DataSourceProvider {
             try (ResultSet resultSet = ps.executeQuery()) {
                 ResultSetMetaData metaData = resultSet.getMetaData();
                 int numColumns = metaData.getColumnCount();
-                List<Map<String, String>> results = new ArrayList<>();
+                List<Map<String, Object>> results = new ArrayList<>();
                 while (resultSet.next()) {
-                    Map<String, String> result = new HashMap<>();
+                    Map<String, Object> result = new HashMap<>();
                     for (int i = 1; i <= numColumns; i++) {
                         Object value = resultSet.getObject(i);
-                        result.put(
-                                metaData.getColumnName(i), value != null ? value.toString() : null);
+                        result.put(metaData.getColumnName(i), value);
                     }
                     results.add(result);
                 }

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/rerank/ReRankAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/rerank/ReRankAgent.java
@@ -185,12 +185,16 @@ public class ReRankAgent extends SingleRecordAgentProcessor {
         Object topDocument = null;
         double topScore = Double.NEGATIVE_INFINITY;
 
-        List<TextWithEmbeddings> texts = remainingDocuments.stream().map(recordExtractor).toList();
+        List<TextWithEmbeddings> texts = remainingDocuments
+                .stream()
+                .map(recordExtractor)
+                .filter(t -> t.text != null && t.embeddings != null && !t.text.isEmpty() && t.embeddings.length > 0)
+                .toList();
 
         double[] bm25scores = calculateBM25Scores(texts, query, bm25_k1, bm25_b);
 
-        for (int i = 0; i < remainingDocuments.size(); i++) {
-            Object documentObject = remainingDocuments.get(i);
+        for (int i = 0; i < texts.size(); i++) {
+            Object documentObject = texts.get(i);
             TextWithEmbeddings document = texts.get(i);
             double bm25score = bm25scores[i];
             double relevance = bm25score;

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/rerank/ReRankAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/rerank/ReRankAgent.java
@@ -67,10 +67,13 @@ public class ReRankAgent extends SingleRecordAgentProcessor {
         String field =
                 ConfigurationUtils.requiredNonEmptyField(
                         configuration, "field", () -> "re-rank agent");
+
+        fieldAccessor = new JstlEvaluator<>("${" + field + "}", List.class);
         outputField =
                 ConfigurationUtils.requiredNonEmptyField(
                         configuration, "output-field", () -> "re-rank agent");
         algorithm = ConfigurationUtils.getString("algorithm", ALGORITHM_NONE, configuration);
+
         String queryEmbeddingsField =
                 ConfigurationUtils.getString("query-embeddings", "", configuration);
         String queryField = ConfigurationUtils.getString("query-text", "", configuration);
@@ -82,7 +85,6 @@ public class ReRankAgent extends SingleRecordAgentProcessor {
         bm25_k1 = ConfigurationUtils.getDouble("k1", 1.5, configuration);
         bm25_b = ConfigurationUtils.getDouble("b", 0.75, configuration);
 
-        fieldAccessor = new JstlEvaluator<>("${" + field + "}", List.class);
         queryEmbeddingsAccessor =
                 new JstlEvaluator<>("${" + queryEmbeddingsField + "}", List.class);
         queryAccessor = new JstlEvaluator<>("${" + queryField + "}", String.class);

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/rerank/ReRankAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/rerank/ReRankAgent.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.ai.agents.rerank;
+
+import static ai.langstream.ai.agents.GenAIToolKitAgent.transformContextToRecord;
+
+import ai.langstream.ai.agents.GenAIToolKitAgent;
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.code.SingleRecordAgentProcessor;
+import ai.langstream.api.util.ConfigurationUtils;
+import com.datastax.oss.streaming.ai.TransformContext;
+import com.datastax.oss.streaming.ai.jstl.JstlEvaluator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+
+@Slf4j
+public class ReRankAgent extends SingleRecordAgentProcessor {
+
+    public static final String ALGORITHM_NONE = "none";
+    public static final String ALGORITHM_MMR = "MMR";
+
+    private String field;
+    private String outputField;
+    private String algorithm = "none";
+    private String query;
+
+    private String fieldInRecord;
+
+    private double lambda;
+
+    private final Map<Schema, Schema> avroValueSchemaCache = new ConcurrentHashMap<>();
+
+    private final Map<Schema, Schema> avroKeySchemaCache = new ConcurrentHashMap<>();
+
+    @Override
+    public void init(Map<String, Object> configuration) {
+        field =
+                ConfigurationUtils.requiredNonEmptyField(
+                        configuration, "field", () -> "re-rank agent");
+        outputField =
+                ConfigurationUtils.requiredNonEmptyField(
+                        configuration, "output-field", () -> "re-rank agent");
+        algorithm = ConfigurationUtils.getString("algorithm", ALGORITHM_NONE, configuration);
+        query = ConfigurationUtils.getString("query", "", configuration);
+        fieldInRecord = ConfigurationUtils.getString("field-in-record", "text", configuration);
+
+        lambda = ConfigurationUtils.getDouble("lambda", 0.5, configuration);
+    }
+
+    @Override
+    public List<Record> processRecord(Record record) throws Exception {
+        if (record == null) {
+            return List.of();
+        }
+        TransformContext transformContext =
+                GenAIToolKitAgent.recordToTransformContext(record, true).copy();
+        JstlEvaluator<List<Object>> fieldAccessor =
+                new JstlEvaluator("${" + field + "}", List.class);
+        List<Object> currentList = fieldAccessor.evaluate(transformContext);
+        Function<Object, String> textExtractor =
+                (Object o) -> {
+                    if (o instanceof String) {
+                        return (String) o;
+                    } else if (o instanceof Map) {
+                        return ((Map<String, Object>) o).getOrDefault(fieldInRecord, "").toString();
+                    } else {
+                        return o.toString();
+                    }
+                };
+        List<Object> result = rerank(currentList, textExtractor);
+        transformContext.setResultField(
+                result, outputField, null, avroKeySchemaCache, avroValueSchemaCache);
+        transformContext.convertMapToStringOrBytes();
+        Optional<Record> recordResult = transformContextToRecord(transformContext);
+        return recordResult.map(List::of).orElse(List.of());
+    }
+
+    private List<Object> rerank(List<Object> currentList, Function<Object, String> textExtractor) {
+        switch (algorithm) {
+            case ALGORITHM_MMR:
+                return rerankMMR(currentList, query, lambda, textExtractor);
+            case ALGORITHM_NONE:
+                return currentList;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    private static List<Object> rerankMMR(
+            List<Object> documents,
+            String query,
+            double lambda,
+            Function<Object, String> textExtractor) {
+        List<Object> rankedDocuments = new ArrayList<>();
+        List<Object> remainingDocuments = new ArrayList<>(documents);
+
+        while (!remainingDocuments.isEmpty()) {
+            log.info("Remaining documents: {}", remainingDocuments);
+            Object topDocument =
+                    calculateTopDocumentMMR(
+                            remainingDocuments, rankedDocuments, textExtractor, query, lambda);
+            rankedDocuments.add(topDocument);
+            log.info("Removing top document: {}", topDocument);
+            remainingDocuments.remove(topDocument);
+        }
+
+        return rankedDocuments;
+    }
+
+    public static Object calculateTopDocumentMMR(
+            List<Object> remainingDocuments,
+            List<Object> rankedDocuments,
+            Function<Object, String> textExtractor,
+            String query,
+            double lambda) {
+        Object topDocument = null;
+        double topScore = Double.NEGATIVE_INFINITY;
+
+        for (Object documentObject : remainingDocuments) {
+            String document = textExtractor.apply(documentObject);
+            double relevance = calculateRelevance(document, query);
+            double diversity = calculateDiversity(document, rankedDocuments, textExtractor);
+            double score = lambda * relevance - (1 - lambda) * diversity;
+
+            if (score > topScore) {
+                topScore = score;
+                topDocument = documentObject;
+            }
+        }
+
+        return topDocument;
+    }
+
+    public static double calculateRelevance(String document, String query) {
+        // Implement your relevance calculation logic here
+        // For example, you can use TF-IDF, BM25, or other relevance metrics.
+        return document.hashCode()
+                * 1.0
+                / query.hashCode(); // Placeholder, replace with actual relevance score.
+    }
+
+    public static double calculateDiversity(
+            String document, List<Object> rankedDocuments, Function<Object, String> textExtractor) {
+        // Implement your diversity calculation logic here
+        // For example, you can use cosine similarity, Jaccard index, or other diversity metrics.
+        return new Random().nextDouble(); // Placeholder, replace with actual diversity score.
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/QueryStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/QueryStep.java
@@ -80,7 +80,7 @@ public class QueryStep implements TransformStep {
                     }
                 });
 
-        List<Map<String, String>> results = dataSource.fetchData(query, params);
+        List<Map<String, Object>> results = dataSource.fetchData(query, params);
         if (results == null) {
             results = List.of();
         }

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
@@ -92,7 +92,7 @@ public class CassandraDataSource implements QueryStepDataSource {
     }
 
     @Override
-    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+    public List<Map<String, Object>> fetchData(String query, List<Object> params) {
         if (log.isDebugEnabled()) {
             log.debug(
                     "Executing query {} with params {} ({})",
@@ -134,7 +134,7 @@ public class CassandraDataSource implements QueryStepDataSource {
         return all.stream()
                 .map(
                         r -> {
-                            Map<String, String> result = new HashMap<>();
+                            Map<String, Object> result = new HashMap<>();
                             ColumnDefinitions columnDefinitions = r.getColumnDefinitions();
                             for (int i = 0; i < columnDefinitions.size(); i++) {
                                 String name = columnDefinitions.get(i).getName().toString();
@@ -146,7 +146,7 @@ public class CassandraDataSource implements QueryStepDataSource {
                                             object != null ? object.getClass().toString() : "null",
                                             object);
                                 }
-                                result.put(name, object != null ? object.toString() : null);
+                                result.put(name, object);
                             }
                             return result;
                         })

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/QueryStepDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/QueryStepDataSource.java
@@ -23,7 +23,7 @@ public interface QueryStepDataSource extends AutoCloseable {
 
     default void initialize(Map<String, Object> config) throws Exception {}
 
-    default List<Map<String, String>> fetchData(String query, List<Object> params) {
+    default List<Map<String, Object>> fetchData(String query, List<Object> params) {
         return Collections.emptyList();
     }
 

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlFunctions.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/jstl/JstlFunctions.java
@@ -87,7 +87,7 @@ public class JstlFunctions {
         return JstlTypeConverter.INSTANCE.coerceToLong(input);
     }
 
-    public static Object toListOfFloat(Object input) {
+    public static List<Float> toListOfFloat(Object input) {
         if (input == null) {
             return null;
         }

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/TransformSchemaType.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/TransformSchemaType.java
@@ -34,7 +34,8 @@ public enum TransformSchemaType {
     BYTES,
     AVRO,
     JSON,
-    PROTOBUF;
+    PROTOBUF,
+    MAP;
 
     public boolean isPrimitive() {
         return isPrimitiveType(this);

--- a/langstream-agents/langstream-ai-agents/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-ai-agents/src/main/resources/META-INF/ai.langstream.agents.index
@@ -9,3 +9,4 @@ compute-ai-embeddings
 query
 ai-chat-completions
 ai-text-completions
+re-rank

--- a/langstream-agents/langstream-ai-agents/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
+++ b/langstream-agents/langstream-ai-agents/src/main/resources/META-INF/services/ai.langstream.api.runner.code.AgentCodeProvider
@@ -1,1 +1,2 @@
 ai.langstream.ai.agents.GenAIAgentCodeProvider
+ai.langstream.ai.agents.ReRankAgentCodeProvider

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/datasource/JdbcDataSourceProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/datasource/JdbcDataSourceProviderTest.java
@@ -54,14 +54,14 @@ public class JdbcDataSourceProviderTest {
             statement.execute("INSERT INTO products (id, name, price) VALUES (2, 'product2', 102)");
         }
 
-        List<Map<String, String>> results =
+        List<Map<String, Object>> results =
                 implementation.fetchData(
                         "SELECT name, price from PRODUCTS where id > ?", List.of(1));
         assertEquals(results.size(), 1);
         log.info("Results: {}", results);
         // H2 returns column names in upper case
         assertEquals("product2", results.get(0).get("NAME"));
-        assertEquals("102", results.get(0).get("PRICE"));
+        assertEquals(102, results.get(0).get("PRICE"));
 
         implementation.close();
     }

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
@@ -21,8 +21,10 @@ import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
+@Slf4j
 class ReRankAgentTest {
 
     @Test
@@ -58,26 +60,40 @@ class ReRankAgentTest {
         try (ReRankAgent agent = new ReRankAgent(); ) {
             agent.init(
                     Map.of(
-                            "field",
-                            "value.field",
-                            "output-field",
-                            "value.output-field",
-                            "field-in-record",
-                            "text",
-                            "query",
-                            "some text",
-                            "lambda",
-                            0.7,
-                            "algorithm",
-                            "MMR"));
+                            // field to re-rank
+                            "field", "value.query_results",
+                            // new field to store re-ranked results
+                            "output-field", "value.output_field",
+                            // field in the message that contains the query
+                            "query-text", "value.query",
+                            // field in the message that contains the embeddings computed for the
+                            // query
+                            "query-embeddings", "value.query_embeddings",
+                            // field in the record that contains the text
+                            "text-field", "record.text",
+                            // field in the record that contains the embeddings
+                            "embeddings-field", "record.embeddings",
+                            // lambda parameter for MMR
+                            "lambda", 0.7,
+                            // algorithm to use
+                            "algorithm", "MMR"));
             SimpleRecord record =
                     SimpleRecord.of(
                             "key",
-                            Map.of("field", List.of(Map.of("text", "one"), Map.of("text", "two"))));
+                            Map.of(
+                                    "query",
+                                    "tell my a number",
+                                    "query_embeddings",
+                                    List.of(3d, 4d),
+                                    "query_results",
+                                    List.of(
+                                            Map.of("text", "one", "embeddings", List.of(1d, 2d)),
+                                            Map.of("text", "two", "embeddings", List.of(3d, 4d)))));
             Record result = agent.processRecord(record).get(0);
+            log.info("{}", result.value());
             assertEquals(
                     """
-                                  {field=[{text=one}, {text=two}], output-field=[{text=two}, {text=one}]}""",
+                                {query_embeddings=[3.0, 4.0], query_results=[{embeddings=[1.0, 2.0], text=one}, {embeddings=[3.0, 4.0], text=two}], query=tell my a number, output_field=[{embeddings=[1.0, 2.0], text=one}, {embeddings=[3.0, 4.0], text=two}]}""",
                     result.value().toString());
         }
     }

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
@@ -91,7 +91,7 @@ class ReRankAgentTest {
                             "key",
                             Map.of(
                                     "query",
-                                    "tell my a number",
+                                    "tell my a number, for instance two",
                                     "query_embeddings",
                                     List.of(3d, 4d),
                                     "query_results",
@@ -100,10 +100,20 @@ class ReRankAgentTest {
                                             Map.of("text", "two", "embeddings", List.of(3d, 4d)))));
             Record result = agent.processRecord(record).get(0);
             log.info("{}", result.value());
-            assertEquals(
-                    """
-                                {query_embeddings=[3.0, 4.0], query_results=[{embeddings=[1.0, 2.0], text=one}, {embeddings=[3.0, 4.0], text=two}], query=tell my a number, output_field=[{embeddings=[1.0, 2.0], text=one}, {embeddings=[3.0, 4.0], text=two}]}""",
-                    result.value().toString());
+            Map<String, Object> parsedResult = (Map<String, Object>) result.value();
+
+            assertEquals(List.of(3d, 4d), parsedResult.get("query_embeddings"));
+            List<Map<String, Object>> queryResults =
+                    (List<Map<String, Object>>) parsedResult.get("query_results");
+            assertEquals(Map.of("text", "one", "embeddings", List.of(1d, 2d)), queryResults.get(0));
+            assertEquals(Map.of("text", "two", "embeddings", List.of(3d, 4d)), queryResults.get(1));
+
+            List<Map<String, Object>> outputField =
+                    (List<Map<String, Object>>) parsedResult.get("output_field");
+            assertEquals(Map.of("text", "two", "embeddings", List.of(3d, 4d)), outputField.get(0));
+            assertEquals(Map.of("text", "one", "embeddings", List.of(1d, 2d)), outputField.get(1));
+
+            assertEquals("tell my a number, for instance two", parsedResult.get("query"));
         }
     }
 }

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.ai.agents.rerank;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.code.SimpleRecord;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReRankAgentTest {
+
+    @Test
+    void testNone() throws Exception {
+        try (ReRankAgent agent = new ReRankAgent(); ) {
+            agent.init(
+                    Map.of(
+                            "field",
+                            "value.field",
+                            "output-field",
+                            "value.output-field",
+                            "algorithm",
+                            "none"));
+            SimpleRecord record =
+                    SimpleRecord.of(
+                            "key",
+                            """
+                    {
+                        "field": [
+                        ]
+                    }
+                    """);
+            Record result = agent.processRecord(record).get(0);
+            assertEquals(
+                    """
+                    {"field":[],"output-field":[]}""",
+                    result.value().toString());
+        }
+    }
+
+    @Test
+    void testMMR() throws Exception {
+        try (ReRankAgent agent = new ReRankAgent(); ) {
+            agent.init(
+                    Map.of(
+                            "field",
+                            "value.field",
+                            "output-field",
+                            "value.output-field",
+                            "field-in-record",
+                            "text",
+                            "query",
+                            "some text",
+                            "lambda",
+                            0.7,
+                            "algorithm",
+                            "MMR"));
+            SimpleRecord record =
+                    SimpleRecord.of(
+                            "key",
+                            Map.of("field", List.of(Map.of("text", "one"), Map.of("text", "two"))));
+            Record result = agent.processRecord(record).get(0);
+            assertEquals(
+                    """
+                                  {field=[{text=one}, {text=two}], output-field=[{text=two}, {text=one}]}""",
+                    result.value().toString());
+        }
+    }
+}

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/rerank/ReRankAgentTest.java
@@ -32,12 +32,21 @@ class ReRankAgentTest {
         try (ReRankAgent agent = new ReRankAgent(); ) {
             agent.init(
                     Map.of(
-                            "field",
-                            "value.field",
-                            "output-field",
-                            "value.output-field",
-                            "algorithm",
-                            "none"));
+                            // field to re-rank
+                            "field", "value.field",
+                            // new field to store re-ranked results
+                            "output-field", "value.output_field",
+                            // field in the message that contains the query
+                            "query-text", "value.query",
+                            // field in the message that contains the embeddings computed for the
+                            // query
+                            "query-embeddings", "value.query_embeddings",
+                            // field in the record that contains the text
+                            "text-field", "record.text",
+                            // field in the record that contains the embeddings
+                            "embeddings-field", "record.embeddings",
+                            // algorithm to use
+                            "algorithm", "none"));
             SimpleRecord record =
                     SimpleRecord.of(
                             "key",
@@ -50,7 +59,7 @@ class ReRankAgentTest {
             Record result = agent.processRecord(record).get(0);
             assertEquals(
                     """
-                    {"field":[],"output-field":[]}""",
+                    {"field":[],"output_field":[]}""",
                     result.value().toString());
         }
     }

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/GenAITest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/GenAITest.java
@@ -317,7 +317,7 @@ public class GenAITest {
 
                         return new QueryStepDataSource() {
                             @Override
-                            public List<Map<String, String>> fetchData(
+                            public List<Map<String, Object>> fetchData(
                                     String query, List<Object> params) {
                                 assertEquals(
                                         "select * from products where description like ?", query);

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/QueryStepTest.java
@@ -67,7 +67,7 @@ public class QueryStepTest {
         QueryStepDataSource dataSource =
                 new QueryStepDataSource() {
                     @Override
-                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                    public List<Map<String, Object>> fetchData(String query, List<Object> params) {
                         assertEquals(query, "select 1");
                         List<Object> expectedParams =
                                 List.of(
@@ -123,7 +123,7 @@ public class QueryStepTest {
         QueryStepDataSource dataSource =
                 new QueryStepDataSource() {
                     @Override
-                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                    public List<Map<String, Object>> fetchData(String query, List<Object> params) {
                         assertEquals(query, "select 1");
                         List<Object> expectedParams =
                                 List.of("Jane", "Doe", 42, 19359, 1672700645006L, 83045006);
@@ -173,7 +173,7 @@ public class QueryStepTest {
         QueryStepDataSource dataSource =
                 new QueryStepDataSource() {
                     @Override
-                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                    public List<Map<String, Object>> fetchData(String query, List<Object> params) {
                         assertEquals(query, "select 1");
                         List<Object> expectedParams =
                                 List.of("a", 42.0, true, List.of("b", "c"), List.of(43.0, 44.0));
@@ -228,7 +228,7 @@ public class QueryStepTest {
         QueryStepDataSource dataSource =
                 new QueryStepDataSource() {
                     @Override
-                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                    public List<Map<String, Object>> fetchData(String query, List<Object> params) {
                         assertEquals(query, "select 1");
                         List<Object> expectedParams = List.of("value1", "key2");
                         assertEquals(params, expectedParams);
@@ -253,7 +253,7 @@ public class QueryStepTest {
         QueryStepDataSource dataSource =
                 new QueryStepDataSource() {
                     @Override
-                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                    public List<Map<String, Object>> fetchData(String query, List<Object> params) {
                         assertEquals(query, "select 1");
                         List<Object> expectedParams = List.of("value1", "key2");
                         assertEquals(params, expectedParams);
@@ -294,7 +294,7 @@ public class QueryStepTest {
         QueryStepDataSource dataSource =
                 new QueryStepDataSource() {
                     @Override
-                    public List<Map<String, String>> fetchData(String query, List<Object> params) {
+                    public List<Map<String, Object>> fetchData(String query, List<Object> params) {
                         List<Object> expectedParams = List.of();
                         assertEquals(params, expectedParams);
                         switch (query) {

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSourceTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSourceTest.java
@@ -35,7 +35,7 @@ public class CassandraDataSourceTest {
         String query = "select * from vsearch.products where id=?";
         List<Object> params = new ArrayList<>();
         params.add(1);
-        List<Map<String, String>> maps = source.fetchData(query, params);
+        List<Map<String, Object>> maps = source.fetchData(query, params);
         log.info("maps {}", maps);
     }
 
@@ -48,7 +48,7 @@ public class CassandraDataSourceTest {
         String query = "SELECT * FROM vsearch.products ORDER BY item_vector ANN OF ? LIMIT 1;";
         List<Object> params = new ArrayList<>();
         params.add(Arrays.asList(0.1, 0.2, 0.3, 0.4, 0.5));
-        List<Map<String, String>> maps = source.fetchData(query, params);
+        List<Map<String, Object>> maps = source.fetchData(query, params);
         log.info("maps {}", maps);
     }
 

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/milvus/MilvusDataSource.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/milvus/MilvusDataSource.java
@@ -112,7 +112,7 @@ public class MilvusDataSource implements DataSourceProvider {
         }
 
         @Override
-        public List<Map<String, String>> fetchData(String query, List<Object> params) {
+        public List<Map<String, Object>> fetchData(String query, List<Object> params) {
             try {
                 SearchSimpleParam searchParam =
                         buildObjectFromJson(
@@ -141,12 +141,11 @@ public class MilvusDataSource implements DataSourceProvider {
                 return data.getRowRecords().stream()
                         .map(
                                 r -> {
-                                    Map<String, String> result = new HashMap<>();
+                                    Map<String, Object> result = new HashMap<>();
                                     r.getFieldValues()
                                             .forEach(
                                                     (k, v) -> {
-                                                        result.put(
-                                                                k, v == null ? null : v.toString());
+                                                        result.put(k, v);
                                                     });
                                     return result;
                                 })

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/pinecone/PineconeDataSource.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/pinecone/PineconeDataSource.java
@@ -116,13 +116,13 @@ public class PineconeDataSource implements DataSourceProvider {
         }
 
         @Override
-        public List<Map<String, String>> fetchData(String query, List<Object> params) {
+        public List<Map<String, Object>> fetchData(String query, List<Object> params) {
             try {
                 Query parsedQuery = buildObjectFromJson(query, Query.class, params);
 
                 QueryRequest batchQueryRequest = mapQueryToQueryRequest(parsedQuery);
 
-                List<Map<String, String>> results;
+                List<Map<String, Object>> results;
 
                 if (clientConfig.getEndpoint() == null) {
                     results = executeQueryUsingClien(batchQueryRequest, parsedQuery);
@@ -135,9 +135,9 @@ public class PineconeDataSource implements DataSourceProvider {
             }
         }
 
-        private List<Map<String, String>> executeQueryWithMockHttpService(
+        private List<Map<String, Object>> executeQueryWithMockHttpService(
                 QueryRequest batchQueryRequest) throws IOException, InterruptedException {
-            List<Map<String, String>> results;
+            List<Map<String, Object>> results;
             HttpClient client = HttpClient.newHttpClient();
             HttpRequest request =
                     HttpRequest.newBuilder(URI.create(clientConfig.getEndpoint()))
@@ -150,9 +150,9 @@ public class PineconeDataSource implements DataSourceProvider {
         }
 
         @NotNull
-        private List<Map<String, String>> executeQueryUsingClien(
+        private List<Map<String, Object>> executeQueryUsingClien(
                 QueryRequest batchQueryRequest, Query parsedQuery) {
-            List<Map<String, String>> results;
+            List<Map<String, Object>> results;
             QueryResponse queryResponse = connection.getBlockingStub().query(batchQueryRequest);
 
             if (log.isDebugEnabled()) {
@@ -169,7 +169,7 @@ public class PineconeDataSource implements DataSourceProvider {
                                             .forEach(
                                                     match -> {
                                                         String id = match.getId();
-                                                        Map<String, String> row = new HashMap<>();
+                                                        Map<String, Object> row = new HashMap<>();
 
                                                         if (parsedQuery.includeMetadata) {
                                                             // put all the metadata

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/JdbcWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/JdbcWriterTest.java
@@ -134,7 +134,7 @@ public class JdbcWriterTest {
                 String query =
                         "SELECT name,text from documents order by cosine_similarity(vector,cast(? as float array)) DESC";
                 List<Object> params = List.of(vector);
-                List<Map<String, String>> results = datasource.fetchData(query, params);
+                List<Map<String, Object>> results = datasource.fetchData(query, params);
                 log.info("Results: {}", results);
 
                 assertEquals(1, results.size());
@@ -154,7 +154,7 @@ public class JdbcWriterTest {
                 writer.upsert(recordUpdated, Map.of()).get();
 
                 List<Object> params2 = List.of(vector2);
-                List<Map<String, String>> results2 = datasource.fetchData(query, params2);
+                List<Map<String, Object>> results2 = datasource.fetchData(query, params2);
                 log.info("Results: {}", results2);
 
                 assertEquals(1, results2.size());
@@ -165,7 +165,7 @@ public class JdbcWriterTest {
                         SimpleRecord.of("{\"name\": \"do'c1\", \"chunk_id\": 1}", null);
                 writer.upsert(recordDelete, Map.of()).get();
 
-                List<Map<String, String>> results3 = datasource.fetchData(query, params2);
+                List<Map<String, Object>> results3 = datasource.fetchData(query, params2);
                 log.info("Results: {}", results3);
                 assertEquals(0, results3.size());
 

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/MilvusDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/MilvusDataSourceTest.java
@@ -232,7 +232,7 @@ class MilvusDataSourceTest {
                             """
                             .formatted(collectionName, databaseName);
             List<Object> params = List.of(vector);
-            List<Map<String, String>> results = datasource.fetchData(query, params);
+            List<Map<String, Object>> results = datasource.fetchData(query, params);
             log.info("Results: {}", results);
 
             assertEquals(1, results.size());
@@ -252,7 +252,7 @@ class MilvusDataSourceTest {
             writer.upsert(recordUpdated, Map.of()).get();
 
             List<Object> params2 = List.of(vector2);
-            List<Map<String, String>> results2 = datasource.fetchData(query, params2);
+            List<Map<String, Object>> results2 = datasource.fetchData(query, params2);
             log.info("Results: {}", results2);
 
             assertEquals(1, results2.size());
@@ -263,7 +263,7 @@ class MilvusDataSourceTest {
                     SimpleRecord.of("{\"name\": \"do'c1\", \"chunk_id\": 1}", null);
             writer.upsert(recordDelete, Map.of()).get();
 
-            List<Map<String, String>> results3 = datasource.fetchData(query, params2);
+            List<Map<String, Object>> results3 = datasource.fetchData(query, params2);
             log.info("Results: {}", results3);
             assertEquals(0, results3.size());
         }

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeDataSourceTest.java
@@ -47,7 +47,7 @@ class PineconeDataSourceTest {
                     }
                 """;
         List<Object> params = List.of(List.of(0.1f, 0.1f, 0.1f, 0.1f, 0.1f));
-        List<Map<String, String>> results = implementation.fetchData(query, params);
+        List<Map<String, Object>> results = implementation.fetchData(query, params);
         log.info("Results: {}", results);
     }
 
@@ -74,7 +74,7 @@ class PineconeDataSourceTest {
                     }
                 """;
         List<Object> params = List.of(List.of(0.1f, 0.1f, 0.1f, 0.1f, 0.1f), "comedy", 2019);
-        List<Map<String, String>> results = implementation.fetchData(query, params);
+        List<Map<String, Object>> results = implementation.fetchData(query, params);
         log.info("Results: {}", results);
     }
 }

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/PineconeWriterTest.java
@@ -94,7 +94,7 @@ class PineconeWriterTest {
                     }
                 """;
         List<Object> params = List.of(vector, genre);
-        List<Map<String, String>> results = implementation.fetchData(query, params);
+        List<Map<String, Object>> results = implementation.fetchData(query, params);
         log.info("Results: {}", results);
 
         assertEquals(results.size(), 1);

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCode.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCode.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 /** Body of the agent */
-public interface AgentCode {
+public interface AgentCode extends AutoCloseable {
 
     String agentId();
 
@@ -48,6 +48,7 @@ public interface AgentCode {
 
     default void start() throws Exception {}
 
+    @Override
     default void close() throws Exception {}
 
     /**

--- a/langstream-core/src/main/java/ai/langstream/impl/nar/NarFileHandler.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/nar/NarFileHandler.java
@@ -384,9 +384,23 @@ public class NarFileHandler
         return classloaders;
     }
 
+    private ClassLoader systemClassloaderWithCustomLib;
+
     @Override
     public ClassLoader getSystemClassloader() {
-        return parentClassloader;
+        if (systemClassloaderWithCustomLib != null) {
+            return systemClassloaderWithCustomLib;
+        }
+        if (customLibClasspath != null && !customLibClasspath.isEmpty()) {
+            systemClassloaderWithCustomLib =
+                    new NarFileClassLoader(
+                            "system-classloader-with-custom-lib",
+                            customLibClasspath,
+                            parentClassloader);
+        } else {
+            systemClassloaderWithCustomLib = parentClassloader;
+        }
+        return systemClassloaderWithCustomLib;
     }
 
     private static URLClassLoader createClassloaderForPackage(

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ReRankAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/ReRankAgentProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.impl.k8s.agents;
+
+import ai.langstream.api.model.AgentConfiguration;
+import ai.langstream.api.runtime.ComponentType;
+import ai.langstream.impl.agents.AbstractComposableAgentProvider;
+import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReRankAgentProvider extends AbstractComposableAgentProvider {
+
+    private static final Set<String> SUPPORTED_AGENT_TYPES = Set.of("re-rank");
+
+    public ReRankAgentProvider() {
+        super(SUPPORTED_AGENT_TYPES, List.of(KubernetesClusterRuntime.CLUSTER_TYPE, "none"));
+    }
+
+    @Override
+    protected ComponentType getComponentType(AgentConfiguration agentConfiguration) {
+        return ComponentType.PROCESSOR;
+    }
+}

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/resources/META-INF/services/ai.langstream.api.runtime.AgentNodeProvider
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/resources/META-INF/services/ai.langstream.api.runtime.AgentNodeProvider
@@ -7,3 +7,4 @@ ai.langstream.runtime.impl.k8s.agents.KafkaConnectAgentsProvider
 ai.langstream.runtime.impl.k8s.agents.KubernetesCompositeAgentProvider
 ai.langstream.runtime.impl.k8s.agents.IdentityAgentProvider
 ai.langstream.runtime.impl.k8s.agents.QueryVectorDBAgentProvider
+ai.langstream.runtime.impl.k8s.agents.ReRankAgentProvider

--- a/langstream-runtime/langstream-runtime-impl/pom.xml
+++ b/langstream-runtime/langstream-runtime-impl/pom.xml
@@ -422,6 +422,17 @@
             <configuration>
               <artifactItems>
 
+                <!-- JDBC driver for tests -->
+
+                <artifactItem>
+                  <groupId>org.herddb</groupId>
+                  <artifactId>herddb-jdbc</artifactId>
+                  <classifier>thin</classifier>
+                  <version>0.28.0</version>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/test-jdbc-drivers/java/lib</outputDirectory>
+                </artifactItem>
+
                 <!-- main implementation for the Agents, Assets and TopicConnectionsRuntime-->
 
                 <artifactItem>

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraAssetQueryWriteIT.java
@@ -143,7 +143,7 @@ class CassandraAssetQueryWriteIT extends AbstractApplicationRunner {
                 waitForMessages(
                         consumer,
                         List.of(
-                                "{\"documentId\":2,\"queryresult\":{\"name\":\"A\",\"description\":\"A description\",\"id\":\"1\"},\"name\":\"A\",\"description\":\"A description\"}"));
+                                "{\"documentId\":2,\"queryresult\":{\"name\":\"A\",\"description\":\"A description\",\"id\":1},\"name\":\"A\",\"description\":\"A description\"}"));
 
                 CqlSessionBuilder builder = new CqlSessionBuilder();
                 builder.addContactPoint(cassandra.getContactPoint());

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraVectorAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraVectorAssetQueryWriteIT.java
@@ -150,7 +150,7 @@ class CassandraVectorAssetQueryWriteIT extends AbstractApplicationRunner {
                 waitForMessages(
                         consumer,
                         List.of(
-                                "{\"documentId\":2,\"embeddings\":[0.1,0.2,0.3,0.4,0.5],\"queryresult\":{\"embeddings\":null,\"name\":\"A\",\"description\":\"A description\",\"id\":\"1\"},\"name\":\"A\",\"description\":\"A description\"}"));
+                                "{\"documentId\":2,\"embeddings\":[0.1,0.2,0.3,0.4,0.5],\"queryresult\":{\"embeddings\":null,\"name\":\"A\",\"description\":\"A description\",\"id\":1},\"name\":\"A\",\"description\":\"A description\"}"));
 
                 CqlSessionBuilder builder = new CqlSessionBuilder();
                 builder.addContactPoint(cassandra.getContactPoint());

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.kafka;
+
+import ai.langstream.AbstractApplicationRunner;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class RerankAgentRunnerIT extends AbstractApplicationRunner {
+
+    @Test
+    public void testSimpleRerank() throws Exception {
+        String tenant = "tenant";
+        String[] expectedAgents = {"app-step1"};
+
+        Map<String, String> application =
+                Map.of(
+                        "module.yaml",
+                        """
+                                module: "module-1"
+                                id: "pipeline-1"
+                                topics:
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                  - name: "output-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - name: "Re-rank query results"
+                                    id: step1
+                                    type: "re-rank"
+                                    input: "input-topic"
+                                    output: "output-topic"
+                                    configuration:
+                                        field: "value.query_results"
+                                        output-field: "value.reranked_results"
+                                        query-text: "value.query"
+                                        query-embeddings: "value.query_embeddings"
+                                        text-field: "record.text"
+                                        embeddings-field: "record.embeddings"
+                                        algorithm: "MMR"
+                                        lambda: 0.5
+                                        b: 2
+                                        k1: 1.2
+                                """);
+
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer();
+                    KafkaConsumer<String, String> consumer = createConsumer("output-topic")) {
+
+                sendMessage(
+                        "input-topic",
+                        """
+                                                        {
+                                                            "query_results": [
+                                                                {
+                                                                    "text": "one",
+                                                                    "embeddings": [1,2,3,4,5]
+                                                                }, {
+                                                                    "text": "two",
+                                                                    "embeddings": [1,2,3,4,6]
+                                                                }, {
+                                                                    "text": "three",
+                                                                    "embeddings": [1,2,3,4,7]
+                                                                }
+                                                            ],
+                                                            "query": "Tell me something",
+                                                            "query_embeddings": [1,2,3,4,5]
+                                                        }
+                                                        """,
+                        producer);
+
+                executeAgentRunners(applicationRuntime);
+                waitForMessages(
+                        consumer,
+                        List.of(
+                                """
+                                    {"query_embeddings":[1,2,3,4,5],"query_results":[{"embeddings":[1,2,3,4,5],"text":"one"},{"embeddings":[1,2,3,4,6],"text":"two"},{"embeddings":[1,2,3,4,7],"text":"three"}],"query":"Tell me something","reranked_results":[{"embeddings":[1,2,3,4,5],"text":"one"},{"embeddings":[1,2,3,4,7],"text":"three"},{"embeddings":[1,2,3,4,6],"text":"two"}]}"""));
+            }
+        }
+    }
+}

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/RerankAgentRunnerIT.java
@@ -15,86 +15,251 @@
  */
 package ai.langstream.kafka;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import ai.langstream.AbstractApplicationRunner;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
+@Testcontainers
 class RerankAgentRunnerIT extends AbstractApplicationRunner {
+
+    @Container
+    static GenericContainer database =
+            new GenericContainer(DockerImageName.parse("herddb/herddb:0.28.0"))
+                    .withExposedPorts(7000);
+
+    @BeforeAll
+    public static void startDatabase() {
+        database.start();
+    }
+
+    @AfterAll
+    public static void stopDatabase() {
+        database.stop();
+    }
+
+    @SneakyThrows
+    private static void validateResults(String message) {
+        log.info("Validating message: {}", message);
+        Map<String, Object> parsed =
+                new ObjectMapper().readValue(message, new TypeReference<Map<String, Object>>() {});
+
+        List<Map<String, Object>> relatedDocuments =
+                (List<Map<String, Object>>) parsed.get("related_documents");
+        assertEquals(relatedDocuments.size(), 8);
+        int i = 0;
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text1", "embeddings_vector", List.of(1.0, 2.0, 3.0, 4.0, 5.0)));
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text9", "embeddings_vector", List.of(9.0, 2.0, 3.0, 4.0, 5.0)));
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text0", "embeddings_vector", List.of(0.0, 2.0, 3.0, 4.0, 5.0)));
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text8", "embeddings_vector", List.of(8.0, 2.0, 3.0, 4.0, 5.0)));
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text7", "embeddings_vector", List.of(7.0, 2.0, 3.0, 4.0, 5.0)));
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text2", "embeddings_vector", List.of(2.0, 2.0, 3.0, 4.0, 5.0)));
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text6", "embeddings_vector", List.of(6.0, 2.0, 3.0, 4.0, 5.0)));
+        assertEquals(
+                relatedDocuments.get(i++),
+                Map.of("text", "text3", "embeddings_vector", List.of(3.0, 2.0, 3.0, 4.0, 5.0)));
+
+        assertEquals("this is a question", parsed.get("question"));
+        assertEquals(List.of(1.0, 2.0, 3.0, 4.0, 5.0), parsed.get("question_embeddings"));
+    }
 
     @Test
     public void testSimpleRerank() throws Exception {
         String tenant = "tenant";
         String[] expectedAgents = {"app-step1"};
+        String jdbcUrl = "jdbc:herddb:server:localhost:" + database.getMappedPort(7000);
+
+        Map<String, String> applicationWriter =
+                Map.of(
+                        "configuration.yaml",
+                        """
+                        configuration:
+                          resources:
+                            - type: "datasource"
+                              name: "JdbcDatasource"
+                              configuration:
+                                service: "jdbc"
+                                driverClass: "herddb.jdbc.Driver"
+                                url: "%s"
+                                user: "sa"
+                                password: "hdb"
+                                """
+                                .formatted(jdbcUrl),
+                        "module.yaml",
+                        """
+                                assets:
+                                  - name: "documents-table"
+                                    asset-type: "jdbc-table"
+                                    creation-mode: create-if-not-exists
+                                    config:
+                                      table-name: "documents"
+                                      datasource: "JdbcDatasource"
+                                      create-statements:
+                                        - |
+                                          CREATE TABLE documents (
+                                          filename TEXT,
+                                          chunk_id int,
+                                          num_tokens int,
+                                          lang TEXT,
+                                          text TEXT,
+                                          embeddings_vector FLOATA,
+                                          PRIMARY KEY (filename, chunk_id));
+                                topics:
+                                  - name: "input-topic"
+                                    creation-mode: create-if-not-exists
+                                pipeline:
+                                  - name: "Write"
+                                    type: "vector-db-sink"
+                                    input: input-topic
+                                    id: step1
+                                    configuration:
+                                      datasource: "JdbcDatasource"
+                                      table-name: "documents"
+                                      fields:
+                                        - name: "filename"
+                                          expression: "value.filename"
+                                          primary-key: true
+                                        - name: "chunk_id"
+                                          expression: "value.chunk_id"
+                                          primary-key: true
+                                        - name: "embeddings_vector"
+                                          expression: "fn:toListOfFloat(value.embeddings_vector)"
+                                        - name: "lang"
+                                          expression: "value.language"
+                                        - name: "text"
+                                          expression: "value.text"
+                                        - name: "num_tokens"
+                                          expression: "value.chunk_num_tokens"
+                                """);
 
         Map<String, String> application =
                 Map.of(
+                        "configuration.yaml",
+                        """
+                        configuration:
+                          resources:
+                            - type: "datasource"
+                              name: "JdbcDatasource"
+                              configuration:
+                                service: "jdbc"
+                                driverClass: "herddb.jdbc.Driver"
+                                url: "%s"
+                                user: "sa"
+                                password: "hdb"
+                                """
+                                .formatted(jdbcUrl),
                         "module.yaml",
                         """
-                                module: "module-1"
-                                id: "pipeline-1"
                                 topics:
                                   - name: "input-topic"
                                     creation-mode: create-if-not-exists
                                   - name: "output-topic"
                                     creation-mode: create-if-not-exists
                                 pipeline:
-                                  - name: "Re-rank query results"
-                                    id: step1
-                                    type: "re-rank"
-                                    input: "input-topic"
-                                    output: "output-topic"
-                                    configuration:
-                                        field: "value.query_results"
-                                        output-field: "value.reranked_results"
-                                        query-text: "value.query"
-                                        query-embeddings: "value.query_embeddings"
-                                        text-field: "record.text"
-                                        embeddings-field: "record.embeddings"
-                                        algorithm: "MMR"
-                                        lambda: 0.5
-                                        b: 2
-                                        k1: 1.2
+                                   - name: "convert-to-structure"
+                                     id: "step1"
+                                     type: "document-to-json"
+                                     input: "input-topic"
+                                     configuration:
+                                       text-field: "question"
+                                   - name: "mock-compute-embeddings"
+                                     type: "compute"
+                                     configuration:
+                                       fields:
+                                          - name: "value.question_embeddings"
+                                            expression: "fn:toListOfFloat([1,2,3,4,5])"
+                                   - name: "lookup-related-documents"
+                                     type: "query-vector-db"
+                                     configuration:
+                                       datasource: "JdbcDatasource"
+                                       query: "SELECT text,embeddings_vector FROM documents ORDER BY cosine_similarity(embeddings_vector, CAST(? as FLOAT ARRAY)) DESC LIMIT 20"
+                                       fields:
+                                         - "value.question_embeddings"
+                                       output-field: "value.related_documents"
+                                   - name: "re-rank documents with MMR"
+                                     type: "re-rank"
+                                     output: output-topic
+                                     configuration:
+                                       max: 8
+                                       field: "value.related_documents"
+                                       query-text: "value.question"
+                                       query-embeddings: "value.question_embeddings"
+                                       output-field: "value.related_documents"
+                                       text-field: "record.text"
+                                       embeddings-field: "record.embeddings_vector"
+                                       algorithm: "MMR"
+                                       lambda: 0.5
+                                       k1: 1.5
+                                       b: 0.7
                                 """);
 
+        // write some data
+        try (ApplicationRuntime applicationRuntime =
+                deployApplication(
+                        tenant, "app", applicationWriter, buildInstanceYaml(), expectedAgents)) {
+            try (KafkaProducer<String, String> producer = createProducer(); ) {
+                for (int i = 0; i < 10; i++) {
+                    sendMessage(
+                            "input-topic",
+                            """
+                                    {
+                                         "filename": "doc%s.pdf",
+                                            "chunk_id": 1,
+                                            "embeddings_vector": [%s,2,3,4,5],
+                                            "language": "en",
+                                            "text": "text%s",
+                                            "chunk_num_tokens": 10
+                                    }
+                                    """
+                                    .formatted(i, i, i),
+                            producer);
+                }
+                executeAgentRunners(applicationRuntime);
+            }
+        }
+
+        Consumer<String> validateMessage = RerankAgentRunnerIT::validateResults;
+
+        // query the database with re-rank
         try (ApplicationRuntime applicationRuntime =
                 deployApplication(
                         tenant, "app", application, buildInstanceYaml(), expectedAgents)) {
             try (KafkaProducer<String, String> producer = createProducer();
                     KafkaConsumer<String, String> consumer = createConsumer("output-topic")) {
 
-                sendMessage(
-                        "input-topic",
-                        """
-                                                        {
-                                                            "query_results": [
-                                                                {
-                                                                    "text": "one",
-                                                                    "embeddings": [1,2,3,4,5]
-                                                                }, {
-                                                                    "text": "two",
-                                                                    "embeddings": [1,2,3,4,6]
-                                                                }, {
-                                                                    "text": "three",
-                                                                    "embeddings": [1,2,3,4,7]
-                                                                }
-                                                            ],
-                                                            "query": "Tell me something",
-                                                            "query_embeddings": [1,2,3,4,5]
-                                                        }
-                                                        """,
-                        producer);
-
+                sendMessage("input-topic", "this is a question", producer);
                 executeAgentRunners(applicationRuntime);
-                waitForMessages(
-                        consumer,
-                        List.of(
-                                """
-                                    {"query_embeddings":[1,2,3,4,5],"query_results":[{"embeddings":[1,2,3,4,5],"text":"one"},{"embeddings":[1,2,3,4,6],"text":"two"},{"embeddings":[1,2,3,4,7],"text":"three"}],"query":"Tell me something","reranked_results":[{"embeddings":[1,2,3,4,5],"text":"one"},{"embeddings":[1,2,3,4,7],"text":"three"},{"embeddings":[1,2,3,4,6],"text":"two"}]}"""));
+                waitForMessages(consumer, List.of(validateMessage));
             }
         }
     }


### PR DESCRIPTION
### Summary

- new agent that performs re-ranking on the results of a query
- there is only an algorithm implemented at the moment: MMR, using BM25 and Cosine Similarity
- update the docker-chatbot and the webcrawler-source examples to use MMR (and query more documents than the available room in the prompt)
- added the first integration test with a local Vector Database (using JDBC/HerdDB)
- there is a small breaking change in the "query" and "query-vector-db" agents, now they return a "List<Map<String,Object>>" instead of "List<Map<String, String>>", this way it is possible to get the vector of floats from the query
- in the integration tests now we are able to load the JDBC drivers (that are not on the classpath but in a directory in target)


### Description about MMR

In order to perform MMR you need two functions, one to compute "diversity" and one to give a "relevance".
We are using BM25 + IDF in order to compute "relevance", and we use the average "cosine similarity" to compute "diversity".
The are a few parameters to tune the algorithms.


### How do I use this feature ?

You need to provide both a "query" and a set of "documents", and for each of them you must also provide the "embeddings" (for the query and for each document).
This is easy in the standard chatbot pipeline because we compute the embeddings of the query before performing the vector search and when you perform the vector search you can get both the text and the embeddings stored on the database.


```yaml
 pipeline:
      - name: "Re-rank query results"
        id: step1
        type: "re-rank"
        input: "input-topic"
        output: "output-topic"
        configuration:
            max: 10
            field: "value.query_results"
            output-field: "value.reranked_results"
            query-text: "value.query"
            query-embeddings: "value.query_embeddings"
            text-field: "record.text"
            embeddings-field: "record.embeddings"
            algorithm: "MMR"
            lambda: 0.5
            b: 2
            k1: 1.2
```

With the "max" parameter you can limit the number of documents, this is pretty useful in case you want to get many documents from the vector database but then you can use only fewer of them to build the prompt.

### Parameters

- max: maximum number of documents to keep
- field: the field that contains the documents to sort
- output-field: the field that will hold the results, it can be the same as "field" to override it
- query-text: this is the field that contains the "query" (usually the question to the chatbot)
- query-embeddings: this is the field that contains the "embeddings" for the "query", they must be precomputed
- text-field: the field in the result set that contains the "text", you have to use the "record.xxx" syntax
- embeddings-field: the field in the result set that contains the "embeddings" for the text, you have to use the "record.xxx" syntax
- algorithm: "MMR" or "none"
- lambda: this a the parameter for the MMR algorithm
- b and k1: parameters for the B25 algoritm

### Notes

you must pre-compute embeddings on the query and in all of the documents, but this is usually easy that you usually perform a vector search before this step, so you have to get both the text and the embeddings vector for each document.

