### PR TITLE
CLI UI: do not print stacktrace if 'open' command is not available

### DIFF
--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/UIAppCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/UIAppCmd.java
@@ -44,11 +44,13 @@ import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.xnio.OptionMap;
 import org.xnio.Xnio;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "ui", header = "Run UI for interact with the application")
+@Slf4j
 public class UIAppCmd extends BaseApplicationCmd {
 
     @CommandLine.Parameters(description = "Application ID")
@@ -165,8 +167,18 @@ public class UIAppCmd extends BaseApplicationCmd {
         server.start();
         port.set(((InetSocketAddress) server.getListenerInfo().get(0).getAddress()).getPort());
 
-        new ProcessBuilder("open", "http://localhost:" + port).start().waitFor();
+        openBrowserAtPort("open", port.get());
+
         return server;
+    }
+
+    static void openBrowserAtPort(String openCommand, int port) {
+        try {
+            new ProcessBuilder(openCommand, "http://localhost:" + port).start().waitFor();
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+        } catch (IOException ioException) {
+        }
     }
 
     @Data

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/UIAppCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/UIAppCmdTest.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.cli.commands.applications;
 
 import static org.junit.jupiter.api.Assertions.*;
-import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Test;
 
 class UIAppCmdTest {

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/UIAppCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/UIAppCmdTest.java
@@ -1,0 +1,16 @@
+package ai.langstream.cli.commands.applications;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class UIAppCmdTest {
+
+    @Test
+    void openBrowser() {
+        // ok
+        UIAppCmd.openBrowserAtPort("echo", 9029);
+        // fail
+        UIAppCmd.openBrowserAtPort("fail", 9029);
+    }
+}


### PR DESCRIPTION
Fix this bad stacktrace

```
/langstream-agents-text-processing-0.2.0-nar.nar to /tmp/nar281146335772970230/langstream-agents-text-processing-0.2.0-nar.nar.dir
Exception in thread "pool-2-thread-1" java.io.IOException: Cannot run program "open": error=2, No such file or directory
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
        at ai.langstream.cli.commands.applications.UIAppCmd.startServer(UIAppCmd.java:168)
        at ai.langstream.cli.commands.docker.LocalRunApplicationCmd.startUI(LocalRunApplicationCmd.java:385)
        at ai.langstream.cli.commands.docker.LocalRunApplicationCmd.lambda$executeOnDocker$2(LocalRunApplicationCmd.java:348)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.io.IOException: error=2, No such file or directory
        at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
        at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:314)
        at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:244)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1110)
        ... 7 more
```