### PR TITLE
Fix pulsar runtime depency conflicts

### DIFF
--- a/langstream-pulsar-runtime/pom.xml
+++ b/langstream-pulsar-runtime/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pulsar</groupId>
-      <artifactId>pulsar-client-original</artifactId>
+      <artifactId>pulsar-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pulsar</groupId>
+        <artifactId>pulsar-client</artifactId>
+        <version>${pulsar.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pulsar</groupId>
         <artifactId>pulsar-client-original</artifactId>
         <version>${pulsar.version}</version>
       </dependency>


### PR DESCRIPTION
NB: this makes Pulsar not working anymore with Avro manipulating agents. But without this Pulsar doesn't work at all.
We can fix the problem with Avro later.