### PR TITLE
Upgrade jandex maven plugin

### DIFF
--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/pom.xml
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/pom.xml
@@ -51,7 +51,6 @@
         <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
         <version>3.1.5</version>
-
         <executions>
           <execution>
             <id>make-index</id>

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/pom.xml
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/pom.xml
@@ -48,9 +48,10 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>${jandex-maven-plugin.version}</version>
+        <version>3.1.5</version>
+
         <executions>
           <execution>
             <id>make-index</id>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,7 @@
     <minio.version>8.5.4</minio.version>
     <bouncy-castle.version>1.70</bouncy-castle.version>
     <kindcontainer.version>1.4.1</kindcontainer.version>
-    <wiremock.version>3.0.0-beta-10</wiremock.version>
-    <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
+    <wiremock.version>3.0.0-beta-10</wiremock.version> 
     <burningwave.version>0.25.5</burningwave.version>
     <jjwt.version>0.11.5</jjwt.version>
     <commons-codec.version>1.16.0</commons-codec.version>


### PR DESCRIPTION
Current jandex plugin generates a different jandex file each time, preventing the java compiler to use the incremental compilation.

Also the jboss plugin is deprecated