### PR TITLE
[compatibility] Backward compatibility with references to secrets and globals using the Mustache syntax

### DIFF
--- a/langstream-core/src/test/java/ai/langstream/impl/common/ApplicationPlaceholderResolverTest.java
+++ b/langstream-core/src/test/java/ai/langstream/impl/common/ApplicationPlaceholderResolverTest.java
@@ -424,4 +424,134 @@ class ApplicationPlaceholderResolverTest {
                 ApplicationPlaceholderResolver.resolveSingleValue(
                         context, "${  globals.foo.number  }-${  globals.foo.map  }"));
     }
+
+    @Test
+    void testResolveCompatibilityTripleBraces() {
+        Map<String, Object> context =
+                Map.of(
+                        "globals",
+                        Map.of(
+                                "foo",
+                                Map.of(
+                                        "bar",
+                                        "xxx",
+                                        "number",
+                                        123,
+                                        "list",
+                                        List.of(1, 2),
+                                        "map",
+                                        Map.of("one", 1, "two", 2))));
+        assertEquals(
+                "xxx",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{{globals.foo.bar}}}"));
+        assertEquals(
+                "123", // this is a string !
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{{globals.foo.number}}}"));
+        assertEquals(
+                "[1,2]", // this is a string !
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{{globals.foo.list}}}"));
+
+        // some spaces
+        assertEquals(
+                "123", // this is a string !
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{{  globals.foo.number  }}}"));
+
+        // simple concat
+        assertEquals(
+                "123-xxx",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{{  globals.foo.number  }}}-{{{  globals.foo.bar  }}}"));
+
+        // using a list, but in a string context
+        assertEquals(
+                "123-[1,2]",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{{ globals.foo.number  }}}-{{{  globals.foo.list  }}}"));
+
+        // using a map, but in a string context
+        assertEquals(
+                "123-{\"one\":1,\"two\":2}",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{{  globals.foo.number  }}}-{{{  globals.foo.map  }}}"));
+    }
+
+    @Test
+    void testResolveCompatibilityDoubleBraces() {
+        Map<String, Object> context =
+                Map.of(
+                        "globals",
+                        Map.of(
+                                "foo",
+                                Map.of(
+                                        "bar",
+                                        "xxx",
+                                        "number",
+                                        123,
+                                        "list",
+                                        List.of(1, 2),
+                                        "map",
+                                        Map.of("one", 1, "two", 2))));
+        assertEquals(
+                "xxx",
+                ApplicationPlaceholderResolver.resolveSingleValue(context, "{{globals.foo.bar}}"));
+        assertEquals(
+                "123", // this is a string !
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{globals.foo.number}}"));
+        assertEquals(
+                "[1,2]", // this is a string !
+                ApplicationPlaceholderResolver.resolveSingleValue(context, "{{globals.foo.list}}"));
+
+        // some spaces
+        assertEquals(
+                "123", // this is a string !
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{  globals.foo.number  }}"));
+
+        // simple concat
+        assertEquals(
+                "123-xxx",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{  globals.foo.number  }}-{{  globals.foo.bar  }}"));
+
+        // using a list, but in a string context
+        assertEquals(
+                "123-[1,2]",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{ globals.foo.number  }}-{{  globals.foo.list  }}"));
+
+        // using a map, but in a string context
+        assertEquals(
+                "123-{\"one\":1,\"two\":2}",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{  globals.foo.number  }}-{{  globals.foo.map  }}"));
+    }
+
+    @Test
+    void testDontBreakAMustacheValue() {
+        Map<String, Object> context =
+                Map.of(
+                        "something",
+                        Map.of("foo", Map.of("bar", "xxx", "number", 123, "list", List.of(1, 2))),
+                        "globals",
+                        Map.of(
+                                "foo",
+                                Map.of(
+                                        "bar",
+                                        "xxx",
+                                        "number",
+                                        123,
+                                        "list",
+                                        List.of(1, 2),
+                                        "map",
+                                        Map.of("one", 1, "two", 2))));
+        assertEquals(
+                "{{something.foo.bar}}",
+                ApplicationPlaceholderResolver.resolveSingleValue(
+                        context, "{{something.foo.bar}}"));
+    }
 }


### PR DESCRIPTION
Summary:

with #507 old applications that use secrets (so 100% of them) require to be rewritten, it is better to not require it.
This patch adds a small backward compatibility layer that allows to interpret secrets and globals using the Mustache syntax.

Please note that when you use Mustache the result is always a string, so if you have a number or a list, you will see them returned as strings.

The suggested way to refer to a secret is now ${secrets.id.field} and ${globals.variable}