### PR TITLE
Cli: include .bat file in the tarball

### DIFF
--- a/langstream-cli/pom.xml
+++ b/langstream-cli/pom.xml
@@ -169,6 +169,7 @@
               <id>langstream</id>
               <platforms>
                 <platform>unix</platform>
+                <platform>windows</platform>
               </platforms>
             </program>
           </programs>


### PR DESCRIPTION
We can include the generated .bat file in the zip. 
I tested it on windows 11 with java 11 and it works like a charm.

The only problem is that windows users will have to download the tarball, extract it and run it. There's no global command 