### PR TITLE
Import Apache Nifi nar maven plugin

### DIFF
--- a/nifi-maven-plugin/pom.xml
+++ b/nifi-maven-plugin/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>langstream-ai</artifactId>
+    <groupId>ai.langstream</groupId>
+    <version>0.2.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>nifi-maven-plugin</artifactId>
+  <packaging>maven-plugin</packaging>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-archiver</artifactId>
+      <version>3.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-dependency-plugin</artifactId>
+      <type>maven-plugin</type>
+      <version>3.5.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven.doxia</groupId>
+          <artifactId>doxia-site-renderer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven.reporting</groupId>
+          <artifactId>maven-reporting-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven.reporting</groupId>
+          <artifactId>maven-reporting-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven.doxia</groupId>
+          <artifactId>doxia-sink-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-io</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-dependency-tree</artifactId>
+      <version>3.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-jar-plugin</artifactId>
+      <version>3.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <scope>provided</scope>
+      <version>3.6.0</version>
+    </dependency>
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/NarDuplicateDependenciesMojo.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/NarDuplicateDependenciesMojo.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+import org.apache.nifi.utils.NarDependencyUtils;
+import org.eclipse.aether.RepositorySystemSession;
+
+/** Generates a list of duplicate dependencies with compile scope in the nar. */
+@Mojo(
+        name = "duplicate-nar-dependencies",
+        defaultPhase = LifecyclePhase.PACKAGE,
+        threadSafe = true,
+        requiresDependencyResolution = ResolutionScope.RUNTIME)
+public class NarDuplicateDependenciesMojo extends AbstractMojo {
+
+    /** The Maven project. */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    /**
+     * The {@link RepositorySystemSession} used for obtaining the local and remote artifact
+     * repositories.
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    /** The dependency tree builder to use for verbose output. */
+    @Component private DependencyCollectorBuilder dependencyCollectorBuilder;
+
+    /**
+     * * The {@link ArtifactHandlerManager} into which any extension {@link ArtifactHandler}
+     * instances should have been injected when the extensions were loaded.
+     */
+    @Component private ArtifactHandlerManager artifactHandlerManager;
+
+    /**
+     * The {@link ProjectBuilder} used to generate the {@link MavenProject} for the nar artifact the
+     * dependency tree is being generated for.
+     */
+    @Component private ProjectBuilder projectBuilder;
+
+    /*
+     * @see org.apache.maven.plugin.Mojo#execute()
+     */
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            NarDependencyUtils.ensureSingleNarDependencyExists(project);
+            // build the project for the nar artifact
+            final ProjectBuildingRequest narRequest = new DefaultProjectBuildingRequest();
+            narRequest.setRepositorySession(repoSession);
+            narRequest.setSystemProperties(System.getProperties());
+
+            artifactHandlerManager.addHandlers(
+                    NarDependencyUtils.createNarHandlerMap(narRequest, project, projectBuilder));
+
+            // get the dependency tree
+            final DependencyNode root =
+                    dependencyCollectorBuilder.collectDependencyGraph(narRequest, null);
+
+            DependencyNode narParent =
+                    root.getChildren().stream()
+                            .filter(
+                                    child ->
+                                            NarDependencyUtils.NAR.equals(
+                                                    child.getArtifact().getType()))
+                            .findFirst()
+                            .orElseThrow(
+                                    () ->
+                                            new MojoExecutionException(
+                                                    "Project does not have any NAR dependencies."));
+
+            getLog().info(
+                            "Analyzing dependencies of "
+                                    + narRequest.getProject().getFile().getPath());
+
+            // all compiled dependencies except inherited from parent
+            Map<String, List<Artifact>> directDependencies = new HashMap<>();
+
+            root.accept(
+                    new DependencyNodeVisitor() {
+                        final Stack<Artifact> hierarchy = new Stack<>();
+
+                        @Override
+                        public boolean visit(DependencyNode node) {
+                            if (node == root) {
+                                return true;
+                            }
+                            Artifact artifact = node.getArtifact();
+                            hierarchy.push(artifact);
+                            if (NarDependencyUtils.COMPILE_STRING.equals(artifact.getScope())
+                                    && !NarDependencyUtils.NAR.equals(artifact.getType())) {
+                                directDependencies.put(
+                                        artifact.toString(), new ArrayList<>(hierarchy));
+                                return true;
+                            }
+                            return false;
+                        }
+
+                        @Override
+                        public boolean endVisit(DependencyNode node) {
+                            if (node != root) {
+                                hierarchy.pop();
+                            }
+                            return true;
+                        }
+                    });
+
+            Map<String, List<String>> errors = new HashMap<>();
+
+            narParent.accept(
+                    new DependencyNodeVisitor() {
+                        final Stack<Artifact> hierarchy = new Stack<>();
+
+                        @Override
+                        public boolean visit(DependencyNode node) {
+                            Artifact artifact = node.getArtifact();
+                            hierarchy.push(artifact);
+                            if (NarDependencyUtils.COMPILE_STRING.equals(artifact.getScope())
+                                    && directDependencies.containsKey(artifact.toString())) {
+                                StringBuilder sb =
+                                        new StringBuilder()
+                                                .append(root.getArtifact())
+                                                .append(" (this nar)")
+                                                .append(System.lineSeparator());
+                                List<Artifact> otherHierarchy =
+                                        directDependencies.get(artifact.toString());
+                                // print other hierarchy
+                                for (int i = 0; i < otherHierarchy.size(); i++) {
+                                    sb.append(indent(i)).append(otherHierarchy.get(i));
+                                    // print the last artifact in the hierarchy
+                                    if (i == otherHierarchy.size() - 1) {
+                                        sb.append(" (duplicate)");
+                                    }
+                                    sb.append(System.lineSeparator());
+                                }
+                                // print this hierarchy
+                                for (int i = 0; i < hierarchy.size(); i++) {
+                                    sb.append(indent(i)).append(hierarchy.get(i));
+                                    // print the last artifact in the hierarchy
+                                    if (i == hierarchy.size() - 1) {
+                                        sb.append(" (already included here)");
+                                    }
+                                    sb.append(System.lineSeparator());
+                                }
+                                errors.computeIfAbsent(artifact.toString(), k -> new ArrayList<>())
+                                        .add(sb.toString());
+                            }
+                            return true;
+                        }
+
+                        @Override
+                        public boolean endVisit(DependencyNode node) {
+                            hierarchy.pop();
+                            return true;
+                        }
+                    });
+
+            for (Map.Entry<String, List<String>> entry : errors.entrySet()) {
+                StringBuilder sb =
+                        new StringBuilder()
+                                .append(entry.getKey())
+                                .append(" is already included in the nar");
+                if (entry.getValue().size() > 1) {
+                    sb.append(" multiple times");
+                }
+                sb.append(":");
+                for (String error : entry.getValue()) {
+                    sb.append(System.lineSeparator()).append(error);
+                }
+                getLog().error(sb.toString());
+            }
+
+            if (!errors.isEmpty()) {
+                getLog().info(
+                                "Consider changing the scope from \"compile\" to \"provided\" or exclude it in case it's a transitive dependency.");
+                throw new MojoFailureException("Found duplicate dependencies");
+            }
+
+        } catch (ProjectBuildingException | DependencyCollectorBuilderException e) {
+            throw new MojoExecutionException("Cannot build project dependency tree", e);
+        }
+    }
+
+    private String indent(int indent) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < indent; i++) {
+            sb.append("|  ");
+        }
+        sb.append("+- ");
+        return sb.toString();
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/NarMojo.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/NarMojo.java
@@ -1,0 +1,1310 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import org.apache.maven.archiver.MavenArchiveConfiguration;
+import org.apache.maven.archiver.MavenArchiver;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.installer.ArtifactInstaller;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryFactory;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.artifact.resolver.DefaultArtifactResolver;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.dependency.utils.DependencyStatusSets;
+import org.apache.maven.plugins.dependency.utils.DependencyUtil;
+import org.apache.maven.plugins.dependency.utils.filters.DestFileFilter;
+import org.apache.maven.plugins.dependency.utils.translators.ArtifactTranslator;
+import org.apache.maven.plugins.dependency.utils.translators.ClassifierTypeTranslator;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactIdFilter;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
+import org.apache.maven.shared.artifact.filter.collection.ClassifierFilter;
+import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
+import org.apache.maven.shared.artifact.filter.collection.GroupIdFilter;
+import org.apache.maven.shared.artifact.filter.collection.ProjectTransitivityFilter;
+import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
+import org.apache.maven.shared.artifact.filter.collection.TypeFilter;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
+import org.apache.nifi.extension.definition.ExtensionDefinition;
+import org.apache.nifi.extension.definition.ExtensionType;
+import org.apache.nifi.extension.definition.ServiceAPIDefinition;
+import org.apache.nifi.extension.definition.extraction.ExtensionClassLoader;
+import org.apache.nifi.extension.definition.extraction.ExtensionClassLoaderFactory;
+import org.apache.nifi.extension.definition.extraction.ExtensionDefinitionFactory;
+import org.apache.nifi.extension.definition.extraction.StandardServiceAPIDefinition;
+import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.codehaus.plexus.archiver.jar.ManifestException;
+import org.codehaus.plexus.archiver.manager.ArchiverManager;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Packages the current project as an Apache NiFi Archive (NAR).
+ *
+ * <p>The following code is derived from maven-dependencies-plugin and maven-jar-plugin. The
+ * functionality of CopyDependenciesMojo and JarMojo was simplified to the use case of NarMojo.
+ */
+@SuppressWarnings("unused")
+@Mojo(
+        name = "nar",
+        defaultPhase = LifecyclePhase.PACKAGE,
+        threadSafe = true,
+        requiresDependencyResolution = ResolutionScope.RUNTIME)
+public class NarMojo extends AbstractMojo {
+    private static final String CONTROLLER_SERVICE_CLASS_NAME =
+            "org.apache.nifi.controller.ControllerService";
+    private static final String DOCUMENTATION_WRITER_CLASS_NAME =
+            "org.apache.nifi.documentation.xml.XmlDocumentationWriter";
+
+    private static final String[] DEFAULT_EXCLUDES = new String[] {"**/package.html"};
+    private static final String[] DEFAULT_INCLUDES = new String[] {"**/**"};
+
+    private static final String BUILD_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+    /** POM */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    protected MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    protected MavenSession session;
+
+    /** List of files to include. Specified as fileset patterns. */
+    @Parameter(property = "includes")
+    protected String[] includes;
+
+    /** List of files to exclude. Specified as fileset patterns. */
+    @Parameter(property = "excludes")
+    protected String[] excludes;
+
+    /** Name of the generated NAR. */
+    @Parameter(
+            alias = "narName",
+            property = "nar.finalName",
+            defaultValue = "${project.build.finalName}",
+            required = true)
+    protected String finalName;
+
+    /**
+     * The Jar archiver.
+     *
+     * <p>\@\component role="org.codehaus.plexus.archiver.Archiver" roleHint="jar"
+     */
+    @Component(role = org.codehaus.plexus.archiver.Archiver.class, hint = "jar")
+    private JarArchiver jarArchiver;
+
+    /**
+     * The archive configuration to use.
+     *
+     * <p>See <a href="http://maven.apache.org/shared/maven-archiver/index.html">the documentation
+     * for Maven Archiver</a>.
+     */
+    @Parameter(property = "archive")
+    protected final MavenArchiveConfiguration archive = new MavenArchiveConfiguration();
+
+    /**
+     * Path to the default MANIFEST file to use. It will be used if <code>useDefaultManifestFile
+     * </code> is set to <code>true</code>.
+     */
+    @Parameter(
+            property = "defaultManifestFiles",
+            defaultValue = "${project.build.outputDirectory}/META-INF/MANIFEST.MF",
+            readonly = true,
+            required = true)
+    protected File defaultManifestFile;
+
+    /**
+     * Set this to <code>true</code> to enable the use of the <code>defaultManifestFile</code>.
+     *
+     * @since 2.2
+     */
+    @Parameter(property = "nar.useDefaultManifestFile", defaultValue = "false")
+    protected boolean useDefaultManifestFile;
+
+    @Component protected MavenProjectHelper projectHelper;
+
+    /** Whether creating the archive should be forced. */
+    @Parameter(property = "nar.forceCreation", defaultValue = "false")
+    protected boolean forceCreation;
+
+    /**
+     * Classifier to add to the artifact generated. If given, the artifact will be an attachment
+     * instead.
+     */
+    @Parameter(property = "classifier")
+    protected String classifier;
+
+    @Component protected ArtifactInstaller installer;
+
+    @Component protected ArtifactRepositoryFactory repositoryFactory;
+
+    /** This only applies if the classifier parameter is used. */
+    @Parameter(property = "mdep.failOnMissingClassifierArtifact", defaultValue = "true")
+    protected boolean failOnMissingClassifierArtifact = true;
+
+    /**
+     * Comma Separated list of Types to include. Empty String indicates include everything
+     * (default).
+     */
+    @Parameter(property = "includeTypes")
+    protected String includeTypes;
+
+    /**
+     * Comma Separated list of Types to exclude. Empty String indicates don't exclude anything
+     * (default).
+     */
+    @Parameter(property = "excludeTypes")
+    protected String excludeTypes;
+
+    /** Scope to include. An Empty string indicates all scopes (default). */
+    @Parameter(property = "includeScope")
+    protected String includeScope;
+
+    /** Scope to exclude. An Empty string indicates no scopes (default). */
+    @Parameter(property = "excludeScope")
+    protected String excludeScope;
+
+    /**
+     * Comma Separated list of Classifiers to include. Empty String indicates include everything
+     * (default).
+     */
+    @Parameter(property = "includeClassifiers")
+    protected String includeClassifiers;
+
+    /**
+     * Comma Separated list of Classifiers to exclude. Empty String indicates don't exclude anything
+     * (default).
+     */
+    @Parameter(property = "excludeClassifiers")
+    protected String excludeClassifiers;
+
+    /** Specify classifier to look for. Example: sources */
+    @Parameter(property = "classifier")
+    protected String copyDepClassifier;
+
+    /**
+     * Specify type to look for when constructing artifact based on classifier. Example:
+     * java-source,jar,war, nar
+     */
+    @Parameter(property = "type", defaultValue = "nar")
+    protected String type;
+
+    /** Comma separated list of Artifact names too exclude. */
+    @Parameter(property = "excludeArtifacts")
+    protected String excludeArtifactIds;
+
+    /** Comma separated list of Artifact names to include. */
+    @Parameter(property = "includeArtifacts")
+    protected String includeArtifactIds;
+
+    /** Comma separated list of GroupId Names to exclude. */
+    @Parameter(property = "excludeArtifacts")
+    protected String excludeGroupIds;
+
+    /** Comma separated list of GroupIds to include. */
+    @Parameter(property = "includeGroupIds")
+    protected String includeGroupIds;
+
+    /** Directory to store flag files */
+    @Parameter(
+            property = "markersDirectory",
+            defaultValue = "${project.build.directory}/dependency-maven-plugin-markers")
+    protected File markersDirectory;
+
+    /** Overwrite release artifacts */
+    @Parameter(property = "overWriteReleases")
+    protected boolean overWriteReleases;
+
+    /** Overwrite snapshot artifacts */
+    @Parameter(property = "overWriteSnapshots")
+    protected boolean overWriteSnapshots;
+
+    /** Overwrite artifacts that don't exist or are older than the source. */
+    @Parameter(property = "overWriteIfNewer", defaultValue = "true")
+    protected boolean overWriteIfNewer;
+
+    @Parameter(property = "projectBuildDirectory", defaultValue = "${project.build.directory}")
+    protected File projectBuildDirectory;
+
+    /** Used to look up Artifacts in the remote repository. */
+    @Component protected ArtifactFactory factory;
+
+    /** Used to look up Artifacts in the remote repository. */
+    @Component protected ArtifactResolver resolver;
+
+    /** Location of the local repository. */
+    @Parameter(property = "localRepository", required = true, readonly = true)
+    protected ArtifactRepository local;
+
+    /** List of Remote Repositories used by the resolver */
+    @Parameter(property = "project.remoteArtifactRepositories", required = true, readonly = true)
+    protected List<ArtifactRepository> remoteRepos;
+
+    /** To look up Archiver/UnArchiver implementations */
+    @Component protected ArchiverManager archiverManager;
+
+    /** Contains the full list of projects in the reactor. */
+    @Parameter(property = "reactorProjects", required = true, readonly = true)
+    protected List reactorProjects;
+
+    /** If the plugin should be silent. */
+    @Parameter(property = "silent", defaultValue = "false")
+    public boolean silent;
+
+    /** The dependency tree builder to use for verbose output. */
+    @Component private DependencyGraphBuilder dependencyGraphBuilder;
+
+    /**
+     * * The {@link ArtifactHandlerManager} into which any extension {@link ArtifactHandler}
+     * instances should have been injected when the extensions were loaded.
+     */
+    @Component private ArtifactHandlerManager artifactHandlerManager;
+
+    /** Output absolute filename for resolved artifacts */
+    @Parameter(property = "outputAbsoluteArtifactFilename", defaultValue = "false")
+    protected boolean outputAbsoluteArtifactFilename;
+
+    /* The values to use for populating the Nar-Group, Nar-Id, and Nar-Version in the MANIFEST file. By default
+     * these values will be set to the standard Maven project equivalents, but they may be overridden through properties.
+     *
+     * For example if the pom.xml for the nifi-test-nar contained the following:
+     *
+     *    <groupId>org.apache.nifi</groupId>
+     *    <artifactId>nifi-test-nar</artifactId>
+     *    <version>1.0</version>
+     *
+     *    <properties>
+     *       <narGroup>org.apache.nifi.overridden</narGroup>
+     *       <narId>nifi-overridden-test-nar</narId>
+     *       <narVersion>2.0</narVersion>
+     *   </properties>
+     *
+     * It would produce a MANIFEST with:
+     *
+     *   Nar-Id: nifi-overridden-test-nar
+     *   Nar-Group: org.apache.nifi.overridden
+     *   Nar-Version: 2.0
+     *
+     */
+
+    @Parameter(property = "narGroup", defaultValue = "${project.groupId}", required = true)
+    protected String narGroup;
+
+    @Parameter(property = "narId", defaultValue = "${project.artifactId}", required = true)
+    protected String narId;
+
+    @Parameter(property = "narVersion", defaultValue = "${project.version}", required = true)
+    protected String narVersion;
+
+    @Parameter(property = "narDependencyGroup")
+    protected String narDependencyGroup = null;
+
+    @Parameter(property = "narDependencyId")
+    protected String narDependencyId = null;
+
+    @Parameter(property = "narDependencyVersion")
+    protected String narDependencyVersion = null;
+
+    /** Build info to be populated in MANIFEST. */
+    @Parameter(property = "buildTag", defaultValue = "${project.scm.tag}")
+    protected String buildTag;
+
+    @Parameter(property = "buildBranch", defaultValue = "${buildBranch}")
+    protected String buildBranch;
+
+    @Parameter(property = "buildRevision", defaultValue = "${buildRevision}")
+    protected String buildRevision;
+
+    /**
+     * Allows a NAR to specify if it's resources should be cloned when a component that depends on
+     * this NAR is performing class loader isolation.
+     */
+    @Parameter(property = "cloneDuringInstanceClassLoading", defaultValue = "false")
+    protected boolean cloneDuringInstanceClassLoading;
+
+    @Parameter(property = "enforceDocGeneration", defaultValue = "false")
+    protected boolean enforceDocGeneration;
+
+    @Parameter(property = "skipDocGeneration", defaultValue = "false")
+    protected boolean skipDocGeneration;
+
+    /**
+     * The {@link RepositorySystemSession} used for obtaining the local and remote artifact
+     * repositories.
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    /**
+     * The {@link ProjectBuilder} used to generate the {@link MavenProject} for the nar artifact the
+     * dependency tree is being generated for.
+     */
+    @Component private ProjectBuilder projectBuilder;
+
+    /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601 <code>
+     * yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like <a
+     * href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     *
+     * @since 3.2.3
+     */
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        copyDependencies();
+
+        if (!skipDocGeneration) {
+            try {
+                generateDocumentation();
+            } catch (final Throwable t) { // Catch Throwable in case a linkage error such as
+                // NoClassDefFoundError occurs
+                if (enforceDocGeneration) {
+                    getLog().error("Could not generate extensions' documentation", t);
+                    throw t;
+                } else {
+                    getLog().warn("Could not generate extensions' documentation", t);
+                }
+            }
+        } else {
+            getLog().info("Skipping documentation generation for NiFi extensions");
+        }
+
+        makeNar();
+    }
+
+    private File getExtensionsDocumentationFile() {
+        final File directory = new File(projectBuildDirectory, "META-INF/docs");
+        return new File(directory, "extension-manifest.xml");
+    }
+
+    private void generateDocumentation() throws MojoExecutionException {
+        getLog().info("Generating documentation for NiFi extensions in the NAR...");
+
+        // Create the ClassLoader for the NAR
+        final ExtensionClassLoaderFactory classLoaderFactory = createClassLoaderFactory();
+
+        final ExtensionClassLoader extensionClassLoader;
+        try {
+            extensionClassLoader = classLoaderFactory.createExtensionClassLoader();
+        } catch (final Exception e) {
+            if (enforceDocGeneration) {
+                throw new MojoExecutionException("Failed to create Extension Documentation", e);
+            } else {
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug(
+                                    "Unable to create a ClassLoader for documenting extensions. If this NAR contains any NiFi Extensions, those extensions will not be documented.",
+                                    e);
+                } else {
+                    getLog().warn(
+                                    "Unable to create a ClassLoader for documenting extensions. If this NAR contains any NiFi Extensions, those extensions will not be documented. "
+                                            + "Enable mvn DEBUG output for more information (mvn -X).");
+                }
+                return;
+            }
+        }
+
+        final File docsFile = getExtensionsDocumentationFile();
+        createDirectory(docsFile.getParentFile());
+
+        final File additionalDetailsDir = new File(docsFile.getParentFile(), "additional-details");
+        createDirectory(additionalDetailsDir);
+
+        try (final OutputStream out = new FileOutputStream(docsFile)) {
+
+            final XMLStreamWriter xmlWriter =
+                    XMLOutputFactory.newInstance().createXMLStreamWriter(out, "UTF-8");
+            try {
+                xmlWriter.writeStartElement("extensionManifest");
+
+                // Write current NAR information
+                writeXmlTag(xmlWriter, "groupId", narGroup);
+                writeXmlTag(xmlWriter, "artifactId", narId);
+                writeXmlTag(xmlWriter, "version", narVersion);
+
+                // Write parent NAR information
+                final NarDependency narDependency = getNarDependency();
+                if (narDependency != null) {
+                    xmlWriter.writeStartElement("parentNar");
+                    writeXmlTag(
+                            xmlWriter,
+                            "groupId",
+                            notEmpty(this.narDependencyGroup)
+                                    ? this.narDependencyGroup
+                                    : narDependency.getGroupId());
+                    writeXmlTag(
+                            xmlWriter,
+                            "artifactId",
+                            notEmpty(this.narDependencyId)
+                                    ? this.narDependencyId
+                                    : narDependency.getArtifactId());
+                    writeXmlTag(
+                            xmlWriter,
+                            "version",
+                            notEmpty(this.narDependencyVersion)
+                                    ? this.narDependencyVersion
+                                    : narDependency.getVersion());
+                    xmlWriter.writeEndElement();
+                }
+
+                // Write system API version
+                final String nifiApiVersion = extensionClassLoader.getNiFiApiVersion();
+                xmlWriter.writeStartElement("systemApiVersion");
+                xmlWriter.writeCharacters(nifiApiVersion);
+                xmlWriter.writeEndElement();
+
+                // Write build info
+                xmlWriter.writeStartElement("buildInfo");
+                if (notEmpty(buildTag)) {
+                    writeXmlTag(xmlWriter, "tag", buildTag);
+                }
+                if (notEmpty(buildBranch)) {
+                    writeXmlTag(xmlWriter, "branch", buildBranch);
+                }
+                if (notEmpty(buildRevision)) {
+                    writeXmlTag(xmlWriter, "revision", buildRevision);
+                }
+                xmlWriter.writeEndElement();
+
+                // Write extensions
+                xmlWriter.writeStartElement("extensions");
+
+                final Class<?> docWriterClass;
+                try {
+                    docWriterClass =
+                            Class.forName(
+                                    DOCUMENTATION_WRITER_CLASS_NAME, false, extensionClassLoader);
+                } catch (ClassNotFoundException e) {
+                    getLog().warn(
+                                    "Cannot locate class "
+                                            + DOCUMENTATION_WRITER_CLASS_NAME
+                                            + ", so no documentation will be generated for the extensions in this NAR");
+                    return;
+                }
+
+                getLog().debug(
+                                "Creating Extension Definition Factory for NiFi API version "
+                                        + nifiApiVersion);
+
+                final ExtensionDefinitionFactory extensionDefinitionFactory =
+                        new ExtensionDefinitionFactory(extensionClassLoader);
+
+                final ClassLoader currentContextClassLoader =
+                        Thread.currentThread().getContextClassLoader();
+                try {
+                    Thread.currentThread().setContextClassLoader(extensionClassLoader);
+
+                    final Set<ExtensionDefinition> processorDefinitions =
+                            extensionDefinitionFactory.discoverExtensions(ExtensionType.PROCESSOR);
+                    writeDocumentation(
+                            processorDefinitions,
+                            extensionClassLoader,
+                            docWriterClass,
+                            xmlWriter,
+                            additionalDetailsDir);
+
+                    final Set<ExtensionDefinition> controllerServiceDefinitions =
+                            extensionDefinitionFactory.discoverExtensions(
+                                    ExtensionType.CONTROLLER_SERVICE);
+                    writeDocumentation(
+                            controllerServiceDefinitions,
+                            extensionClassLoader,
+                            docWriterClass,
+                            xmlWriter,
+                            additionalDetailsDir);
+
+                    final Set<ExtensionDefinition> reportingTaskDefinitions =
+                            extensionDefinitionFactory.discoverExtensions(
+                                    ExtensionType.REPORTING_TASK);
+                    writeDocumentation(
+                            reportingTaskDefinitions,
+                            extensionClassLoader,
+                            docWriterClass,
+                            xmlWriter,
+                            additionalDetailsDir);
+                } finally {
+                    if (currentContextClassLoader != null) {
+                        Thread.currentThread().setContextClassLoader(currentContextClassLoader);
+                    }
+                }
+
+                xmlWriter.writeEndElement();
+                xmlWriter.writeEndElement();
+            } finally {
+                xmlWriter.close();
+            }
+        } catch (final Exception ioe) {
+            throw new MojoExecutionException("Failed to create Extension Documentation", ioe);
+        }
+    }
+
+    private void writeXmlTag(
+            final XMLStreamWriter xmlWriter, final String tagName, final String value)
+            throws XMLStreamException {
+        xmlWriter.writeStartElement(tagName);
+        xmlWriter.writeCharacters(value);
+        xmlWriter.writeEndElement();
+    }
+
+    private void writeDocumentation(
+            final Set<ExtensionDefinition> extensionDefinitions,
+            final ExtensionClassLoader classLoader,
+            final Class<?> docWriterClass,
+            final XMLStreamWriter xmlWriter,
+            final File additionalDetailsDir)
+            throws InvocationTargetException,
+                    NoSuchMethodException,
+                    ClassNotFoundException,
+                    InstantiationException,
+                    IllegalAccessException,
+                    IOException {
+
+        final Set<ExtensionDefinition> sorted =
+                new TreeSet<>(Comparator.comparing(ExtensionDefinition::getExtensionName));
+        sorted.addAll(extensionDefinitions);
+
+        for (final ExtensionDefinition definition : sorted) {
+            writeDocumentation(definition, classLoader, docWriterClass, xmlWriter);
+        }
+
+        final Set<String> extensionNames =
+                sorted.stream()
+                        .map(ExtensionDefinition::getExtensionName)
+                        .collect(Collectors.toSet());
+
+        try {
+            writeAdditionalDetails(classLoader, extensionNames, additionalDetailsDir);
+        } catch (final Exception e) {
+            throw new IOException("Unable to extract Additional Details", e);
+        }
+    }
+
+    private void writeDocumentation(
+            final ExtensionDefinition extensionDefinition,
+            final ExtensionClassLoader classLoader,
+            final Class<?> docWriterClass,
+            final XMLStreamWriter xmlWriter)
+            throws NoSuchMethodException,
+                    IllegalAccessException,
+                    InvocationTargetException,
+                    InstantiationException,
+                    ClassNotFoundException {
+
+        getLog().debug(
+                        "Generating documentation for "
+                                + extensionDefinition.getExtensionName()
+                                + " using ClassLoader:"
+                                + System.lineSeparator()
+                                + classLoader.toTree());
+        final Object docWriter =
+                docWriterClass.getConstructor(XMLStreamWriter.class).newInstance(xmlWriter);
+        final Class<?> configurableComponentClass =
+                Class.forName(
+                        "org.apache.nifi.components.ConfigurableComponent", false, classLoader);
+
+        final Class<?> extensionClass =
+                Class.forName(extensionDefinition.getExtensionName(), false, classLoader);
+        final Object extensionInstance = extensionClass.getDeclaredConstructor().newInstance();
+
+        final Method initMethod =
+                docWriterClass.getMethod("initialize", configurableComponentClass);
+        initMethod.invoke(docWriter, extensionInstance);
+
+        final Map<String, ServiceAPIDefinition> propertyServiceDefinitions =
+                getRequiredServiceDefinitions(extensionClass, extensionInstance);
+        final Set<ServiceAPIDefinition> providedServiceDefinitions =
+                extensionDefinition.getProvidedServiceAPIs();
+
+        if ((providedServiceDefinitions == null || providedServiceDefinitions.isEmpty())
+                && (propertyServiceDefinitions == null || propertyServiceDefinitions.isEmpty())) {
+            final Method writeMethod =
+                    docWriterClass.getMethod("write", configurableComponentClass);
+            writeMethod.invoke(docWriter, extensionInstance);
+        } else {
+            final Class<?> serviceApiClass =
+                    Class.forName(
+                            "org.apache.nifi.documentation.StandardServiceAPI", false, classLoader);
+            final List<Object> providedServices =
+                    getDocumentationServiceAPIs(serviceApiClass, providedServiceDefinitions);
+            final Map<String, Object> propertyServices =
+                    getDocumentationServiceAPIs(serviceApiClass, propertyServiceDefinitions);
+
+            final Method writeMethod =
+                    docWriterClass.getMethod(
+                            "write", configurableComponentClass, Collection.class, Map.class);
+            writeMethod.invoke(docWriter, extensionInstance, providedServices, propertyServices);
+        }
+    }
+
+    private List<Object> getDocumentationServiceAPIs(
+            Class<?> serviceApiClass, Set<ServiceAPIDefinition> serviceDefinitions)
+            throws NoSuchMethodException,
+                    InstantiationException,
+                    IllegalAccessException,
+                    InvocationTargetException {
+        final Constructor<?> ctr =
+                serviceApiClass.getConstructor(
+                        String.class, String.class, String.class, String.class);
+
+        final List<Object> providedServices = new ArrayList<>();
+
+        for (final ServiceAPIDefinition definition : serviceDefinitions) {
+            final Object serviceApi =
+                    ctr.newInstance(
+                            definition.getServiceAPIClassName(),
+                            definition.getServiceGroupId(),
+                            definition.getServiceArtifactId(),
+                            definition.getServiceVersion());
+            providedServices.add(serviceApi);
+        }
+        return providedServices;
+    }
+
+    private Map<String, Object> getDocumentationServiceAPIs(
+            Class<?> serviceApiClass, Map<String, ServiceAPIDefinition> serviceDefinitions)
+            throws NoSuchMethodException,
+                    InstantiationException,
+                    IllegalAccessException,
+                    InvocationTargetException {
+        final Constructor<?> ctr =
+                serviceApiClass.getConstructor(
+                        String.class, String.class, String.class, String.class);
+
+        final Map<String, Object> providedServices = new HashMap<>();
+
+        for (final Map.Entry<String, ServiceAPIDefinition> entry : serviceDefinitions.entrySet()) {
+            final String propName = entry.getKey();
+            final ServiceAPIDefinition definition = entry.getValue();
+
+            final Object serviceApi =
+                    ctr.newInstance(
+                            definition.getServiceAPIClassName(),
+                            definition.getServiceGroupId(),
+                            definition.getServiceArtifactId(),
+                            definition.getServiceVersion());
+            providedServices.put(propName, serviceApi);
+        }
+        return providedServices;
+    }
+
+    private Map<String, ServiceAPIDefinition> getRequiredServiceDefinitions(
+            final Class<?> extensionClass, final Object extensionInstance)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final Map<String, ServiceAPIDefinition> requiredServiceAPIDefinitions = new HashMap<>();
+
+        final Method writeMethod = extensionClass.getMethod("getPropertyDescriptors");
+        final List<Object> propertyDescriptors =
+                (List<Object>) writeMethod.invoke(extensionInstance);
+
+        if (propertyDescriptors == null) {
+            return requiredServiceAPIDefinitions;
+        }
+
+        for (final Object propDescriptor : propertyDescriptors) {
+            final Method nameMethod = propDescriptor.getClass().getMethod("getName");
+            final String propName = (String) nameMethod.invoke(propDescriptor);
+
+            final Method serviceDefinitionMethod =
+                    propDescriptor.getClass().getMethod("getControllerServiceDefinition");
+            final Object serviceDefinition = serviceDefinitionMethod.invoke(propDescriptor);
+
+            if (serviceDefinition == null) {
+                continue;
+            }
+
+            final Class<?> serviceDefinitionClass = (Class<?>) serviceDefinition;
+            if (CONTROLLER_SERVICE_CLASS_NAME.equals(serviceDefinitionClass.getName())) {
+                continue;
+            }
+
+            final ExtensionClassLoader extensionClassLoader =
+                    (ExtensionClassLoader) serviceDefinitionClass.getClassLoader();
+            final Artifact narArtifact = extensionClassLoader.getNarArtifact();
+
+            if (narArtifact == null) {
+                getLog().warn(
+                                "Could not find NAR Artifact for Controller Service Definition "
+                                        + serviceDefinitionClass.getName()
+                                        + ". Documentation may  not show appropriate linkage to Controller Service.");
+                continue;
+            }
+
+            final ServiceAPIDefinition serviceAPIDefinition =
+                    new StandardServiceAPIDefinition(
+                            serviceDefinitionClass.getName(),
+                            narArtifact.getGroupId(),
+                            narArtifact.getArtifactId(),
+                            narArtifact.getBaseVersion());
+
+            requiredServiceAPIDefinitions.put(propName, serviceAPIDefinition);
+        }
+
+        return requiredServiceAPIDefinitions;
+    }
+
+    private void writeAdditionalDetails(
+            final ExtensionClassLoader classLoader,
+            final Set<String> extensionNames,
+            final File additionalDetailsDir)
+            throws URISyntaxException, IOException, MojoExecutionException {
+
+        for (final URL url : classLoader.getURLs()) {
+            final File file = new File(url.toURI());
+            final String filename = file.getName();
+            if (!filename.endsWith(".jar")) {
+                continue;
+            }
+
+            writeAdditionalDetails(file, extensionNames, additionalDetailsDir);
+        }
+    }
+
+    private void writeAdditionalDetails(
+            final File file, final Set<String> extensionNames, final File additionalDetailsDir)
+            throws IOException, MojoExecutionException {
+        final JarFile jarFile = new JarFile(file);
+
+        for (final Enumeration<JarEntry> jarEnumeration = jarFile.entries();
+                jarEnumeration.hasMoreElements(); ) {
+            final JarEntry jarEntry = jarEnumeration.nextElement();
+
+            final String entryName = jarEntry.getName();
+            if (!entryName.startsWith("docs/")) {
+                continue;
+            }
+
+            final int nextSlashIndex = entryName.indexOf("/", 5);
+            if (nextSlashIndex < 0) {
+                continue;
+            }
+
+            final String componentName = entryName.substring(5, nextSlashIndex);
+            if (!extensionNames.contains(componentName)) {
+                continue;
+            }
+
+            if (jarEntry.isDirectory()) {
+                continue;
+            }
+
+            if (entryName.length() < nextSlashIndex + 1) {
+                continue;
+            }
+
+            getLog().debug(
+                            "Found file "
+                                    + entryName
+                                    + " in "
+                                    + file
+                                    + " that consists of documentation for "
+                                    + componentName);
+            final File componentDirectory = new File(additionalDetailsDir, componentName);
+            final String remainingPath = entryName.substring(nextSlashIndex + 1);
+            final File destinationFile = new File(componentDirectory, remainingPath);
+
+            createDirectory(destinationFile.getParentFile());
+
+            try (final InputStream in = jarFile.getInputStream(jarEntry);
+                    final OutputStream out = new FileOutputStream(destinationFile)) {
+                copy(in, out);
+            }
+        }
+    }
+
+    private void copy(final InputStream in, final OutputStream out) throws IOException {
+        final byte[] buffer = new byte[8192];
+        int len;
+        while ((len = in.read(buffer)) >= 0) {
+            out.write(buffer, 0, len);
+        }
+    }
+
+    private ExtensionClassLoaderFactory createClassLoaderFactory() {
+        return new ExtensionClassLoaderFactory.Builder()
+                .artifactResolver(resolver)
+                .dependencyGraphBuilder(dependencyGraphBuilder)
+                .localRepository(local)
+                .remoteRepositories(remoteRepos)
+                .log(getLog())
+                .project(project)
+                .projectBuilder(projectBuilder)
+                .repositorySession(repoSession)
+                .artifactHandlerManager(artifactHandlerManager)
+                .build();
+    }
+
+    private void createDirectory(final File file) throws MojoExecutionException {
+        if (!file.exists()) {
+            try {
+                Files.createDirectories(file.toPath());
+            } catch (IOException e) {
+                throw new MojoExecutionException("Could not create directory " + file, e);
+            }
+        }
+    }
+
+    private void copyDependencies() throws MojoExecutionException {
+        DependencyStatusSets dss = getDependencySets();
+        Set<Artifact> artifacts = dss.getResolvedDependencies();
+
+        for (Artifact artifact : artifacts) {
+            copyArtifact(artifact);
+        }
+
+        artifacts = dss.getSkippedDependencies();
+        for (Artifact artifact : artifacts) {
+            getLog().debug(artifact.getFile().getName() + " already exists in destination.");
+        }
+    }
+
+    protected void copyArtifact(Artifact artifact) throws MojoExecutionException {
+        String destFileName = DependencyUtil.getFormattedFileName(artifact, false);
+        final File destDir =
+                DependencyUtil.getFormattedOutputDirectory(
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        getDependenciesDirectory(),
+                        artifact);
+        final File destFile = new File(destDir, destFileName);
+        copyFile(artifact.getFile(), destFile);
+    }
+
+    protected Artifact getResolvedPomArtifact(Artifact artifact) {
+        Artifact pomArtifact =
+                this.factory.createArtifact(
+                        artifact.getGroupId(),
+                        artifact.getArtifactId(),
+                        artifact.getVersion(),
+                        "",
+                        "pom");
+        // Resolve the pom artifact using repos
+        ArtifactResolutionRequest artifactResolutionRequest =
+                getArtifactResolutionRequest(pomArtifact);
+        ArtifactResolutionResult artifactResolutionResult =
+                this.resolver.resolve(artifactResolutionRequest);
+        if (artifactResolutionResult.hasExceptions()) {
+            getLog().info("Could not resolve [" + pomArtifact + "]");
+            for (Exception e : artifactResolutionResult.getExceptions()) {
+                getLog().info(e.getMessage());
+            }
+        }
+        return pomArtifact;
+    }
+
+    protected ArtifactsFilter getMarkedArtifactFilter() {
+        return new DestFileFilter(
+                this.overWriteReleases,
+                this.overWriteSnapshots,
+                this.overWriteIfNewer,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                getDependenciesDirectory());
+    }
+
+    protected DependencyStatusSets getDependencySets() throws MojoExecutionException {
+        // add filters in well known order, least specific to most specific
+        FilterArtifacts filter = new FilterArtifacts();
+
+        filter.addFilter(new ProjectTransitivityFilter(project.getDependencyArtifacts(), false));
+        filter.addFilter(new ScopeFilter(this.includeScope, this.excludeScope));
+        filter.addFilter(new TypeFilter(this.includeTypes, this.excludeTypes));
+        filter.addFilter(new ClassifierFilter(this.includeClassifiers, this.excludeClassifiers));
+        filter.addFilter(new GroupIdFilter(this.includeGroupIds, this.excludeGroupIds));
+        filter.addFilter(new ArtifactIdFilter(this.includeArtifactIds, this.excludeArtifactIds));
+
+        // explicitly filter our nar dependencies
+        filter.addFilter(new TypeFilter("", "nar"));
+
+        // start with all artifacts.
+        Set<Artifact> artifacts = project.getArtifacts();
+
+        // perform filtering
+        try {
+            artifacts = filter.filter(artifacts);
+        } catch (ArtifactFilterException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+
+        // transform artifacts if classifier is set
+        final DependencyStatusSets status;
+        if (StringUtils.isNotEmpty(copyDepClassifier)) {
+            status = getClassifierTranslatedDependencies(artifacts);
+        } else {
+            status = filterMarkedDependencies(artifacts);
+        }
+
+        return status;
+    }
+
+    protected DependencyStatusSets getClassifierTranslatedDependencies(Set<Artifact> artifacts)
+            throws MojoExecutionException {
+        Set<Artifact> unResolvedArtifacts = new HashSet<>();
+        Set<Artifact> resolvedArtifacts = artifacts;
+        DependencyStatusSets status = new DependencyStatusSets();
+
+        // possibly translate artifacts into a new set of artifacts based on the
+        // classifier and type
+        // if this did something, we need to resolve the new artifacts
+        if (StringUtils.isNotEmpty(copyDepClassifier)) {
+            ArtifactTranslator translator =
+                    new ClassifierTypeTranslator(artifactHandlerManager, copyDepClassifier, type);
+            Set<ArtifactCoordinate> artifactCoordinates = translator.translate(artifacts, getLog());
+
+            status = filterMarkedDependencies(artifacts);
+
+            // the unskipped artifacts are in the resolved set.
+            artifacts = status.getResolvedDependencies();
+            unResolvedArtifacts.addAll(artifacts);
+
+            // resolve the rest of the artifacts
+            ArtifactResolver artifactResolver = new DefaultArtifactResolver();
+            for (Artifact artifact : artifacts) {
+                ArtifactResolutionRequest req = getArtifactResolutionRequest(artifact);
+                ArtifactResolutionResult result = artifactResolver.resolve(req);
+                if (result.getArtifacts() != null) {
+                    unResolvedArtifacts.removeAll(result.getArtifacts());
+                }
+            }
+        }
+
+        // return a bean of all 3 sets.
+        status.setResolvedDependencies(resolvedArtifacts);
+        status.setUnResolvedDependencies(unResolvedArtifacts);
+
+        return status;
+    }
+
+    protected DependencyStatusSets filterMarkedDependencies(Set<Artifact> artifacts)
+            throws MojoExecutionException {
+        // remove files that have markers already
+        FilterArtifacts filter = new FilterArtifacts();
+        filter.clearFilters();
+        filter.addFilter(getMarkedArtifactFilter());
+
+        Set<Artifact> unMarkedArtifacts;
+        try {
+            unMarkedArtifacts = filter.filter(artifacts);
+        } catch (ArtifactFilterException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+
+        // calculate the skipped artifacts
+        Set<Artifact> skippedArtifacts = new HashSet<>(artifacts);
+        skippedArtifacts.removeAll(unMarkedArtifacts);
+
+        return new DependencyStatusSets(unMarkedArtifacts, null, skippedArtifacts);
+    }
+
+    protected void copyFile(File artifact, File destFile) throws MojoExecutionException {
+        try {
+            getLog().info(
+                            "Copying "
+                                    + (this.outputAbsoluteArtifactFilename
+                                            ? artifact.getAbsolutePath()
+                                            : artifact.getName())
+                                    + " to "
+                                    + destFile);
+            FileUtils.copyFile(artifact, destFile);
+        } catch (Exception e) {
+            throw new MojoExecutionException(
+                    "Error copying artifact from " + artifact + " to " + destFile, e);
+        }
+    }
+
+    private File getClassesDirectory() {
+        final File outputDirectory = projectBuildDirectory;
+        return new File(outputDirectory, "classes");
+    }
+
+    private File getDependenciesDirectory() {
+        return new File(getClassesDirectory(), "META-INF/bundled-dependencies");
+    }
+
+    private void makeNar() throws MojoExecutionException {
+        File narFile = createArchive();
+
+        if (classifier != null) {
+            projectHelper.attachArtifact(project, "nar", classifier, narFile);
+        } else {
+            project.getArtifact().setFile(narFile);
+        }
+    }
+
+    public File createArchive() throws MojoExecutionException {
+        final File outputDirectory = projectBuildDirectory;
+        File narFile = getNarFile(outputDirectory, finalName, classifier);
+        MavenArchiver archiver = new MavenArchiver();
+        archiver.setCreatedBy(
+                "Apache NiFi Nar Maven Plugin", "org.apache.nifi", "nifi-nar-maven-plugin");
+        archiver.setArchiver(jarArchiver);
+        archiver.setOutputFile(narFile);
+        Date timestamp =
+                archiver.configureReproducible(
+                        outputTimestamp); // configure for Reproducible Builds based on
+        // outputTimestamp value
+        archive.setForced(forceCreation);
+
+        try {
+            File contentDirectory = getClassesDirectory();
+            if (contentDirectory.exists()) {
+                archiver.getArchiver().addDirectory(contentDirectory, getIncludes(), getExcludes());
+            } else {
+                getLog().warn("NAR will be empty - no content was marked for inclusion!");
+            }
+
+            File extensionDocsFile = getExtensionsDocumentationFile();
+            if (extensionDocsFile.exists()) {
+                archiver.getArchiver()
+                        .addFile(extensionDocsFile, "META-INF/docs/" + extensionDocsFile.getName());
+            } else {
+                getLog().warn(
+                                "NAR will not contain any Extensions' documentation - no META-INF/"
+                                        + extensionDocsFile.getName()
+                                        + " file found!");
+            }
+
+            File additionalDetailsDirectory =
+                    new File(extensionDocsFile.getParentFile(), "additional-details");
+            if (additionalDetailsDirectory.exists()) {
+                archiver.getArchiver()
+                        .addDirectory(
+                                additionalDetailsDirectory, "META-INF/docs/additional-details/");
+            }
+
+            File existingManifest = defaultManifestFile;
+            if (useDefaultManifestFile
+                    && existingManifest.exists()
+                    && archive.getManifestFile() == null) {
+                getLog().info(
+                                "Adding existing MANIFEST to archive. Found under: "
+                                        + existingManifest.getPath());
+                archive.setManifestFile(existingManifest);
+            }
+
+            // automatically add the artifact id, group id, and version to the manifest
+            archive.addManifestEntry("Nar-Id", narId);
+            archive.addManifestEntry("Nar-Group", narGroup);
+            archive.addManifestEntry("Nar-Version", narVersion);
+
+            // look for a nar dependency
+            NarDependency narDependency = getNarDependency();
+            if (narDependency != null) {
+                final String narDependencyGroup =
+                        notEmpty(this.narDependencyGroup)
+                                ? this.narDependencyGroup
+                                : narDependency.getGroupId();
+                final String narDependencyId =
+                        notEmpty(this.narDependencyId)
+                                ? this.narDependencyId
+                                : narDependency.getArtifactId();
+                final String narDependencyVersion =
+                        notEmpty(this.narDependencyVersion)
+                                ? this.narDependencyVersion
+                                : narDependency.getVersion();
+
+                archive.addManifestEntry("Nar-Dependency-Group", narDependencyGroup);
+                archive.addManifestEntry("Nar-Dependency-Id", narDependencyId);
+                archive.addManifestEntry("Nar-Dependency-Version", narDependencyVersion);
+            }
+
+            // add build information when available
+
+            if (notEmpty(buildTag)) {
+                archive.addManifestEntry("Build-Tag", buildTag);
+            }
+            if (notEmpty(buildBranch)) {
+                archive.addManifestEntry("Build-Branch", buildBranch);
+            }
+            if (notEmpty(buildRevision)) {
+                archive.addManifestEntry("Build-Revision", buildRevision);
+            }
+
+            SimpleDateFormat dateFormat = new SimpleDateFormat(BUILD_TIMESTAMP_FORMAT);
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            archive.addManifestEntry(
+                    "Build-Timestamp",
+                    dateFormat.format(timestamp == null ? new Date() : timestamp));
+
+            archive.addManifestEntry(
+                    "Clone-During-Instance-Class-Loading",
+                    String.valueOf(cloneDuringInstanceClassLoading));
+
+            archiver.createArchive(session, project, archive);
+            return narFile;
+        } catch (ArchiverException
+                | MojoExecutionException
+                | ManifestException
+                | IOException
+                | DependencyResolutionRequiredException e) {
+            throw new MojoExecutionException("Error assembling NAR", e);
+        }
+    }
+
+    private boolean notEmpty(String value) {
+        return value != null && !value.isEmpty();
+    }
+
+    private String[] getIncludes() {
+        if (includes != null && includes.length > 0) {
+            return includes;
+        }
+        return DEFAULT_INCLUDES;
+    }
+
+    private String[] getExcludes() {
+        if (excludes != null && excludes.length > 0) {
+            return excludes;
+        }
+        return DEFAULT_EXCLUDES;
+    }
+
+    private ArtifactResolutionRequest getArtifactResolutionRequest(Artifact artifact) {
+        ArtifactResolutionRequest request = new ArtifactResolutionRequest();
+        request.setRemoteRepositories(this.remoteRepos);
+        request.setLocalRepository(this.local);
+        request.setArtifact(artifact);
+        return request;
+    }
+
+    protected File getNarFile(File basedir, String finalName, String classifier) {
+        if (classifier == null) {
+            classifier = "";
+        } else if (classifier.trim().length() > 0 && !classifier.startsWith("-")) {
+            classifier = "-" + classifier;
+        }
+
+        return new File(basedir, finalName + classifier + ".nar");
+    }
+
+    private NarDependency getNarDependency() throws MojoExecutionException {
+        NarDependency narDependency = null;
+
+        // get nar dependencies
+        FilterArtifacts filter = new FilterArtifacts();
+        filter.addFilter(new TypeFilter("nar", ""));
+
+        // start with all artifacts.
+        Set<Artifact> artifacts = project.getArtifacts();
+
+        // perform filtering
+        try {
+            artifacts = filter.filter(artifacts);
+        } catch (ArtifactFilterException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+
+        // ensure there is a single nar dependency
+        if (artifacts.size() > 1) {
+            throw new MojoExecutionException(
+                    "Each NAR represents a ClassLoader. A NAR dependency allows that NAR's ClassLoader to be "
+                            + "used as the parent of this NAR's ClassLoader. As a result, only a single NAR dependency is allowed.");
+        } else if (artifacts.size() == 1) {
+            final Artifact artifact = artifacts.iterator().next();
+
+            narDependency =
+                    new NarDependency(
+                            artifact.getGroupId(),
+                            artifact.getArtifactId(),
+                            artifact.getBaseVersion());
+        }
+
+        return narDependency;
+    }
+
+    private static class NarDependency {
+
+        final String groupId;
+        final String artifactId;
+        final String version;
+
+        public NarDependency(String groupId, String artifactId, String version) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.version = version;
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public String getArtifactId() {
+            return artifactId;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/NarProvidedDependenciesMojo.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/NarProvidedDependenciesMojo.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+import org.apache.nifi.utils.NarDependencyUtils;
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Generates the listing of dependencies that is provided by the NAR dependency of the current NAR.
+ * This is important as artifacts that bundle dependencies will not project those dependences using
+ * the traditional maven dependency plugin. This plugin will override that setting in order to print
+ * the dependencies being inherited at runtime.
+ */
+@Mojo(
+        name = "provided-nar-dependencies",
+        defaultPhase = LifecyclePhase.PACKAGE,
+        threadSafe = true,
+        requiresDependencyResolution = ResolutionScope.RUNTIME)
+public class NarProvidedDependenciesMojo extends AbstractMojo {
+
+    /** The Maven project. */
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    /** The local artifact repository. */
+    @Parameter(defaultValue = "${localRepository}", readonly = true)
+    private ArtifactRepository localRepository;
+
+    /**
+     * The {@link RepositorySystemSession} used for obtaining the local and remote artifact
+     * repositories.
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    /**
+     * If specified, this parameter will cause the dependency tree to be written using the specified
+     * format. Currently supported format are: <code>tree</code> or <code>pom</code>.
+     */
+    @Parameter(property = "mode", defaultValue = "tree")
+    private String mode;
+
+    /** The dependency tree builder to use for verbose output. */
+    @Component private DependencyGraphBuilder dependencyGraphBuilder;
+
+    /**
+     * * The {@link ArtifactHandlerManager} into which any extension {@link ArtifactHandler}
+     * instances should have been injected when the extensions were loaded.
+     */
+    @Component private ArtifactHandlerManager artifactHandlerManager;
+
+    /**
+     * The {@link ProjectBuilder} used to generate the {@link MavenProject} for the nar artifact the
+     * dependency tree is being generated for.
+     */
+    @Component private ProjectBuilder projectBuilder;
+
+    /*
+     * @see org.apache.maven.plugin.Mojo#execute()
+     */
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            NarDependencyUtils.ensureSingleNarDependencyExists(project);
+            // build the project for the nar artifact
+            final ProjectBuildingRequest narRequest = new DefaultProjectBuildingRequest();
+            narRequest.setRepositorySession(repoSession);
+            narRequest.setSystemProperties(System.getProperties());
+
+            artifactHandlerManager.addHandlers(
+                    NarDependencyUtils.createNarHandlerMap(narRequest, project, projectBuilder));
+
+            // get the dependency tree
+            final DependencyNode root =
+                    dependencyGraphBuilder.buildDependencyGraph(narRequest, null);
+
+            // write the appropriate output
+            DependencyNodeVisitor visitor = null;
+            if ("tree".equals(mode)) {
+                visitor = new TreeWriter();
+            } else if ("pom".equals(mode)) {
+                visitor = new PomWriter();
+            }
+
+            // ensure the mode was specified correctly
+            if (visitor == null) {
+                throw new MojoExecutionException(
+                        "The specified mode is invalid. Supported options are 'tree' and 'pom'.");
+            }
+
+            // visit and print the results
+            root.accept(visitor);
+            getLog().info(
+                            "--- Provided NAR Dependencies ---"
+                                    + System.lineSeparator()
+                                    + System.lineSeparator()
+                                    + visitor);
+        } catch (ProjectBuildingException | DependencyGraphBuilderException e) {
+            throw new MojoExecutionException("Cannot build project dependency tree", e);
+        }
+    }
+
+    /**
+     * Gets the Maven project used by this mojo.
+     *
+     * @return the Maven project
+     */
+    public MavenProject getProject() {
+        return project;
+    }
+
+    /**
+     * Returns whether the specified dependency has test scope.
+     *
+     * @param node The dependency
+     * @return What the dependency is a test scoped dep
+     */
+    private boolean isTest(final DependencyNode node) {
+        return "test".equals(node.getArtifact().getScope());
+    }
+
+    /** A dependency visitor that builds a dependency tree. */
+    private class TreeWriter implements DependencyNodeVisitor {
+
+        private final StringBuilder output = new StringBuilder();
+        private final Deque<DependencyNode> hierarchy = new ArrayDeque<>();
+
+        @Override
+        public boolean visit(DependencyNode node) {
+            // add this node
+            hierarchy.push(node);
+
+            // don't print test deps, but still add to hierarchy as they will
+            // be removed in endVisit below
+            if (isTest(node)) {
+                return false;
+            }
+
+            // build the padding
+            final StringBuilder pad = new StringBuilder();
+            for (int i = 0; i < hierarchy.size() - 1; i++) {
+                pad.append("   ");
+            }
+            pad.append("+- ");
+
+            // log it
+            output.append(pad).append(node.toNodeString()).append(System.lineSeparator());
+
+            return true;
+        }
+
+        @Override
+        public boolean endVisit(DependencyNode node) {
+            hierarchy.pop();
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return output.toString();
+        }
+    }
+
+    /**
+     * A dependency visitor that generates output that can be copied into a pom's dependency
+     * management section.
+     */
+    private class PomWriter implements DependencyNodeVisitor {
+
+        private final StringBuilder output = new StringBuilder();
+
+        @Override
+        public boolean visit(DependencyNode node) {
+            if (isTest(node)) {
+                return false;
+            }
+
+            final Artifact artifact = node.getArtifact();
+            if (!NarDependencyUtils.NAR.equals(artifact.getType())) {
+                output.append("<dependency>").append(System.lineSeparator());
+                output.append("    <groupId>")
+                        .append(artifact.getGroupId())
+                        .append("</groupId>")
+                        .append(System.lineSeparator());
+                output.append("    <artifactId>")
+                        .append(artifact.getArtifactId())
+                        .append("</artifactId>")
+                        .append(System.lineSeparator());
+                output.append("    <version>")
+                        .append(artifact.getVersion())
+                        .append("</version>")
+                        .append(System.lineSeparator());
+                output.append("    <scope>provided</scope>").append(System.lineSeparator());
+                output.append("</dependency>").append(System.lineSeparator());
+            }
+
+            return true;
+        }
+
+        @Override
+        public boolean endVisit(DependencyNode node) {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return output.toString();
+        }
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/ExtensionDefinition.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/ExtensionDefinition.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition;
+
+import java.util.Set;
+
+public interface ExtensionDefinition {
+
+    /**
+     * @return the type of Extension
+     */
+    ExtensionType getExtensionType();
+
+    /**
+     * @return the Set of all Services API's that this extension provides. Note that this will be an
+     *     empty set for any Extension for which {@link #getExtensionType()} is not {@link
+     *     ExtensionType#CONTROLLER_SERVICE}.
+     */
+    Set<ServiceAPIDefinition> getProvidedServiceAPIs();
+
+    /**
+     * @return the name of the Extension
+     */
+    String getExtensionName();
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/ExtensionType.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/ExtensionType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition;
+
+public enum ExtensionType {
+    PROCESSOR,
+
+    CONTROLLER_SERVICE,
+
+    REPORTING_TASK;
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/ServiceAPIDefinition.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/ServiceAPIDefinition.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition;
+
+public interface ServiceAPIDefinition {
+    String getServiceAPIClassName();
+
+    String getServiceGroupId();
+
+    String getServiceArtifactId();
+
+    String getServiceVersion();
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoader.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoader.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition.extraction;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.maven.artifact.Artifact;
+
+public class ExtensionClassLoader extends URLClassLoader {
+    private final URL[] urls;
+    private final Artifact narArtifact;
+    private final Collection<Artifact> allArtifacts;
+
+    public ExtensionClassLoader(
+            final URL[] urls,
+            final ClassLoader parent,
+            final Artifact narArtifact,
+            final Collection<Artifact> otherArtifacts) {
+        super(urls, parent);
+        this.urls = urls;
+        this.narArtifact = narArtifact;
+        this.allArtifacts = new ArrayList<>(otherArtifacts);
+        if (narArtifact != null) {
+            allArtifacts.add(narArtifact);
+        }
+    }
+
+    public ExtensionClassLoader(
+            final URL[] urls,
+            final Artifact narArtifact,
+            final Collection<Artifact> otherArtifacts) {
+        super(urls);
+        this.urls = urls;
+        this.narArtifact = narArtifact;
+        this.allArtifacts = new ArrayList<>(otherArtifacts);
+        if (narArtifact != null) {
+            allArtifacts.add(narArtifact);
+        }
+    }
+
+    public String getNiFiApiVersion() {
+        final Collection<Artifact> artifacts = getAllArtifacts();
+        for (final Artifact artifact : artifacts) {
+            if (artifact.getArtifactId().equals("nifi-api")
+                    && artifact.getGroupId().equals("org.apache.nifi")) {
+                return artifact.getVersion();
+            }
+        }
+
+        final ClassLoader parent = getParent();
+        if (parent instanceof ExtensionClassLoader) {
+            return ((ExtensionClassLoader) parent).getNiFiApiVersion();
+        }
+
+        return null;
+    }
+
+    public Artifact getNarArtifact() {
+        return narArtifact;
+    }
+
+    public Collection<Artifact> getAllArtifacts() {
+        return allArtifacts;
+    }
+
+    @Override
+    public String toString() {
+        return "ExtensionClassLoader["
+                + narArtifact
+                + ", Dependencies="
+                + Arrays.asList(urls)
+                + "]";
+    }
+
+    public String toTree() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("ClassLoader for ")
+                .append(narArtifact)
+                .append(" with nifi-api version ")
+                .append(getNiFiApiVersion())
+                .append(":\n");
+
+        for (final URL url : urls) {
+            sb.append(url).append("\n");
+        }
+
+        final ClassLoader parent = getParent();
+        if (parent instanceof ExtensionClassLoader) {
+            sb.append("\n\n-------- Parent:\n");
+            sb.append(((ExtensionClassLoader) parent).toTree());
+        } else if (parent instanceof URLClassLoader) {
+            sb.append(toTree((URLClassLoader) parent));
+        }
+
+        return sb.toString();
+    }
+
+    private String toTree(final URLClassLoader classLoader) {
+        final StringBuilder sb = new StringBuilder();
+
+        sb.append("\n\n-------- Parent:\n");
+        final URL[] urls = classLoader.getURLs();
+
+        for (final URL url : urls) {
+            sb.append(url).append("\n");
+        }
+
+        final ClassLoader parent = classLoader.getParent();
+        if (parent instanceof URLClassLoader) {
+            final URLClassLoader urlParent = (URLClassLoader) parent;
+            sb.append(toTree(urlParent));
+        }
+
+        return sb.toString();
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactory.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactory.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition.extraction;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.artifact.resolver.filter.ExclusionSetFilter;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+import org.eclipse.aether.RepositorySystemSession;
+
+public class ExtensionClassLoaderFactory {
+
+    private static final Set<String> EXCLUDED_ARTIFACT_IDS;
+
+    static {
+        final Set<String> excludedArtifactIds = new HashSet<>();
+        excludedArtifactIds.add("jdk.tools:jdk.tools");
+        excludedArtifactIds.add("com.sun:tools");
+        EXCLUDED_ARTIFACT_IDS = Collections.unmodifiableSet(excludedArtifactIds);
+    }
+
+    private final Log log;
+    private final MavenProject project;
+    private final RepositorySystemSession repoSession;
+    private final ProjectBuilder projectBuilder;
+    private final ArtifactRepository localRepo;
+    private final List<ArtifactRepository> remoteRepos;
+    private final DependencyGraphBuilder dependencyGraphBuilder;
+    private final ArtifactResolver artifactResolver;
+    private final ArtifactHandlerManager artifactHandlerManager;
+
+    private ExtensionClassLoaderFactory(final Builder builder) {
+        this.log = builder.log;
+        this.project = builder.project;
+        this.repoSession = builder.repositorySession;
+        this.projectBuilder = builder.projectBuilder;
+        this.localRepo = builder.localRepo;
+        this.remoteRepos = new ArrayList<>(builder.remoteRepos);
+        this.dependencyGraphBuilder = builder.dependencyGraphBuilder;
+        this.artifactResolver = builder.artifactResolver;
+        this.artifactHandlerManager = builder.artifactHandlerManager;
+    }
+
+    private Log getLog() {
+        return log;
+    }
+
+    public ExtensionClassLoader createExtensionClassLoader()
+            throws MojoExecutionException, ProjectBuildingException {
+        final Artifact narArtifact = project.getArtifact();
+        final Set<Artifact> narArtifacts = getNarDependencies(narArtifact);
+
+        final ArtifactsHolder artifactsHolder = new ArtifactsHolder();
+        artifactsHolder.addArtifacts(narArtifacts);
+
+        getLog().debug("Project artifacts: ");
+        narArtifacts.forEach(artifact -> getLog().debug(artifact.getArtifactId()));
+
+        final ExtensionClassLoader parentClassLoader =
+                createClassLoader(narArtifacts, artifactsHolder);
+        final ExtensionClassLoader classLoader =
+                createClassLoader(narArtifacts, parentClassLoader, narArtifact);
+
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Full ClassLoader is:\n" + classLoader.toTree());
+        }
+
+        return classLoader;
+    }
+
+    private ExtensionClassLoader createClassLoader(
+            final Set<Artifact> artifacts, final ArtifactsHolder artifactsHolder)
+            throws MojoExecutionException, ProjectBuildingException {
+
+        final Artifact nar = removeNarArtifact(artifacts);
+        if (nar == null) {
+            return createProvidedEntitiesClassLoader(artifactsHolder);
+        }
+
+        final Set<Artifact> narDependencies = getNarDependencies(nar);
+        artifactsHolder.addArtifacts(narDependencies);
+
+        return createClassLoader(
+                narDependencies, createClassLoader(narDependencies, artifactsHolder), nar);
+    }
+
+    private Artifact removeNarArtifact(final Set<Artifact> artifacts) {
+        final Iterator<Artifact> itr = artifacts.iterator();
+        while (itr.hasNext()) {
+            final Artifact artifact = itr.next();
+
+            if (artifact.equals(project.getArtifact())) {
+                continue;
+            }
+
+            if ("nar".equalsIgnoreCase(artifact.getType())) {
+                getLog().info("Found NAR dependency of " + artifact);
+                itr.remove();
+
+                return artifact;
+            }
+        }
+
+        return null;
+    }
+
+    private Set<Artifact> getNarDependencies(final Artifact narArtifact)
+            throws MojoExecutionException, ProjectBuildingException {
+        final ProjectBuildingRequest narRequest = createProjectBuildingRequest();
+
+        final ProjectBuildingResult narResult = projectBuilder.build(narArtifact, narRequest);
+
+        final Set<Artifact> narDependencies = gatherArtifacts(narResult.getProject(), TreeSet::new);
+        narDependencies.remove(narArtifact);
+        narDependencies.remove(project.getArtifact());
+
+        getLog().debug(
+                        "Found NAR dependency of "
+                                + narArtifact
+                                + ", which resolved to the following artifacts: "
+                                + narDependencies);
+        return narDependencies;
+    }
+
+    private String determineProvidedEntityVersion(
+            final Set<Artifact> artifacts, final String groupId, final String artifactId)
+            throws ProjectBuildingException, MojoExecutionException {
+        getLog().debug("Determining provided entities for " + groupId + ":" + artifactId);
+
+        for (final Artifact artifact : artifacts) {
+            if (artifact.getGroupId().equals(groupId)
+                    && artifact.getArtifactId().equals(artifactId)) {
+                return artifact.getVersion();
+            }
+        }
+
+        return findProvidedDependencyVersion(artifacts, groupId, artifactId);
+    }
+
+    private String findProvidedDependencyVersion(
+            final Set<Artifact> artifacts, final String groupId, final String artifactId) {
+        final ProjectBuildingRequest projectRequest = createProjectBuildingRequest();
+
+        for (final Artifact artifact : artifacts) {
+            try {
+                final ProjectBuildingResult projectResult =
+                        projectBuilder.build(artifact, projectRequest);
+                final Set<Artifact> artifactDependencies =
+                        gatherArtifacts(projectResult.getProject(), HashSet::new);
+                getLog().debug("For Artifact " + artifact + ", found the following dependencies:");
+                artifactDependencies.forEach(dep -> getLog().debug(dep.toString()));
+
+                for (final Artifact dependency : artifactDependencies) {
+                    if (dependency.getGroupId().equals(groupId)
+                            && dependency.getArtifactId().equals(artifactId)) {
+                        getLog().debug(
+                                        "Found version of "
+                                                + groupId
+                                                + ":"
+                                                + artifactId
+                                                + " to be "
+                                                + dependency.getVersion());
+                        return dependency.getVersion();
+                    }
+                }
+            } catch (final Exception e) {
+                getLog().warn(
+                                "Unable to construct Maven Project for "
+                                        + artifact
+                                        + " when attempting to determine the expected version of NiFi API");
+                getLog().debug(
+                                "Unable to construct Maven Project for "
+                                        + artifact
+                                        + " when attempting to determine the expected version of NiFi API",
+                                e);
+            }
+        }
+
+        return null;
+    }
+
+    private Artifact getProvidedArtifact(
+            final String groupId, final String artifactId, final String version)
+            throws MojoExecutionException {
+        final ArtifactHandler handler = artifactHandlerManager.getArtifactHandler("jar");
+
+        final VersionRange versionRange;
+        try {
+            versionRange = VersionRange.createFromVersionSpec(version);
+        } catch (final Exception e) {
+            throw new MojoExecutionException(
+                    "Could not determine appropriate version for Provided Artifact "
+                            + groupId
+                            + ":"
+                            + artifactId,
+                    e);
+        }
+
+        final Artifact artifact =
+                new DefaultArtifact(groupId, artifactId, versionRange, null, "jar", null, handler);
+
+        final ArtifactResolutionRequest request = new ArtifactResolutionRequest();
+        request.setLocalRepository(localRepo);
+        request.setRemoteRepositories(remoteRepos);
+        request.setArtifact(artifact);
+
+        final ArtifactResolutionResult result = artifactResolver.resolve(request);
+        if (!result.isSuccess()) {
+            final List<Exception> exceptions = result.getExceptions();
+
+            final MojoExecutionException exception =
+                    new MojoExecutionException("Could not resolve local dependency " + artifact);
+            if (exceptions != null) {
+                for (final Exception e : exceptions) {
+                    exception.addSuppressed(e);
+                }
+            }
+
+            throw exception;
+        }
+
+        final Set<Artifact> artifacts = result.getArtifacts();
+        if (artifacts.isEmpty()) {
+            throw new MojoExecutionException(
+                    "Could not resolve any artifacts for dependency " + artifact);
+        }
+
+        final List<Artifact> sorted = new ArrayList<>(artifacts);
+        Collections.sort(sorted);
+
+        return sorted.get(0);
+    }
+
+    private ExtensionClassLoader createProvidedEntitiesClassLoader(
+            final ArtifactsHolder artifactsHolder)
+            throws MojoExecutionException, ProjectBuildingException {
+
+        final String nifiApiVersion =
+                determineProvidedEntityVersion(
+                        artifactsHolder.getAllArtifacts(), "org.apache.nifi", "nifi-api");
+        if (nifiApiVersion == null) {
+            throw new MojoExecutionException(
+                    "Could not find any dependency, provided or otherwise, on [org.apache.nifi:nifi-api]");
+        } else {
+            getLog().info("Found a dependency on version " + nifiApiVersion + " of NiFi API");
+        }
+
+        final String slf4jApiVersion =
+                determineProvidedEntityVersion(
+                        artifactsHolder.getAllArtifacts(), "org.slf4j", "slf4j-api");
+
+        final Artifact nifiApiArtifact =
+                getProvidedArtifact("org.apache.nifi", "nifi-api", nifiApiVersion);
+        final Artifact nifiFrameworkApiArtifact =
+                getProvidedArtifact(
+                        "org.apache.nifi", "nifi-framework-api", nifiApiArtifact.getVersion());
+
+        final Artifact slf4jArtifact =
+                getProvidedArtifact("org.slf4j", "slf4j-api", slf4jApiVersion);
+
+        final Set<Artifact> providedArtifacts = new HashSet<>();
+        providedArtifacts.add(nifiApiArtifact);
+        providedArtifacts.add(nifiFrameworkApiArtifact);
+        providedArtifacts.add(slf4jArtifact);
+
+        getLog().debug(
+                        "Creating Provided Entities Class Loader with artifacts: "
+                                + providedArtifacts);
+        return createClassLoader(providedArtifacts, null, null);
+    }
+
+    /* package visible for testing reasons */
+    ExtensionClassLoader createClassLoader(
+            final Set<Artifact> artifacts,
+            final ExtensionClassLoader parent,
+            final Artifact narArtifact)
+            throws MojoExecutionException {
+        final Set<URL> urls = new HashSet<>();
+        for (final Artifact artifact : artifacts) {
+            final Set<URL> artifactUrls = toURLs(artifact);
+            urls.addAll(artifactUrls);
+        }
+
+        getLog().debug("Creating class loader with following dependencies: " + urls);
+
+        final URL[] urlArray = urls.toArray(new URL[0]);
+        if (parent == null) {
+            return new ExtensionClassLoader(urlArray, narArtifact, artifacts);
+        } else {
+            return new ExtensionClassLoader(urlArray, parent, narArtifact, artifacts);
+        }
+    }
+
+    private Set<Artifact> gatherArtifacts(
+            final MavenProject mavenProject, final Supplier<Set<Artifact>> setSupplier)
+            throws MojoExecutionException {
+        final Set<Artifact> artifacts = setSupplier.get();
+        final DependencyNodeVisitor nodeVisitor =
+                new DependencyNodeVisitor() {
+                    @Override
+                    public boolean visit(final DependencyNode dependencyNode) {
+                        final Artifact artifact = dependencyNode.getArtifact();
+                        artifacts.add(artifact);
+                        return true;
+                    }
+
+                    @Override
+                    public boolean endVisit(final DependencyNode dependencyNode) {
+                        return true;
+                    }
+                };
+
+        try {
+            final ProjectBuildingRequest projectRequest = createProjectBuildingRequest();
+            projectRequest.setProject(mavenProject);
+
+            final ArtifactFilter excludesFilter = new ExclusionSetFilter(EXCLUDED_ARTIFACT_IDS);
+            final DependencyNode depNode =
+                    dependencyGraphBuilder.buildDependencyGraph(projectRequest, excludesFilter);
+            depNode.accept(nodeVisitor);
+        } catch (DependencyGraphBuilderException e) {
+            throw new MojoExecutionException("Failed to build dependency tree", e);
+        }
+        return artifacts;
+    }
+
+    private ProjectBuildingRequest createProjectBuildingRequest() {
+        final ProjectBuildingRequest projectRequest = new DefaultProjectBuildingRequest();
+        projectRequest.setRepositorySession(repoSession);
+        projectRequest.setSystemProperties(System.getProperties());
+        projectRequest.setUserProperties(System.getProperties());
+        projectRequest.setLocalRepository(localRepo);
+        projectRequest.setRemoteRepositories(remoteRepos);
+        return projectRequest;
+    }
+
+    private Set<URL> toURLs(final Artifact artifact) throws MojoExecutionException {
+        final Set<URL> urls = new HashSet<>();
+
+        final File artifactFile = artifact.getFile();
+        if (artifactFile == null) {
+            getLog().debug(
+                            "Attempting to resolve Artifact "
+                                    + artifact
+                                    + " because it has no File associated with it");
+
+            final ArtifactResolutionRequest request = new ArtifactResolutionRequest();
+            request.setLocalRepository(localRepo);
+            request.setRemoteRepositories(remoteRepos);
+            request.setArtifact(artifact);
+
+            final ArtifactResolutionResult result = artifactResolver.resolve(request);
+            if (!result.isSuccess()) {
+                throw new MojoExecutionException("Could not resolve local dependency " + artifact);
+            }
+
+            getLog().debug("Resolved Artifact " + artifact + " to " + result.getArtifacts());
+
+            for (final Artifact resolved : result.getArtifacts()) {
+                urls.addAll(toURLs(resolved));
+            }
+        } else {
+            try {
+                final URL url = artifact.getFile().toURI().toURL();
+                getLog().debug("Adding URL " + url + " to ClassLoader");
+                urls.add(url);
+            } catch (final MalformedURLException mue) {
+                throw new MojoExecutionException(
+                        "Failed to convert File " + artifact.getFile() + " into URL", mue);
+            }
+        }
+
+        return urls;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Log log;
+        private MavenProject project;
+        private ArtifactRepository localRepo;
+        private List<ArtifactRepository> remoteRepos;
+        private DependencyGraphBuilder dependencyGraphBuilder;
+        private ArtifactResolver artifactResolver;
+        private ProjectBuilder projectBuilder;
+        private RepositorySystemSession repositorySession;
+        private ArtifactHandlerManager artifactHandlerManager;
+
+        public Builder log(final Log log) {
+            this.log = log;
+            return this;
+        }
+
+        public Builder projectBuilder(final ProjectBuilder projectBuilder) {
+            this.projectBuilder = projectBuilder;
+            return this;
+        }
+
+        public Builder project(final MavenProject project) {
+            this.project = project;
+            return this;
+        }
+
+        public Builder localRepository(final ArtifactRepository localRepo) {
+            this.localRepo = localRepo;
+            return this;
+        }
+
+        public Builder remoteRepositories(final List<ArtifactRepository> remoteRepos) {
+            this.remoteRepos = remoteRepos;
+            return this;
+        }
+
+        public Builder dependencyGraphBuilder(final DependencyGraphBuilder dependencyGraphBuilder) {
+            this.dependencyGraphBuilder = dependencyGraphBuilder;
+            return this;
+        }
+
+        public Builder artifactResolver(final ArtifactResolver resolver) {
+            this.artifactResolver = resolver;
+            return this;
+        }
+
+        public Builder repositorySession(final RepositorySystemSession repositorySession) {
+            this.repositorySession = repositorySession;
+            return this;
+        }
+
+        public Builder artifactHandlerManager(final ArtifactHandlerManager artifactHandlerManager) {
+            this.artifactHandlerManager = artifactHandlerManager;
+            return this;
+        }
+
+        public ExtensionClassLoaderFactory build() {
+            return new ExtensionClassLoaderFactory(this);
+        }
+    }
+
+    private static class ArtifactsHolder {
+
+        private Set<Artifact> allArtifacts = new TreeSet<>();
+
+        public void addArtifacts(final Set<Artifact> artifacts) {
+            if (artifacts != null) {
+                allArtifacts.addAll(artifacts);
+            }
+        }
+
+        public Set<Artifact> getAllArtifacts() {
+            return allArtifacts;
+        }
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionDefinitionFactory.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/ExtensionDefinitionFactory.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition.extraction;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.artifact.Artifact;
+import org.apache.nifi.extension.definition.ExtensionDefinition;
+import org.apache.nifi.extension.definition.ExtensionType;
+import org.apache.nifi.extension.definition.ServiceAPIDefinition;
+
+public class ExtensionDefinitionFactory {
+    private static final String SERVICES_DIRECTORY = "META-INF/services/";
+
+    private static final Map<ExtensionType, String> INTERFACE_NAMES = new HashMap<>();
+
+    static {
+        INTERFACE_NAMES.put(ExtensionType.PROCESSOR, "org.apache.nifi.processor.Processor");
+        INTERFACE_NAMES.put(
+                ExtensionType.CONTROLLER_SERVICE, "org.apache.nifi.controller.ControllerService");
+        INTERFACE_NAMES.put(
+                ExtensionType.REPORTING_TASK, "org.apache.nifi.reporting.ReportingTask");
+    }
+
+    private final ClassLoader extensionClassLoader;
+
+    public ExtensionDefinitionFactory(final ClassLoader classLoader) {
+        this.extensionClassLoader = classLoader;
+    }
+
+    public Set<ExtensionDefinition> discoverExtensions(final ExtensionType extensionType)
+            throws IOException {
+        final String interfaceName = INTERFACE_NAMES.get(extensionType);
+        final Set<String> classNames = discoverClassNames(interfaceName);
+
+        if (classNames.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        final Set<ExtensionDefinition> definitions = new HashSet<>();
+        for (final String className : classNames) {
+            try {
+                definitions.add(createExtensionDefinition(extensionType, className));
+            } catch (final Exception e) {
+                throw new IOException(
+                        "Failed to create Extension Definition for "
+                                + extensionType
+                                + " "
+                                + className,
+                        e);
+            }
+        }
+
+        return definitions;
+    }
+
+    private ExtensionDefinition createExtensionDefinition(
+            final ExtensionType extensionType, final String className)
+            throws ClassNotFoundException {
+        final Class<?> extensionClass = Class.forName(className, false, extensionClassLoader);
+        final Set<ServiceAPIDefinition> serviceApis =
+                getProvidedServiceAPIs(extensionType, extensionClass);
+        return new StandardExtensionDefinition(extensionType, className, serviceApis);
+    }
+
+    private Set<ServiceAPIDefinition> getProvidedServiceAPIs(
+            final ExtensionType extensionType, final Class<?> extensionClass)
+            throws ClassNotFoundException {
+        if (extensionType != ExtensionType.CONTROLLER_SERVICE) {
+            return Collections.emptySet();
+        }
+
+        final Set<ServiceAPIDefinition> serviceApis = new HashSet<>();
+        final Class<?> controllerServiceClass =
+                Class.forName(
+                        "org.apache.nifi.controller.ControllerService",
+                        false,
+                        extensionClassLoader);
+        addProvidedServiceAPIs(controllerServiceClass, extensionClass, serviceApis);
+        return serviceApis;
+    }
+
+    private void addProvidedServiceAPIs(
+            final Class<?> controllerServiceClass,
+            final Class<?> extensionClass,
+            final Set<ServiceAPIDefinition> serviceApis) {
+        final Class<?>[] extensionInterfaces = extensionClass.getInterfaces();
+        if (extensionInterfaces == null) {
+            return;
+        }
+
+        for (final Class<?> immediateInterface : extensionInterfaces) {
+            final Set<Class<?>> interfaceHierarchy = new HashSet<>();
+            interfaceHierarchy.add(immediateInterface);
+            getInterfaceHierarchy(immediateInterface, interfaceHierarchy);
+
+            for (final Class<?> implementedInterface : interfaceHierarchy) {
+                processImplementedInterface(
+                        implementedInterface, controllerServiceClass, serviceApis);
+            }
+        }
+
+        if (extensionClass.getSuperclass() != null) {
+            addProvidedServiceAPIs(
+                    controllerServiceClass, extensionClass.getSuperclass(), serviceApis);
+        }
+    }
+
+    private void getInterfaceHierarchy(
+            final Class<?> implementedInterface, final Set<Class<?>> interfaceHierarchy) {
+        final Class<?>[] parentInterfaces = implementedInterface.getInterfaces();
+        if (parentInterfaces == null) {
+            return;
+        }
+
+        for (final Class<?> parentInterface : parentInterfaces) {
+            if (!interfaceHierarchy.contains(parentInterface)) {
+                interfaceHierarchy.add(parentInterface);
+                getInterfaceHierarchy(parentInterface, interfaceHierarchy);
+            }
+        }
+    }
+
+    private void processImplementedInterface(
+            final Class<?> implementedInterface,
+            final Class<?> controllerServiceClass,
+            final Set<ServiceAPIDefinition> serviceApis) {
+        if (controllerServiceClass.isAssignableFrom(implementedInterface)
+                && !controllerServiceClass.equals(implementedInterface)) {
+            final ClassLoader interfaceClassLoader = implementedInterface.getClassLoader();
+            if (interfaceClassLoader instanceof ExtensionClassLoader) {
+                final Artifact interfaceNarArtifact =
+                        ((ExtensionClassLoader) interfaceClassLoader).getNarArtifact();
+
+                final ServiceAPIDefinition serviceDefinition =
+                        new StandardServiceAPIDefinition(
+                                implementedInterface.getName(),
+                                interfaceNarArtifact.getGroupId(),
+                                interfaceNarArtifact.getArtifactId(),
+                                interfaceNarArtifact.getBaseVersion());
+
+                serviceApis.add(serviceDefinition);
+            }
+        }
+    }
+
+    private Set<String> discoverClassNames(final String extensionType) throws IOException {
+        final Set<URL> resourceUrls = new HashSet<>();
+
+        final Enumeration<URL> resources =
+                extensionClassLoader.getResources(SERVICES_DIRECTORY + extensionType);
+        while (resources.hasMoreElements()) {
+            resourceUrls.add(resources.nextElement());
+        }
+
+        final ClassLoader parentClassLoader = extensionClassLoader.getParent();
+        if (parentClassLoader != null) {
+            final Enumeration<URL> parentResources =
+                    parentClassLoader.getResources(SERVICES_DIRECTORY + extensionType);
+            while (parentResources.hasMoreElements()) {
+                resourceUrls.remove(parentResources.nextElement());
+            }
+        }
+
+        final Set<String> classNames = new HashSet<>();
+        for (final URL resourceUrl : resourceUrls) {
+            classNames.addAll(discoverClassNames(resourceUrl));
+        }
+        return classNames;
+    }
+
+    private Set<String> discoverClassNames(final URL serviceUrl) throws IOException {
+        final Set<String> classNames = new HashSet<>();
+
+        try (final InputStream in = serviceUrl.openStream();
+                final Reader rawReader = new InputStreamReader(in);
+                final BufferedReader reader = new BufferedReader(rawReader)) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+
+                classNames.add(line);
+            }
+        }
+
+        return classNames;
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/StandardExtensionDefinition.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/StandardExtensionDefinition.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition.extraction;
+
+import java.util.Set;
+import org.apache.nifi.extension.definition.ExtensionDefinition;
+import org.apache.nifi.extension.definition.ExtensionType;
+import org.apache.nifi.extension.definition.ServiceAPIDefinition;
+
+public class StandardExtensionDefinition implements ExtensionDefinition {
+
+    private final ExtensionType extensionType;
+    private final String extensionName;
+    private final Set<ServiceAPIDefinition> providedServiceApis;
+
+    public StandardExtensionDefinition(
+            final ExtensionType extensionType,
+            final String extensionName,
+            final Set<ServiceAPIDefinition> providedServiceApis) {
+        this.extensionType = extensionType;
+        this.extensionName = extensionName;
+        this.providedServiceApis = providedServiceApis;
+    }
+
+    @Override
+    public ExtensionType getExtensionType() {
+        return extensionType;
+    }
+
+    @Override
+    public Set<ServiceAPIDefinition> getProvidedServiceAPIs() {
+        return providedServiceApis;
+    }
+
+    @Override
+    public String getExtensionName() {
+        return extensionName;
+    }
+
+    @Override
+    public String toString() {
+        return "ExtensionDefinition[type="
+                + getExtensionType()
+                + ", name="
+                + getExtensionName()
+                + "]";
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/StandardServiceAPIDefinition.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/extension/definition/extraction/StandardServiceAPIDefinition.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition.extraction;
+
+import java.util.Objects;
+import org.apache.nifi.extension.definition.ServiceAPIDefinition;
+
+public class StandardServiceAPIDefinition implements ServiceAPIDefinition {
+    private final String serviceAPIClassName;
+    private final String serviceGroupId;
+    private final String serviceArtifactId;
+    private final String serviceVersion;
+
+    public StandardServiceAPIDefinition(
+            final String serviceAPIClassName,
+            final String serviceGroupId,
+            final String serviceArtifactId,
+            final String serviceVersion) {
+        this.serviceAPIClassName = serviceAPIClassName;
+        this.serviceGroupId = serviceGroupId;
+        this.serviceArtifactId = serviceArtifactId;
+        this.serviceVersion = serviceVersion;
+    }
+
+    @Override
+    public String getServiceAPIClassName() {
+        return serviceAPIClassName;
+    }
+
+    @Override
+    public String getServiceGroupId() {
+        return serviceGroupId;
+    }
+
+    @Override
+    public String getServiceArtifactId() {
+        return serviceArtifactId;
+    }
+
+    @Override
+    public String getServiceVersion() {
+        return serviceVersion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final StandardServiceAPIDefinition that = (StandardServiceAPIDefinition) o;
+        return serviceAPIClassName.equals(that.serviceAPIClassName)
+                && serviceGroupId.equals(that.serviceGroupId)
+                && serviceArtifactId.equals(that.serviceArtifactId)
+                && serviceVersion.equals(that.serviceVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serviceAPIClassName, serviceGroupId, serviceArtifactId, serviceVersion);
+    }
+}

--- a/nifi-maven-plugin/src/main/java/org/apache/nifi/utils/NarDependencyUtils.java
+++ b/nifi-maven-plugin/src/main/java/org/apache/nifi/utils/NarDependencyUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+
+public class NarDependencyUtils {
+    public static final String NAR = "nar";
+    public static final String COMPILE_STRING = "compile";
+
+    public static Map<String, ArtifactHandler> createNarHandlerMap(
+            ProjectBuildingRequest narRequest, MavenProject project, ProjectBuilder projectBuilder)
+            throws ProjectBuildingException {
+
+        final Artifact projectArtifact = project.getArtifact();
+        final ProjectBuildingResult narResult = projectBuilder.build(projectArtifact, narRequest);
+        narRequest.setProject(narResult.getProject());
+
+        // get the artifact handler for excluding dependencies
+        final ArtifactHandler narHandler = excludesDependencies(projectArtifact);
+        projectArtifact.setArtifactHandler(narHandler);
+
+        // nar artifacts by nature includes dependencies, however this prevents the
+        // transitive dependencies from printing using tools like dependency:tree.
+        // here we are overriding the artifact handler for all nars so the
+        // dependencies can be listed. this is important because nar dependencies
+        // will be used as the parent classloader for this nar and seeing what
+        // dependencies are provided is critical.
+        final Map<String, ArtifactHandler> narHandlerMap = new HashMap<>();
+        narHandlerMap.put(NAR, narHandler);
+        return narHandlerMap;
+    }
+
+    public static void ensureSingleNarDependencyExists(MavenProject project)
+            throws MojoExecutionException {
+        // find the nar dependency
+        boolean found = false;
+        for (final Artifact artifact : project.getDependencyArtifacts()) {
+            if (NAR.equals(artifact.getType())) {
+                // ensure the project doesn't have two nar dependencies
+                if (found) {
+                    throw new MojoExecutionException("Project can only have one NAR dependency.");
+                }
+
+                // record the nar dependency
+                found = true;
+            }
+        }
+
+        // ensure there is a nar dependency
+        if (!found) {
+            throw new MojoExecutionException("Project does not have any NAR dependencies.");
+        }
+    }
+
+    /**
+     * Creates a new ArtifactHandler for the specified Artifact that overrides the
+     * includeDependencies flag. When set, this flag prevents transitive dependencies from being
+     * printed in dependencies plugin.
+     *
+     * @param artifact The artifact
+     * @return The handler for the artifact
+     */
+    private static ArtifactHandler excludesDependencies(final Artifact artifact) {
+        final ArtifactHandler orig = artifact.getArtifactHandler();
+
+        return new ArtifactHandler() {
+            @Override
+            public String getExtension() {
+                return orig.getExtension();
+            }
+
+            @Override
+            public String getDirectory() {
+                return orig.getDirectory();
+            }
+
+            @Override
+            public String getClassifier() {
+                return orig.getClassifier();
+            }
+
+            @Override
+            public String getPackaging() {
+                return orig.getPackaging();
+            }
+
+            // mark dependencies as excluded, so they will appear in tree listing
+            @Override
+            public boolean isIncludesDependencies() {
+                return false;
+            }
+
+            @Override
+            public String getLanguage() {
+                return orig.getLanguage();
+            }
+
+            @Override
+            public boolean isAddedToClasspath() {
+                return orig.isAddedToClasspath();
+            }
+        };
+    }
+}

--- a/nifi-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/nifi-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>nar</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.apache.nifi:nifi-nar-maven-plugin:nar</package>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>nar</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>nar</type>
+                <language>java</language>
+                <addedToClasspath>false</addedToClasspath>
+                <includesDependencies>true</includesDependencies>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/nifi-maven-plugin/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
+++ b/nifi-maven-plugin/src/test/java/org/apache/nifi/extension/definition/extraction/ExtensionClassLoaderFactoryTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.extension.definition.extraction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.eclipse.aether.RepositorySystemSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExtensionClassLoaderFactoryTest {
+
+    @Mock private Log log;
+    @Mock private ArtifactResolver artifactResolver;
+    @Mock private ArtifactRepository localRepository;
+    @Mock private ArtifactRepository remoteRepository;
+    @Mock private ArtifactHandlerManager artifactHandlerManager;
+    @Mock private DependencyGraphBuilder dependencyGraphBuilder;
+    @Mock private MavenProject project;
+    @Mock private ProjectBuilder projectBuilder;
+    @Mock private RepositorySystemSession repositorySession;
+    private Artifact artifact1;
+    private Artifact artifact2;
+    private Artifact artifact3;
+
+    // Test Subject
+    private ExtensionClassLoaderFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        artifact1 = projectArtifact();
+        artifact2 = localRepositoryDependencyArtifact();
+        artifact3 = remoteRepositoryDependencyArtifact();
+
+        when(artifactResolver.resolve(any(ArtifactResolutionRequest.class)))
+                .thenAnswer(
+                        args ->
+                                resolved(
+                                        args.getArgument(0, ArtifactResolutionRequest.class)
+                                                .getArtifact()));
+
+        factory =
+                ExtensionClassLoaderFactory.builder()
+                        .log(log)
+                        .project(project)
+                        .projectBuilder(projectBuilder)
+                        .dependencyGraphBuilder(dependencyGraphBuilder)
+                        .artifactHandlerManager(artifactHandlerManager)
+                        .artifactResolver(artifactResolver)
+                        .localRepository(localRepository)
+                        .remoteRepositories(Collections.singletonList(remoteRepository))
+                        .repositorySession(repositorySession)
+                        .build();
+    }
+
+    @Test
+    void createClassLoaderTest() throws Exception {
+        Set<Artifact> dependencyArtifacts = new TreeSet<>();
+        dependencyArtifacts.add(localRepositoryDependencyArtifact());
+        dependencyArtifacts.add(remoteRepositoryDependencyArtifact());
+
+        ExtensionClassLoader classLoader =
+                factory.createClassLoader(dependencyArtifacts, null, artifact1);
+
+        String[] expectedURLs = new String[] {"/path/to/service-api-nar", "/path/to/service-nar"};
+        assertEquals(expectedURLs.length, classLoader.getURLs().length);
+        List<String> expectedUrlsList = Arrays.asList(expectedURLs);
+        List<String> actualUrlsList =
+                Arrays.stream(classLoader.getURLs()).map(URL::getFile).collect(Collectors.toList());
+        assertTrue(expectedUrlsList.containsAll(actualUrlsList));
+
+        InOrder inOrder = inOrder(artifactResolver);
+        for (ArtifactResolutionRequest req : getExpectedArtifactResolutionRequests()) {
+            inOrder.verify(artifactResolver)
+                    .resolve(
+                            argThat(
+                                    arg ->
+                                            req.getArtifact()
+                                                            .getArtifactId()
+                                                            .equals(
+                                                                    arg.getArtifact()
+                                                                            .getArtifactId())
+                                                    && req.getLocalRepository()
+                                                            == arg.getLocalRepository()
+                                                    && req.getRemoteRepositories()
+                                                            .equals(arg.getRemoteRepositories())));
+        }
+        verifyNoMoreInteractions(artifactResolver);
+    }
+
+    private List<ArtifactResolutionRequest> getExpectedArtifactResolutionRequests() {
+        ArtifactResolutionRequest request1 = new ArtifactResolutionRequest();
+        request1.setArtifact(artifact2);
+        request1.setLocalRepository(localRepository);
+        request1.setRemoteRepositories(Collections.singletonList(remoteRepository));
+
+        ArtifactResolutionRequest request2 = new ArtifactResolutionRequest();
+        request2.setArtifact(artifact3);
+        request2.setLocalRepository(localRepository);
+        request2.setRemoteRepositories(Collections.singletonList(remoteRepository));
+
+        List<ArtifactResolutionRequest> resolutionRequests = new ArrayList<>();
+        resolutionRequests.add(request1);
+        resolutionRequests.add(request2);
+        return resolutionRequests;
+    }
+
+    private Artifact projectArtifact() {
+        Artifact artifact =
+                new DefaultArtifact(
+                        "org.apache.nifi",
+                        "processor-nar",
+                        "1.0.0",
+                        "compile",
+                        "nar",
+                        "arbitrary",
+                        mock(ArtifactHandler.class));
+        artifact.setFile(new File("/path/to/" + artifact.getArtifactId()));
+        return artifact;
+    }
+
+    private Artifact localRepositoryDependencyArtifact() {
+        Artifact artifact =
+                new DefaultArtifact(
+                        "org.apache.nifi",
+                        "service-api-nar",
+                        "1.0.0",
+                        "compile",
+                        "nar",
+                        "arbitrary",
+                        mock(ArtifactHandler.class));
+        artifact.setFile(null);
+        artifact.setRepository(localRepository);
+        return artifact;
+    }
+
+    private Artifact remoteRepositoryDependencyArtifact() {
+        Artifact artifact =
+                new DefaultArtifact(
+                        "org.apache.nifi",
+                        "service-nar",
+                        "1.0.0",
+                        "provided",
+                        "nar",
+                        "arbitrary",
+                        mock(ArtifactHandler.class));
+        artifact.setFile(null);
+        artifact.setRepository(remoteRepository);
+        return artifact;
+    }
+
+    private ArtifactResolutionResult resolved(Artifact artifact) {
+        Artifact resolvedArtifact =
+                new DefaultArtifact(
+                        artifact.getGroupId(),
+                        artifact.getArtifactId(),
+                        artifact.getVersion(),
+                        artifact.getScope(),
+                        artifact.getType(),
+                        artifact.getClassifier(),
+                        artifact.getArtifactHandler());
+        resolvedArtifact.setFile(new File("/path/to/" + artifact.getArtifactId()));
+        ArtifactResolutionResult result = new ArtifactResolutionResult();
+        result.setArtifacts(Collections.singleton(resolvedArtifact));
+        return result;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -820,6 +820,7 @@
         <module>langstream-api-gateway</module>
         <module>langstream-api-gateway-auth</module>
         <module>langstream-runtime</module>
+        <module>nifi-maven-plugin</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
Since the OpenSearch build may break with the current version of the official nifi-nar-maven-plugin, a solution is to temporarily import a patched version of the plugin in the project. 

Changes: 
* Imported from master branch of https://github.com/apache/nifi-maven, including the fix https://github.com/apache/nifi-maven/pull/35

I'll add the OpenSearch PR back 