### PR TITLE
Add dry-run apps deployment

### DIFF
--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -182,15 +182,20 @@ public class AdminClient implements AutoCloseable {
 
     private class ApplicationsImpl implements Applications {
         @Override
+        public String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher) {
+            return deploy(application, multiPartBodyPublisher, false);
+        }
+
+        @Override
         @SneakyThrows
-        public void deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher) {
-            final String path = tenantAppPath("/" + application);
+        public String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher, boolean dryRun) {
+            final String path = tenantAppPath("/" + application) + "?dry-run=" + dryRun;
             final String contentType =
                     String.format(
                             "multipart/form-data; boundary=%s",
                             multiPartBodyPublisher.getBoundary());
             final HttpRequest request = newPost(path, contentType, multiPartBodyPublisher.build());
-            http(request);
+            return http(request).body();
         }
 
         @Override

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -188,7 +188,8 @@ public class AdminClient implements AutoCloseable {
 
         @Override
         @SneakyThrows
-        public String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher, boolean dryRun) {
+        public String deploy(
+                String application, MultiPartBodyPublisher multiPartBodyPublisher, boolean dryRun) {
             final String path = tenantAppPath("/" + application) + "?dry-run=" + dryRun;
             final String contentType =
                     String.format(

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
@@ -19,7 +19,9 @@ import ai.langstream.admin.client.util.MultiPartBodyPublisher;
 import java.net.http.HttpResponse;
 
 public interface Applications {
-    void deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher);
+    String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher);
+
+    String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher, boolean dryRun);
 
     void update(String application, MultiPartBodyPublisher multiPartBodyPublisher);
 

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
@@ -21,7 +21,8 @@ import java.net.http.HttpResponse;
 public interface Applications {
     String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher);
 
-    String deploy(String application, MultiPartBodyPublisher multiPartBodyPublisher, boolean dryRun);
+    String deploy(
+            String application, MultiPartBodyPublisher multiPartBodyPublisher, boolean dryRun);
 
     void update(String application, MultiPartBodyPublisher multiPartBodyPublisher);
 

--- a/langstream-api/src/main/java/ai/langstream/api/webservice/application/ApplicationDescription.java
+++ b/langstream-api/src/main/java/ai/langstream/api/webservice/application/ApplicationDescription.java
@@ -64,7 +64,7 @@ public class ApplicationDescription {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ApplicationDefinition {
 
-        private ApplicationDefinition(Application application) {
+        public ApplicationDefinition(Application application) {
             this.resources = application.getResources();
             this.modules =
                     application.getModules().values().stream().map(ModuleDefinition::new).toList();

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -24,6 +24,7 @@ import ai.langstream.cli.LangStreamCLIConfig;
 import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.applications.GithubRepositoryDownloader;
 import ai.langstream.cli.commands.profiles.BaseProfileCmd;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -24,7 +24,6 @@ import ai.langstream.cli.LangStreamCLIConfig;
 import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.applications.GithubRepositoryDownloader;
 import ai.langstream.cli.commands.profiles.BaseProfileCmd;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -195,15 +195,14 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
 
         long size = Files.size(tempZip);
 
-
         final Map<String, Object> contents = new HashMap<>();
         contents.put("app", tempZip);
         if (instanceFile != null) {
             try {
                 contents.put(
                         "instance",
-                                LocalFileReferenceResolver.resolveFileReferencesInYAMLFile(
-                                        instanceFile.toPath()));
+                        LocalFileReferenceResolver.resolveFileReferencesInYAMLFile(
+                                instanceFile.toPath()));
             } catch (Exception e) {
                 log(
                         "Failed to resolve instance file references. Please double check the file path: "
@@ -216,8 +215,8 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
             try {
                 contents.put(
                         "secrets",
-                                LocalFileReferenceResolver.resolveFileReferencesInYAMLFile(
-                                        secretsFile.toPath()));
+                        LocalFileReferenceResolver.resolveFileReferencesInYAMLFile(
+                                secretsFile.toPath()));
             } catch (Exception e) {
                 log(
                         "Failed to resolve secrets file references. Please double check the file path: "
@@ -235,11 +234,15 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
         } else {
             final boolean dryRun = isDryRun();
             if (dryRun) {
-                log(String.format("resolving application: %s. Dry run mode is enabled, the application will NOT be deployed", applicationId));
+                log(
+                        String.format(
+                                "resolving application: %s. Dry run mode is enabled, the application will NOT be deployed",
+                                applicationId));
             } else {
                 log(String.format("deploying application: %s (%d KB)", applicationId, size / 1024));
             }
-            final String response = getClient().applications().deploy(applicationId, bodyPublisher, dryRun);
+            final String response =
+                    getClient().applications().deploy(applicationId, bodyPublisher, dryRun);
             if (dryRun) {
                 final Formats format = format();
                 print(format == Formats.raw ? Formats.yaml : format, response, null, null);

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -57,7 +57,8 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
 
         @CommandLine.Option(
                 names = {"--dry-run"},
-                description = "Dry-run mode. Do not deploy the application but only resolves placeholders and display the result.")
+                description =
+                        "Dry-run mode. Do not deploy the application but only resolves placeholders and display the result.")
         private boolean dryRun;
 
         @CommandLine.Option(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmd.java
@@ -57,7 +57,7 @@ public abstract class AbstractDeployApplicationCmd extends BaseApplicationCmd {
 
         @CommandLine.Option(
                 names = {"--dry-run"},
-                description = "")
+                description = "Dry-run mode. Do not deploy the application but only resolves placeholders and display the result.")
         private boolean dryRun;
 
         @CommandLine.Option(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -102,6 +102,11 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
             description = "Docker image of the LangStream runtime to use")
     private String dockerImageName;
 
+    @CommandLine.Option(
+            names = {"--dry-run"},
+            description = "Dry-run mode. Do not deploy the application but only resolves placeholders and display the result.")
+    private boolean dryRun;
+
     @Override
     @SneakyThrows
     public void run() {
@@ -120,6 +125,10 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
                 dockerImageName = "ghcr.io/langstream/langstream-runtime-tester";
             }
         }
+        startBroker = !dryRun && startBroker;
+        startDatabase = !dryRun && startDatabase;
+        startS3 = !dryRun && startS3;
+        startWebservices = !dryRun && startWebservices;
 
         final File appDirectory = checkFileExistsOrDownload(appPath);
         final File instanceFile;
@@ -170,7 +179,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
                 throw e;
             }
         } else {
-            if (startBroker) {
+            if (startBroker || dryRun) {
                 instanceContents =
                         "instance:\n"
                                 + "  streamingCluster:\n"
@@ -211,7 +220,8 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
                 startBroker,
                 startS3,
                 startWebservices,
-                startDatabase);
+                startDatabase,
+                dryRun);
     }
 
     private void executeOnDocker(
@@ -224,7 +234,8 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
             boolean startBroker,
             boolean startS3,
             boolean startWebservices,
-            boolean startDatabase)
+            boolean startDatabase,
+            boolean dryRun)
             throws Exception {
         File tmpInstanceFile = Files.createTempFile("instance", ".yaml").toFile();
         Files.write(tmpInstanceFile.toPath(), instanceContents.getBytes(StandardCharsets.UTF_8));
@@ -251,6 +262,8 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         commandLine.add("LANSGSTREAM_TESTER_APPLICATIONID=" + applicationId);
         commandLine.add("-e");
         commandLine.add("LANSGSTREAM_TESTER_STARTWEBSERVICES=" + startWebservices);
+        commandLine.add("-e");
+        commandLine.add("LANSGSTREAM_TESTER_DRYRUN=" + dryRun);
 
         if (singleAgentId != null && !singleAgentId.isEmpty()) {
             commandLine.add("-e");

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -104,7 +104,8 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
 
     @CommandLine.Option(
             names = {"--dry-run"},
-            description = "Dry-run mode. Do not deploy the application but only resolves placeholders and display the result.")
+            description =
+                    "Dry-run mode. Do not deploy the application but only resolves placeholders and display the result.")
     private boolean dryRun;
 
     @Override

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
@@ -168,7 +168,6 @@ class AppsCmdTest extends CommandTestBase {
         Assertions.assertEquals("", result.err());
     }
 
-
     @Test
     public void testDeployDryRun() throws Exception {
         Path langstream = Files.createTempDirectory("langstream");
@@ -222,11 +221,8 @@ class AppsCmdTest extends CommandTestBase {
                         "json");
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
-        Assertions.assertTrue(result.out().contains("{\n"
-                                                    + "  \"name\" : \"my-app\"\n"
-                                                    + "}"));
+        Assertions.assertTrue(result.out().contains("{\n" + "  \"name\" : \"my-app\"\n" + "}"));
     }
-
 
     @Test
     public void testUpdateInstance() throws Exception {

--- a/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
+++ b/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
@@ -33,4 +33,4 @@ if [ "$START_HERDDB" = "true" ]; then
   /herddb/herddb/bin/service server start
 fi
 
-exec java ${JAVA_OPTS} -Dlogging.config=/app/logback.xml -Djdk.lang.Process.launchMechanism=vfork -cp "/app/lib/*:/app/tester/lib/*" "ai.langstream.runtime.tester.Main"
+exec java ${JAVA_OPTS} -D -Dlogback.configurationFile=/app/logback.xml -Djdk.lang.Process.launchMechanism=vfork -cp "/app/lib/*" "ai.langstream.runtime.tester.Main"

--- a/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
@@ -41,8 +41,9 @@ RUN chmod -R g+w /kafka \
        && chown 10000:0 -R /herddb
 
 # Add the runtime code at the end. This optimizes docker layers to not depend on artifacts-specific changes.
-ADD maven/lib /app/tester/lib
-RUN rm -f /app/tester/lib/*netty*
+RUN rm -rf /app/lib
+ADD maven/lib /app/lib
+RUN rm -f /app/lib/*netty*
 ADD maven/entrypoint.sh /app/entrypoint.sh
 ADD maven/logback.xml /app/logback.xml
 

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
@@ -48,8 +48,7 @@ public class Main {
 
             boolean dryRunMode =
                     Boolean.parseBoolean(
-                            System.getenv()
-                                    .getOrDefault("LANSGSTREAM_TESTER_DRYRUN", "false"));
+                            System.getenv().getOrDefault("LANSGSTREAM_TESTER_DRYRUN", "false"));
             String applicationPath = "/code/application";
             String instanceFile = "/code/instance.yaml";
             String secretsFile = "/code/secrets.yaml";
@@ -73,7 +72,8 @@ public class Main {
             if (dryRunMode) {
                 log.info("Dry run mode");
                 final Application resolved =
-                        ApplicationPlaceholderResolver.resolvePlaceholders(applicationWithPackageInfo.getApplication());
+                        ApplicationPlaceholderResolver.resolvePlaceholders(
+                                applicationWithPackageInfo.getApplication());
                 final ApplicationDescription.ApplicationDefinition def =
                         new ApplicationDescription.ApplicationDefinition(resolved);
 
@@ -81,9 +81,6 @@ public class Main {
                 log.info("Application:\n{}", asString);
                 return;
             }
-
-
-
 
             List<String> expectedAgents = new ArrayList<>();
             List<String> allAgentIds = new ArrayList<>();

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
@@ -15,9 +15,15 @@
  */
 package ai.langstream.runtime.tester;
 
+import ai.langstream.api.model.Application;
+import ai.langstream.api.webservice.application.ApplicationDescription;
 import ai.langstream.apigateway.LangStreamApiGateway;
+import ai.langstream.impl.common.ApplicationPlaceholderResolver;
 import ai.langstream.impl.parser.ModelBuilder;
 import ai.langstream.webservice.LangStreamControlPlaneWebApplication;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,6 +46,10 @@ public class Main {
                             System.getenv()
                                     .getOrDefault("LANSGSTREAM_TESTER_STARTWEBSERVICES", "true"));
 
+            boolean dryRunMode =
+                    Boolean.parseBoolean(
+                            System.getenv()
+                                    .getOrDefault("LANSGSTREAM_TESTER_DRYRUN", "false"));
             String applicationPath = "/code/application";
             String instanceFile = "/code/instance.yaml";
             String secretsFile = "/code/secrets.yaml";
@@ -59,6 +69,21 @@ public class Main {
             ModelBuilder.ApplicationWithPackageInfo applicationWithPackageInfo =
                     ModelBuilder.buildApplicationInstance(
                             applicationDirectories, instance, secrets);
+
+            if (dryRunMode) {
+                log.info("Dry run mode");
+                final Application resolved =
+                        ApplicationPlaceholderResolver.resolvePlaceholders(applicationWithPackageInfo.getApplication());
+                final ApplicationDescription.ApplicationDefinition def =
+                        new ApplicationDescription.ApplicationDefinition(resolved);
+
+                final String asString = yamlPrinter().writeValueAsString(def);
+                log.info("Application:\n{}", asString);
+                return;
+            }
+
+
+
 
             List<String> expectedAgents = new ArrayList<>();
             List<String> allAgentIds = new ArrayList<>();
@@ -144,5 +169,11 @@ public class Main {
         } catch (Throwable error) {
             error.printStackTrace();
         }
+    }
+
+    private static ObjectMapper yamlPrinter() {
+        return new ObjectMapper(new YAMLFactory())
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
     }
 }

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
@@ -152,8 +152,9 @@ public class ApplicationResource {
                         dryRun);
         final Application application;
         if (dryRun) {
-            application = ApplicationPlaceholderResolver.resolvePlaceholders(
-                    parsedApplication.getApplication().getApplication());
+            application =
+                    ApplicationPlaceholderResolver.resolvePlaceholders(
+                            parsedApplication.getApplication().getApplication());
 
         } else {
             applicationService.deployApplication(

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
@@ -16,11 +16,13 @@
 package ai.langstream.webservice.application;
 
 import ai.langstream.api.codestorage.CodeStorageException;
+import ai.langstream.api.model.Application;
 import ai.langstream.api.model.ApplicationSpecs;
 import ai.langstream.api.model.StoredApplication;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.api.webservice.application.ApplicationCodeInfo;
 import ai.langstream.api.webservice.application.ApplicationDescription;
+import ai.langstream.impl.common.ApplicationPlaceholderResolver;
 import ai.langstream.impl.parser.ModelBuilder;
 import ai.langstream.webservice.security.infrastructure.primary.TokenAuthFilter;
 import io.swagger.v3.oas.annotations.Operation;
@@ -130,13 +132,14 @@ public class ApplicationResource {
 
     @PostMapping(value = "/{tenant}/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "Create and deploy an application")
-    void deployApplication(
+    ApplicationDescription.ApplicationDefinition deployApplication(
             Authentication authentication,
             @NotBlank @PathVariable("tenant") String tenant,
             @NotBlank @PathVariable("id") String applicationId,
             @RequestParam("app") MultipartFile appFile,
             @RequestParam String instance,
-            @RequestParam Optional<String> secrets)
+            @RequestParam Optional<String> secrets,
+            @RequestParam(value = "dry-run", required = false) boolean dryRun)
             throws Exception {
         performAuthorization(authentication, tenant);
         final ParsedApplication parsedApplication =
@@ -145,12 +148,22 @@ public class ApplicationResource {
                         Optional.of(appFile),
                         Optional.of(instance),
                         secrets,
-                        tenant);
-        applicationService.deployApplication(
-                tenant,
-                applicationId,
-                parsedApplication.getApplication(),
-                parsedApplication.getCodeArchiveReference());
+                        tenant,
+                        dryRun);
+        final Application application;
+        if (dryRun) {
+            application = ApplicationPlaceholderResolver.resolvePlaceholders(
+                    parsedApplication.getApplication().getApplication());
+
+        } else {
+            applicationService.deployApplication(
+                    tenant,
+                    applicationId,
+                    parsedApplication.getApplication(),
+                    parsedApplication.getCodeArchiveReference());
+            application = parsedApplication.getApplication().getApplication();
+        }
+        return new ApplicationDescription.ApplicationDefinition(application);
     }
 
     @PatchMapping(value = "/{tenant}/{id}", consumes = "multipart/form-data")
@@ -165,7 +178,7 @@ public class ApplicationResource {
             throws Exception {
         performAuthorization(authentication, tenant);
         final ParsedApplication parsedApplication =
-                parseApplicationInstance(applicationId, appFile, instance, secrets, tenant);
+                parseApplicationInstance(applicationId, appFile, instance, secrets, tenant, false);
         applicationService.updateApplication(
                 tenant,
                 applicationId,
@@ -184,7 +197,8 @@ public class ApplicationResource {
             Optional<MultipartFile> file,
             Optional<String> instance,
             Optional<String> secrets,
-            String tenant)
+            String tenant,
+            boolean dryRun)
             throws Exception {
         final ParsedApplication parsedApplication = new ParsedApplication();
         withApplicationZip(
@@ -197,7 +211,7 @@ public class ApplicationResource {
                                         instance.orElse(null),
                                         secrets.orElse(null));
                         final String codeArchiveReference;
-                        if (zip == null) {
+                        if (zip == null || dryRun) {
                             codeArchiveReference = null;
                         } else {
                             codeArchiveReference =

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/AppTestHelper.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/AppTestHelper.java
@@ -136,7 +136,6 @@ public class AppTestHelper {
                 secretsContent,
                 checkOk,
                 null);
-
     }
 
     public static ResultActions updateApp(
@@ -150,15 +149,18 @@ public class AppTestHelper {
             boolean checkOk,
             Map<String, String> queryString)
             throws Exception {
-        final String queryStringStr = queryString == null ? "" : queryString.entrySet()
-                .stream()
-                .map(e -> e.getKey() + "=" + e.getValue())
-                .reduce((a, b) -> a + "&" + b)
-                .orElse("");
+        final String queryStringStr =
+                queryString == null
+                        ? ""
+                        : queryString.entrySet().stream()
+                                .map(e -> e.getKey() + "=" + e.getValue())
+                                .reduce((a, b) -> a + "&" + b)
+                                .orElse("");
         final MockMultipartHttpServletRequestBuilder multipart =
                 multipart(
                         patch ? HttpMethod.PATCH : HttpMethod.POST,
-                        "/api/applications/%s/%s?%s".formatted(tenant, applicationId, queryStringStr));
+                        "/api/applications/%s/%s?%s"
+                                .formatted(tenant, applicationId, queryStringStr));
         if (appFileContent != null) {
             multipart.file(getMultipartFile(appFileContent));
         }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/AppTestHelper.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/AppTestHelper.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -125,10 +126,39 @@ public class AppTestHelper {
             String secretsContent,
             boolean checkOk)
             throws Exception {
+        return updateApp(
+                mockMvc,
+                patch,
+                tenant,
+                applicationId,
+                appFileContent,
+                instanceContent,
+                secretsContent,
+                checkOk,
+                null);
+
+    }
+
+    public static ResultActions updateApp(
+            MockMvc mockMvc,
+            boolean patch,
+            String tenant,
+            String applicationId,
+            String appFileContent,
+            String instanceContent,
+            String secretsContent,
+            boolean checkOk,
+            Map<String, String> queryString)
+            throws Exception {
+        final String queryStringStr = queryString == null ? "" : queryString.entrySet()
+                .stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .reduce((a, b) -> a + "&" + b)
+                .orElse("");
         final MockMultipartHttpServletRequestBuilder multipart =
                 multipart(
                         patch ? HttpMethod.PATCH : HttpMethod.POST,
-                        "/api/applications/%s/%s".formatted(tenant, applicationId));
+                        "/api/applications/%s/%s?%s".formatted(tenant, applicationId, queryStringStr));
         if (appFileContent != null) {
             multipart.file(getMultipartFile(appFileContent));
         }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
@@ -293,16 +293,15 @@ class ApplicationResourceTest {
                 .andExpect(status().isInternalServerError());
     }
 
-
     @Test
     void testDeployDryRun() throws Exception {
         mockMvc.perform(put("/api/tenants/my-tenant4")).andExpect(status().isOk());
         AppTestHelper.updateApp(
-                mockMvc,
-                false,
-                "my-tenant4",
-                "test",
-                """
+                        mockMvc,
+                        false,
+                        "my-tenant4",
+                        "test",
+                        """
                         id: app1
                         name: test
                         topics:
@@ -314,24 +313,26 @@ class ApplicationResourceTest {
                               configuration:
                                 model: "${secrets.s1.key-s}"
                         """,
-                """
+                        """
                         instance:
                           streamingCluster:
                             type: pulsar
                           computeCluster:
                             type: none
                         """,
-                """
+                        """
                         secrets:
                           - id: s1
                             data:
                               key-s: value-s
-                         
+
                         """,
-                true,
-                Map.of("dry-run", "true"))
-                .andExpect(content()
-                        .string("""
+                        true,
+                        Map.of("dry-run", "true"))
+                .andExpect(
+                        content()
+                                .string(
+                                        """
                                 {
                                   "resources" : { },
                                   "modules" : [ {
@@ -395,6 +396,5 @@ class ApplicationResourceTest {
                                     "globals" : { }
                                   }
                                 }"""));
-
     }
 }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -27,6 +28,7 @@ import ai.langstream.impl.codestorage.NoopCodeStorageProvider;
 import ai.langstream.impl.k8s.tests.KubeK3sServer;
 import ai.langstream.webservice.WebAppTestConfig;
 import java.nio.file.Path;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -289,5 +291,110 @@ class ApplicationResourceTest {
 
         mockMvc.perform(get("/api/applications/my-tenant3/test"))
                 .andExpect(status().isInternalServerError());
+    }
+
+
+    @Test
+    void testDeployDryRun() throws Exception {
+        mockMvc.perform(put("/api/tenants/my-tenant4")).andExpect(status().isOk());
+        AppTestHelper.updateApp(
+                mockMvc,
+                false,
+                "my-tenant4",
+                "test",
+                """
+                        id: app1
+                        name: test
+                        topics:
+                          - name: "history-topic"
+                        pipeline:
+                            - name: "ai-chat-completions"
+                              type: "ai-chat-completions"
+                              output: "history-topic"
+                              configuration:
+                                model: "${secrets.s1.key-s}"
+                        """,
+                """
+                        instance:
+                          streamingCluster:
+                            type: pulsar
+                          computeCluster:
+                            type: none
+                        """,
+                """
+                        secrets:
+                          - id: s1
+                            data:
+                              key-s: value-s
+                         
+                        """,
+                true,
+                Map.of("dry-run", "true"))
+                .andExpect(content()
+                        .string("""
+                                {
+                                  "resources" : { },
+                                  "modules" : [ {
+                                    "id" : "default",
+                                    "pipelines" : [ {
+                                      "id" : "app1",
+                                      "module" : "default",
+                                      "name" : "test",
+                                      "resources" : {
+                                        "parallelism" : 1,
+                                        "size" : 1
+                                      },
+                                      "errors" : {
+                                        "retries" : 0,
+                                        "on-failure" : "fail"
+                                      },
+                                      "agents" : [ {
+                                        "id" : "app1-ai-chat-completions-1",
+                                        "name" : "ai-chat-completions",
+                                        "type" : "ai-chat-completions",
+                                        "input" : null,
+                                        "output" : {
+                                          "connectionType" : "TOPIC",
+                                          "definition" : "history-topic",
+                                          "enableDeadletterQueue" : false
+                                        },
+                                        "configuration" : {
+                                          "model" : "value-s"
+                                        },
+                                        "resources" : {
+                                          "parallelism" : 1,
+                                          "size" : 1
+                                        },
+                                        "errors" : {
+                                          "retries" : 0,
+                                          "on-failure" : "fail"
+                                        }
+                                      } ]
+                                    } ],
+                                    "topics" : [ {
+                                      "name" : "history-topic",
+                                      "config" : null,
+                                      "options" : null,
+                                      "keySchema" : null,
+                                      "valueSchema" : null,
+                                      "partitions" : 0,
+                                      "implicit" : false,
+                                      "creation-mode" : "none",
+                                      "deletion-mode" : "none"
+                                    } ]
+                                  } ],
+                                  "instance" : {
+                                    "streamingCluster" : {
+                                      "type" : "pulsar",
+                                      "configuration" : { }
+                                    },
+                                    "computeCluster" : {
+                                      "type" : "none",
+                                      "configuration" : { }
+                                    },
+                                    "globals" : { }
+                                  }
+                                }"""));
+
     }
 }


### PR DESCRIPTION
Fixes #532

Changes:
* New option in the deploy `langstream apps deploy --dry-run my-app -app ...`. This sends a request to the control plane.
* The control plane handles the new option and generates the application description with the resolved application. The app is not deployed
* You can customize the output with `-o yaml/json`. By default is `yaml`
* The same option is not recognized for the update command since we don't want to expose already stored secrets to the user (that might not have access to them)

