### PR TITLE
Improve apps logs command for CrashLoopBack and add JSON format

### DIFF
--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -186,17 +186,19 @@ public class AdminClient implements AutoCloseable {
         if (params == null || params.isEmpty()) {
             return "";
         }
-        return "?" + params.entrySet().stream()
-                .filter(e -> e.getValue() != null && !e.getValue().isBlank())
-                .map(
-                        e ->
-                                String.format(
-                                        "%s=%s",
-                                        URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8),
-                                        URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8)))
-                .collect(Collectors.joining("&"));
+        return "?"
+                + params.entrySet().stream()
+                        .filter(e -> e.getValue() != null && !e.getValue().isBlank())
+                        .map(
+                                e ->
+                                        String.format(
+                                                "%s=%s",
+                                                URLEncoder.encode(
+                                                        e.getKey(), StandardCharsets.UTF_8),
+                                                URLEncoder.encode(
+                                                        e.getValue(), StandardCharsets.UTF_8)))
+                        .collect(Collectors.joining("&"));
     }
-
 
     public Applications applications() {
         return new ApplicationsImpl();
@@ -291,15 +293,13 @@ public class AdminClient implements AutoCloseable {
 
         @Override
         @SneakyThrows
-        public HttpResponse<InputStream> logs(String application, List<String> filter, String format) {
+        public HttpResponse<InputStream> logs(
+                String application, List<String> filter, String format) {
             final String filterStr = filter == null ? "" : String.join(",", filter);
-            final String query = formatQueryString(
-                    Map.of(
-                            "filter", filterStr,
-                            "format", format == null ? "" : format
-            ));
-            final HttpRequest request =
-                    newGet(tenantAppPath("/" + application + "/logs" + query));
+            final String query =
+                    formatQueryString(
+                            Map.of("filter", filterStr, "format", format == null ? "" : format));
+            final HttpRequest request = newGet(tenantAppPath("/" + application + "/logs" + query));
             return http(request, HttpResponse.BodyHandlers.ofInputStream());
         }
     }

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -297,7 +297,7 @@ public class AdminClient implements AutoCloseable {
                     Map.of(
                             "filter", filterStr,
                             "format", format == null ? "" : format
-            );
+            ));
             final HttpRequest request =
                     newGet(tenantAppPath("/" + application + "/logs" + query));
             return http(request, HttpResponse.BodyHandlers.ofInputStream());

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -25,10 +25,14 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -178,6 +182,22 @@ public class AdminClient implements AutoCloseable {
         return String.format("/applications/%s%s", tenant, uri);
     }
 
+    static String formatQueryString(Map<String, String> params) {
+        if (params == null || params.isEmpty()) {
+            return "";
+        }
+        return "?" + params.entrySet().stream()
+                .filter(e -> e.getValue() != null && !e.getValue().isBlank())
+                .map(
+                        e ->
+                                String.format(
+                                        "%s=%s",
+                                        URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8),
+                                        URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8)))
+                .collect(Collectors.joining("&"));
+    }
+
+
     public Applications applications() {
         return new ApplicationsImpl();
     }
@@ -271,10 +291,15 @@ public class AdminClient implements AutoCloseable {
 
         @Override
         @SneakyThrows
-        public HttpResponse<InputStream> logs(String application, List<String> filter) {
-            final String filterStr = filter == null ? "" : "?filter=" + String.join(",", filter);
+        public HttpResponse<InputStream> logs(String application, List<String> filter, String format) {
+            final String filterStr = filter == null ? "" : String.join(",", filter);
+            final String query = formatQueryString(
+                    Map.of(
+                            "filter", filterStr,
+                            "format", format == null ? "" : format
+            );
             final HttpRequest request =
-                    newGet(tenantAppPath("/" + application + "/logs" + filterStr));
+                    newGet(tenantAppPath("/" + application + "/logs" + query));
             return http(request, HttpResponse.BodyHandlers.ofInputStream());
         }
     }

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
@@ -48,5 +48,5 @@ public interface Applications {
 
     String getCodeInfo(String application, String codeArchiveId);
 
-    HttpResponse<InputStream> logs(String application, List<String> filter);
+    HttpResponse<InputStream> logs(String application, List<String> filter, String format);
 }

--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -20,6 +20,7 @@ import ai.langstream.api.model.ApplicationSpecs;
 import ai.langstream.api.model.Secrets;
 import ai.langstream.api.model.StoredApplication;
 import ai.langstream.api.runtime.ExecutionPlan;
+import java.sql.Time;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -71,10 +72,17 @@ public interface ApplicationStore extends GenericStore {
     }
 
     interface LogLineConsumer {
-        boolean onLogLine(String line);
+
+        LogLineResult onPodNotRunning(String state, String reason);
+
+        LogLineResult onLogLine(String content, long timestamp);
+
+        LogLineResult onPodLogNotAvailable();
 
         void onEnd();
     }
+
+    record LogLineResult(boolean continueLogging, Long delayInSeconds) {}
 
     List<PodLogHandler> logs(String tenant, String applicationId, LogOptions logOptions);
 }

--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -20,7 +20,6 @@ import ai.langstream.api.model.ApplicationSpecs;
 import ai.langstream.api.model.Secrets;
 import ai.langstream.api.model.StoredApplication;
 import ai.langstream.api.runtime.ExecutionPlan;
-import java.sql.Time;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationLogsCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GetApplicationLogsCmd.java
@@ -35,11 +35,16 @@ public class GetApplicationLogsCmd extends BaseApplicationCmd {
             description = "Filter logs by the worker id")
     private List<String> filter;
 
+    @CommandLine.Option(
+            names = {"-o"},
+            description = "Logs format. Supported values: \"text\" and \"json\". Default: \"text\"")
+    private String format = "text";
+
     @Override
     @SneakyThrows
     public void run() {
         final HttpResponse<InputStream> response =
-                getClient().applications().logs(applicationId, filter);
+                getClient().applications().logs(applicationId, filter, format);
 
         BufferedReader br = new BufferedReader(new InputStreamReader(response.body()));
         String line;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/UIAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/UIAppCmd.java
@@ -75,7 +75,7 @@ public class UIAppCmd extends BaseApplicationCmd {
                     @SneakyThrows
                     public void run(Consumer<String> lineConsumer) {
                         final HttpResponse<InputStream> response =
-                                getClient().applications().logs(applicationId, List.of());
+                                getClient().applications().logs(applicationId, List.of(), "text");
                         InputStream inputStream = response.body();
                         InputStreamReader reader =
                                 new InputStreamReader(inputStream, StandardCharsets.UTF_8);

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
@@ -395,16 +395,20 @@ class AppsCmdTest extends CommandTestBase {
 
         wireMock.register(
                 WireMock.get(String.format("/api/applications/%s/my-app/logs?format=json", TENANT))
-                        .willReturn(WireMock.ok("{\"replica\":\"app-1-0\","
+                        .willReturn(
+                                WireMock.ok(
+                                        "{\"replica\":\"app-1-0\","
                                                 + "\"message\":\"08:53:44.519 [stats-pipeline-python-processor-1] INFO  a.l.runtime.agent.AgentRunner -- Records: total 5, working 0, Memory stats: used 16 MB, total 38 MB, free 22 MB, max 121 MB Direct memory 4 MB\",\"timestamp\":1697447779798}")));
 
         result = executeCommand("apps", "logs", "my-app", "-o", "json");
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
-        Assertions.assertEquals("{\"replica\":\"app-1-0\",\"message\":\"08:53:44.519 "
-                                + "[stats-pipeline-python-processor-1] INFO  a.l.runtime.agent.AgentRunner -- "
-                                + "Records: total 5, working 0, Memory stats: used 16 MB, total 38 MB, free 22 MB, "
-                                + "max 121 MB Direct memory 4 MB\",\"timestamp\":1697447779798}", result.out());
+        Assertions.assertEquals(
+                "{\"replica\":\"app-1-0\",\"message\":\"08:53:44.519 "
+                        + "[stats-pipeline-python-processor-1] INFO  a.l.runtime.agent.AgentRunner -- "
+                        + "Records: total 5, working 0, Memory stats: used 16 MB, total 38 MB, free 22 MB, "
+                        + "max 121 MB Direct memory 4 MB\",\"timestamp\":1697447779798}",
+                result.out());
     }
 
     @Test

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
@@ -385,13 +385,26 @@ class AppsCmdTest extends CommandTestBase {
     @Test
     public void testLogs() {
         wireMock.register(
-                WireMock.get(String.format("/api/applications/%s/my-app/logs", TENANT))
-                        .willReturn(WireMock.ok()));
+                WireMock.get(String.format("/api/applications/%s/my-app/logs?format=text", TENANT))
+                        .willReturn(WireMock.ok("some logs")));
 
         CommandResult result = executeCommand("apps", "logs", "my-app");
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
-        Assertions.assertEquals("", result.out());
+        Assertions.assertEquals("some logs", result.out());
+
+        wireMock.register(
+                WireMock.get(String.format("/api/applications/%s/my-app/logs?format=json", TENANT))
+                        .willReturn(WireMock.ok("{\"replica\":\"app-1-0\","
+                                                + "\"message\":\"08:53:44.519 [stats-pipeline-python-processor-1] INFO  a.l.runtime.agent.AgentRunner -- Records: total 5, working 0, Memory stats: used 16 MB, total 38 MB, free 22 MB, max 121 MB Direct memory 4 MB\",\"timestamp\":1697447779798}")));
+
+        result = executeCommand("apps", "logs", "my-app", "-o", "json");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("{\"replica\":\"app-1-0\",\"message\":\"08:53:44.519 "
+                                + "[stats-pipeline-python-processor-1] INFO  a.l.runtime.agent.AgentRunner -- "
+                                + "Records: total 5, working 0, Memory stats: used 16 MB, total 38 MB, free 22 MB, "
+                                + "max 121 MB Direct memory 4 MB\",\"timestamp\":1697447779798}", result.out());
     }
 
     @Test

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
@@ -122,7 +122,7 @@ public class KubeUtil {
     public static Map<String, PodStatus> getPodsStatuses(List<Pod> pods) {
         Map<String, PodStatus> podStatuses = new HashMap<>();
         for (Pod pod : pods) {
-            log.info(
+            log.debug(
                     "pod name={} namespace={} status {}",
                     pod.getMetadata().getName(),
                     pod.getMetadata().getNamespace(),
@@ -167,7 +167,7 @@ public class KubeUtil {
                             + "."
                             + pod.getMetadata().getNamespace()
                             + ".svc.cluster.local:8080";
-            log.info("Pod url: {}", podUrl);
+            log.debug("Pod url: {}", podUrl);
             status = status.withUrl(podUrl);
 
             podStatuses.put(podName, status);

--- a/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreLogsTest.java
+++ b/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreLogsTest.java
@@ -30,11 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Slf4j
@@ -67,8 +65,6 @@ class KubernetesApplicationStoreLogsTest {
         List<ApplicationStore.PodLogHandler> podHandlers =
                 store.logs("mytenant", "myapp", new ApplicationStore.LogOptions());
 
-
-
         final CountDownLatch done = new CountDownLatch(2);
 
         podHandlers
@@ -76,7 +72,8 @@ class KubernetesApplicationStoreLogsTest {
                 .start(
                         new ApplicationStore.LogLineConsumer() {
                             @Override
-                            public ApplicationStore.LogLineResult onPodNotRunning(String state, String reason) {
+                            public ApplicationStore.LogLineResult onPodNotRunning(
+                                    String state, String reason) {
                                 log.info("Pod not running: {} {}", state, reason);
                                 return new ApplicationStore.LogLineResult(true, 2L);
                             }
@@ -88,7 +85,8 @@ class KubernetesApplicationStoreLogsTest {
                             }
 
                             @Override
-                            public ApplicationStore.LogLineResult onLogLine(String content, long timestamp) {
+                            public ApplicationStore.LogLineResult onLogLine(
+                                    String content, long timestamp) {
                                 assertEquals("hello from myapp-agent111-0", content);
                                 done.countDown();
                                 return new ApplicationStore.LogLineResult(false, null);
@@ -103,7 +101,8 @@ class KubernetesApplicationStoreLogsTest {
                         new ApplicationStore.LogLineConsumer() {
 
                             @Override
-                            public ApplicationStore.LogLineResult onPodNotRunning(String state, String reason) {
+                            public ApplicationStore.LogLineResult onPodNotRunning(
+                                    String state, String reason) {
                                 log.info("Pod not running: {} {}", state, reason);
                                 return new ApplicationStore.LogLineResult(true, 2L);
                             }
@@ -115,7 +114,8 @@ class KubernetesApplicationStoreLogsTest {
                             }
 
                             @Override
-                            public ApplicationStore.LogLineResult onLogLine(String content, long timestamp) {
+                            public ApplicationStore.LogLineResult onLogLine(
+                                    String content, long timestamp) {
                                 assertEquals("hello from myapp-agent111-1", content);
                                 done.countDown();
                                 return new ApplicationStore.LogLineResult(false, null);
@@ -126,7 +126,6 @@ class KubernetesApplicationStoreLogsTest {
                         });
 
         done.await(30, TimeUnit.SECONDS);
-
 
         final CountDownLatch doneFiltered = new CountDownLatch(1);
 
@@ -143,7 +142,8 @@ class KubernetesApplicationStoreLogsTest {
                         new ApplicationStore.LogLineConsumer() {
 
                             @Override
-                            public ApplicationStore.LogLineResult onPodNotRunning(String state, String reason) {
+                            public ApplicationStore.LogLineResult onPodNotRunning(
+                                    String state, String reason) {
                                 return new ApplicationStore.LogLineResult(true, null);
                             }
 
@@ -153,7 +153,8 @@ class KubernetesApplicationStoreLogsTest {
                             }
 
                             @Override
-                            public ApplicationStore.LogLineResult onLogLine(String content, long timestamp) {
+                            public ApplicationStore.LogLineResult onLogLine(
+                                    String content, long timestamp) {
                                 assertEquals("hello from myapp-agent111-1", content);
                                 doneFiltered.countDown();
                                 return new ApplicationStore.LogLineResult(false, null);
@@ -179,22 +180,16 @@ class KubernetesApplicationStoreLogsTest {
                 .getContainers()
                 .get(0)
                 .setCommand(List.of("sh", "-c"));
-        sts.getSpec().getTemplate()
-                        .getSpec()
-                                .getContainers()
-                                        .get(0)
-                                                .setReadinessProbe(null);
-        sts.getSpec().getTemplate()
-                .getSpec()
-                .getContainers()
-                .get(0)
-                .setLivenessProbe(null);
+        sts.getSpec().getTemplate().getSpec().getContainers().get(0).setReadinessProbe(null);
+        sts.getSpec().getTemplate().getSpec().getContainers().get(0).setLivenessProbe(null);
         sts.getSpec()
                 .getTemplate()
                 .getSpec()
                 .getContainers()
                 .get(0)
-                .setArgs(List.of("while true; do echo \"hello from $(hostname)\"; sleep 1000000; done"));
+                .setArgs(
+                        List.of(
+                                "while true; do echo \"hello from $(hostname)\"; sleep 1000000; done"));
         k3s.getClient().resource(sts).inNamespace("langstream-mytenant").serverSideApply();
     }
 

--- a/langstream-runtime/langstream-runtime-base-docker-image/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-base-docker-image/src/main/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /etc/apt/keyrings \
      && echo networkaddress.cache.ttl=1 >> /usr/lib/jvm/temurin-17-jdk-$ARCH/conf/security/java.security
 
 # Install utility packages for Python unstructured data processing
-RUN apt-get -y install --no-install-recommends libmagic-dev poppler-utils tesseract-ocr libreoffice pandoc
+#RUN apt-get -y install --no-install-recommends libmagic-dev poppler-utils tesseract-ocr libreoffice pandoc
 
 # Cleanup apt
 RUN  apt-get -y --purge autoremove \

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
@@ -423,7 +423,7 @@ public class ApplicationResource {
                 if (timestamp > 0) {
                     fields.put("timestamp", timestamp);
                 }
-                fields.put("pod", this.podLog.getPodName());
+                fields.put("replica", this.podLog.getPodName());
                 fields.put("message", content);
                 return newlineDelimitedJSONWriter.writeValueAsString(fields) + "\n";
             }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceLogsTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceLogsTest.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.webservice.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+
 import ai.langstream.api.storage.ApplicationStore;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
@@ -14,36 +29,36 @@ import reactor.core.publisher.FluxSink;
 
 class ApplicationResourceLogsTest {
 
-
     @ParameterizedTest
     @EnumSource(ApplicationResource.ApplicationLogsFormats.class)
     void testLogLine(ApplicationResource.ApplicationLogsFormats format) {
 
         AtomicLong lastSent = new AtomicLong();
 
-        final ApplicationStore.PodLogHandler podLogHandler = new ApplicationStore.PodLogHandler() {
-            @Override
-            public void start(ApplicationStore.LogLineConsumer onLogLine) {
-            }
+        final ApplicationStore.PodLogHandler podLogHandler =
+                new ApplicationStore.PodLogHandler() {
+                    @Override
+                    public void start(ApplicationStore.LogLineConsumer onLogLine) {}
 
-            @Override
-            public String getPodName() {
-                return "mypod-0";
-            }
+                    @Override
+                    public String getPodName() {
+                        return "mypod-0";
+                    }
 
-            @Override
-            public void close() {
-            }
-        };
+                    @Override
+                    public void close() {}
+                };
         final FluxSink fluxSink = Mockito.mock(FluxSink.class);
         AtomicReference<String> output = new AtomicReference<>();
-        when(fluxSink.next(any())).thenAnswer(invocationOnMock -> {
-            output.set(invocationOnMock.getArguments()[0] + "");
-            return null;
-        });
+        when(fluxSink.next(any()))
+                .thenAnswer(
+                        invocationOnMock -> {
+                            output.set(invocationOnMock.getArguments()[0] + "");
+                            return null;
+                        });
         final ApplicationResource.LogLineConsumer lineConsumer =
-                new ApplicationResource.LogLineConsumer(podLogHandler, value -> lastSent.set(value), fluxSink,
-                        format);
+                new ApplicationResource.LogLineConsumer(
+                        podLogHandler, value -> lastSent.set(value), fluxSink, format);
 
         ApplicationStore.LogLineResult result = lineConsumer.onLogLine("line logs", 1696926662058L);
         assertTrue(result.continueLogging());
@@ -52,31 +67,38 @@ class ApplicationResourceLogsTest {
         if (format == ApplicationResource.ApplicationLogsFormats.text) {
             assertEquals("\u001B[32m[mypod-0] line logs\u001B[0m\n", output.get());
         } else {
-            assertEquals("{\"replica\":\"mypod-0\",\"message\":\"line logs\",\"timestamp\":1696926662058}\n", output.get());
+            assertEquals(
+                    "{\"replica\":\"mypod-0\",\"message\":\"line logs\",\"timestamp\":1696926662058}\n",
+                    output.get());
         }
 
         result = lineConsumer.onPodNotRunning("Error", "Some long exception");
         assertTrue(result.continueLogging());
         assertEquals(10L, result.delayInSeconds());
         if (format == ApplicationResource.ApplicationLogsFormats.text) {
-            assertEquals("\u001B[32m[mypod-0] Replica mypod-0 is not running, will retry in 10 seconds. State: Error,"
-                         + " Reason: Some long exception\u001B[0m\n", output.get());
+            assertEquals(
+                    "\u001B[32m[mypod-0] Replica mypod-0 is not running, will retry in 10 seconds. State: Error,"
+                            + " Reason: Some long exception\u001B[0m\n",
+                    output.get());
         } else {
-            assertEquals("{\"replica\":\"mypod-0\",\"message\":\"Replica mypod-0 is not running, will retry in 10 seconds"
-                         + ". State: Error, Reason: Some long exception\"}\n", output.get());
+            assertEquals(
+                    "{\"replica\":\"mypod-0\",\"message\":\"Replica mypod-0 is not running, will retry in 10 seconds"
+                            + ". State: Error, Reason: Some long exception\"}\n",
+                    output.get());
         }
 
         result = lineConsumer.onPodLogNotAvailable();
         assertTrue(result.continueLogging());
         assertEquals(10L, result.delayInSeconds());
         if (format == ApplicationResource.ApplicationLogsFormats.text) {
-            assertEquals("\u001B[32m[mypod-0] Replica mypod-0 logs not available, will retry in 10 seconds\u001B[0m\n", output.get());
+            assertEquals(
+                    "\u001B[32m[mypod-0] Replica mypod-0 logs not available, will retry in 10 seconds\u001B[0m\n",
+                    output.get());
         } else {
-            assertEquals("{\"replica\":\"mypod-0\",\"message\":\"Replica mypod-0 logs not available, will retry in 10 "
-                         + "seconds\"}\n", output.get());
+            assertEquals(
+                    "{\"replica\":\"mypod-0\",\"message\":\"Replica mypod-0 logs not available, will retry in 10 "
+                            + "seconds\"}\n",
+                    output.get());
         }
-
     }
-
-
 }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceLogsTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceLogsTest.java
@@ -1,0 +1,82 @@
+package ai.langstream.webservice.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import ai.langstream.api.storage.ApplicationStore;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
+import reactor.core.publisher.FluxSink;
+
+class ApplicationResourceLogsTest {
+
+
+    @ParameterizedTest
+    @EnumSource(ApplicationResource.ApplicationLogsFormats.class)
+    void testLogLine(ApplicationResource.ApplicationLogsFormats format) {
+
+        AtomicLong lastSent = new AtomicLong();
+
+        final ApplicationStore.PodLogHandler podLogHandler = new ApplicationStore.PodLogHandler() {
+            @Override
+            public void start(ApplicationStore.LogLineConsumer onLogLine) {
+            }
+
+            @Override
+            public String getPodName() {
+                return "mypod-0";
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        final FluxSink fluxSink = Mockito.mock(FluxSink.class);
+        AtomicReference<String> output = new AtomicReference<>();
+        when(fluxSink.next(any())).thenAnswer(invocationOnMock -> {
+            output.set(invocationOnMock.getArguments()[0] + "");
+            return null;
+        });
+        final ApplicationResource.LogLineConsumer lineConsumer =
+                new ApplicationResource.LogLineConsumer(podLogHandler, value -> lastSent.set(value), fluxSink,
+                        format);
+
+        ApplicationStore.LogLineResult result = lineConsumer.onLogLine("line logs", 1696926662058L);
+        assertTrue(result.continueLogging());
+        assertNull(result.delayInSeconds());
+
+        if (format == ApplicationResource.ApplicationLogsFormats.text) {
+            assertEquals("\u001B[32m[mypod-0] line logs\u001B[0m\n", output.get());
+        } else {
+            assertEquals("{\"pod\":\"mypod-0\",\"message\":\"line logs\",\"timestamp\":1696926662058}\n", output.get());
+        }
+
+        result = lineConsumer.onPodNotRunning("Error", "Some long exception");
+        assertTrue(result.continueLogging());
+        assertEquals(10L, result.delayInSeconds());
+        if (format == ApplicationResource.ApplicationLogsFormats.text) {
+            assertEquals("\u001B[32m[mypod-0] Replica mypod-0 is not running, will retry in 10 seconds. State: Error,"
+                         + " Reason: Some long exception\u001B[0m\n", output.get());
+        } else {
+            assertEquals("{\"pod\":\"mypod-0\",\"message\":\"Replica mypod-0 is not running, will retry in 10 seconds"
+                         + ". State: Error, Reason: Some long exception\"}\n", output.get());
+        }
+
+        result = lineConsumer.onPodLogNotAvailable();
+        assertTrue(result.continueLogging());
+        assertEquals(10L, result.delayInSeconds());
+        if (format == ApplicationResource.ApplicationLogsFormats.text) {
+            assertEquals("\u001B[32m[mypod-0] Replica mypod-0 logs not available, will retry in 10 seconds\u001B[0m\n", output.get());
+        } else {
+            assertEquals("{\"pod\":\"mypod-0\",\"message\":\"Replica mypod-0 logs not available, will retry in 10 "
+                         + "seconds\"}\n", output.get());
+        }
+
+    }
+
+
+}

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceLogsTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceLogsTest.java
@@ -52,7 +52,7 @@ class ApplicationResourceLogsTest {
         if (format == ApplicationResource.ApplicationLogsFormats.text) {
             assertEquals("\u001B[32m[mypod-0] line logs\u001B[0m\n", output.get());
         } else {
-            assertEquals("{\"pod\":\"mypod-0\",\"message\":\"line logs\",\"timestamp\":1696926662058}\n", output.get());
+            assertEquals("{\"replica\":\"mypod-0\",\"message\":\"line logs\",\"timestamp\":1696926662058}\n", output.get());
         }
 
         result = lineConsumer.onPodNotRunning("Error", "Some long exception");
@@ -62,7 +62,7 @@ class ApplicationResourceLogsTest {
             assertEquals("\u001B[32m[mypod-0] Replica mypod-0 is not running, will retry in 10 seconds. State: Error,"
                          + " Reason: Some long exception\u001B[0m\n", output.get());
         } else {
-            assertEquals("{\"pod\":\"mypod-0\",\"message\":\"Replica mypod-0 is not running, will retry in 10 seconds"
+            assertEquals("{\"replica\":\"mypod-0\",\"message\":\"Replica mypod-0 is not running, will retry in 10 seconds"
                          + ". State: Error, Reason: Some long exception\"}\n", output.get());
         }
 
@@ -72,7 +72,7 @@ class ApplicationResourceLogsTest {
         if (format == ApplicationResource.ApplicationLogsFormats.text) {
             assertEquals("\u001B[32m[mypod-0] Replica mypod-0 logs not available, will retry in 10 seconds\u001B[0m\n", output.get());
         } else {
-            assertEquals("{\"pod\":\"mypod-0\",\"message\":\"Replica mypod-0 logs not available, will retry in 10 "
+            assertEquals("{\"replica\":\"mypod-0\",\"message\":\"Replica mypod-0 logs not available, will retry in 10 "
                          + "seconds\"}\n", output.get());
         }
 


### PR DESCRIPTION
Fixes: #453

Changes:
* Better handling of logs in case the pod is in crash loop. We also check the pod status before asking for the logs. In case it's not running we show the error message and sleep 10 seconds and retry
* Added new query string param "format=json|text" to get the result in NDJSON format containing "message", "replica", "timestamp". For the CLI, `apps logs <app> -o json`