### PR TITLE
CLI docker run: create a dedicated profile  

### DIFF
--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -14,6 +14,16 @@
 # limitations under the License.
 #
 
-webServiceUrl: http://localhost:8090
-apiGatewayUrl: ws://localhost:8091
-tenant: default
+---
+webServiceUrl: "http://localhost:8090"
+apiGatewayUrl: "ws://localhost:8091"
+tenant: "default"
+token: null
+profiles:
+  local-docker-run:
+    webServiceUrl: "http://localhost:8090"
+    apiGatewayUrl: "ws://localhost:8091"
+    tenant: "local-docker-run"
+    token: null
+    name: "local-docker-run"
+currentProfile: "default"

--- a/examples/applications/openai-completions/gateways.yaml
+++ b/examples/applications/openai-completions/gateways.yaml
@@ -26,13 +26,7 @@ gateways:
         - key: langstream-client-session-id
           value-from-parameters: sessionId
 
-  - id: chat
-    type: chat
-    chat-options:
-      answers-topic: output-topic
-      questions-topic: input-topic
-      headers:
-        - value-from-parameters: session-id
+
 
   - id: consume-output
     type: consume
@@ -55,6 +49,13 @@ gateways:
         headers:
           - key: langstream-client-session-id
             value-from-parameters: sessionId
+  - id: chat
+    type: chat
+    chat-options:
+      answers-topic: output-topic
+      questions-topic: input-topic
+      headers:
+        - value-from-parameters: session-id
 
   - id: produce-input-auth
     type: produce

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
@@ -15,6 +15,8 @@
  */
 package ai.langstream.cli.commands.docker;
 
+import ai.langstream.cli.LangStreamCLIConfig;
+import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.BaseCmd;
 import ai.langstream.cli.commands.RootCmd;
 import ai.langstream.cli.commands.RootDockerCmd;
@@ -23,10 +25,6 @@ import picocli.CommandLine;
 public abstract class BaseDockerCmd extends BaseCmd {
 
     @CommandLine.ParentCommand private RootDockerCmd rootDockerCmd;
-
-    protected String getTenant() {
-        return getCurrentProfile().getTenant();
-    }
 
     @Override
     protected RootCmd getRootCmd() {

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/BaseDockerCmd.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.cli.commands.docker;
 
-import ai.langstream.cli.LangStreamCLIConfig;
-import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.BaseCmd;
 import ai.langstream.cli.commands.RootCmd;
 import ai.langstream.cli.commands.RootDockerCmd;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -127,6 +127,11 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
                     "Dry-run mode. Do not deploy the application but only resolves placeholders and display the result.")
     private boolean dryRun;
 
+    @CommandLine.Option(
+            names = {"--tenant"},
+            description = "Tenant name. Default to local-docker-run")
+    private String tenant = "local-docker-run";
+
     @Override
     @SneakyThrows
     public void run() {
@@ -160,7 +165,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         }
         final File secretsFile = checkFileExistsOrDownload(secretFilePath);
 
-        log("Tenant " + getTenant());
+        log("Tenant " + tenant);
         log("Application " + name);
         log("Application directory: " + appDirectory.getAbsolutePath());
         if (singleAgentId != null && !singleAgentId.isEmpty()) {
@@ -231,7 +236,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         }
 
         executeOnDocker(
-                getTenant(),
+                tenant,
                 name,
                 singleAgentId,
                 appDirectory,

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -133,7 +133,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
     @CommandLine.Option(
             names = {"--tenant"},
             description = "Tenant name. Default to local-docker-run")
-    private String tenant = LOCAL_DOCKER_RUN_PROFILE;
+    private String tenant = "default";
 
     @Override
     @SneakyThrows

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -20,6 +20,7 @@ import ai.langstream.admin.client.AdminClientConfiguration;
 import ai.langstream.admin.client.http.GenericRetryExecution;
 import ai.langstream.admin.client.http.HttpClientProperties;
 import ai.langstream.admin.client.http.NoRetryPolicy;
+import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.api.model.Gateways;
 import ai.langstream.cli.commands.VersionProvider;
 import ai.langstream.cli.commands.applications.MermaidAppDiagramGenerator;
@@ -42,8 +43,10 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "run", header = "Run on a docker container a LangStream application")
 public class LocalRunApplicationCmd extends BaseDockerCmd {
 
-    @CommandLine.Parameters(description = "Name of the application")
-    private String name;
+    protected static final String LOCAL_DOCKER_RUN_PROFILE = "local-docker-run";
+
+    @CommandLine.Parameters(description = "ID of the application")
+    private String applicationId;
 
     @CommandLine.Option(
             names = {"-app", "--application"},
@@ -130,7 +133,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
     @CommandLine.Option(
             names = {"--tenant"},
             description = "Tenant name. Default to local-docker-run")
-    private String tenant = "local-docker-run";
+    private String tenant = LOCAL_DOCKER_RUN_PROFILE;
 
     @Override
     @SneakyThrows
@@ -166,7 +169,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         final File secretsFile = checkFileExistsOrDownload(secretFilePath);
 
         log("Tenant " + tenant);
-        log("Application " + name);
+        log("Application " + applicationId);
         log("Application directory: " + appDirectory.getAbsolutePath());
         if (singleAgentId != null && !singleAgentId.isEmpty()) {
             log("Filter agent: " + singleAgentId);
@@ -181,6 +184,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         log("Start S3: " + startS3);
         log("Start Database: " + startDatabase);
         log("Start Webservices " + startWebservices);
+        log("Using docker image: " + dockerImageName + ":" + dockerImageVersion);
 
         if (appDirectory == null) {
             throw new IllegalArgumentException("application files are required");
@@ -235,9 +239,11 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
             secretsContents = null;
         }
 
+        updateLocalDockerRunProfile(tenant);
+
         executeOnDocker(
                 tenant,
-                name,
+                applicationId,
                 singleAgentId,
                 appDirectory,
                 instanceContents,
@@ -247,6 +253,19 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
                 startWebservices,
                 startDatabase,
                 dryRun);
+    }
+
+    private void updateLocalDockerRunProfile(String tenant) {
+        updateConfig(
+                langStreamCLIConfig -> {
+                    final NamedProfile profile = new NamedProfile();
+                    profile.setName(LOCAL_DOCKER_RUN_PROFILE);
+                    profile.setTenant(tenant);
+                    profile.setWebServiceUrl("http://localhost:8090");
+                    profile.setApiGatewayUrl("ws://localhost:8091");
+                    langStreamCLIConfig.updateProfile(LOCAL_DOCKER_RUN_PROFILE, profile);
+                    log("profile " + LOCAL_DOCKER_RUN_PROFILE + " updated");
+                });
     }
 
     private void executeOnDocker(
@@ -355,9 +374,9 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
                     .execute(() -> startUI(tenant, applicationId, outputLog, process));
         }
         final int exited = process.waitFor();
+        // wait for the log to be printed
+        Thread.sleep(1000);
         if (exited != 0) {
-            // wait for the log to be printed
-            Thread.sleep(1000);
             throw new RuntimeException("Process exited with code " + exited);
         }
     }

--- a/langstream-cli/src/main/resources/app-ui/index.html
+++ b/langstream-cli/src/main/resources/app-ui/index.html
@@ -131,6 +131,7 @@
                         Render Markdown
                     </label>
                     <input type="checkbox"
+                           checked
                            class="border rounded-l-lg p-3 "
                            id="render-markdown" />
                 </div>

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.docker;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.langstream.cli.NamedProfile;
+import ai.langstream.cli.commands.applications.CommandTestBase;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class LocalRunApplicationCmdTest extends CommandTestBase {
+
+    @Test
+    void testArgs() throws Exception {
+        final Path tempDir = Files.createTempDirectory(this.tempDir, "langstream");
+
+        final String appDir = tempDir.toFile().getAbsolutePath();
+        CommandResult result =
+                executeCommand(
+                        "docker", "run", "my-app", "-app", appDir, "--docker-command", "echo");
+        assertEquals("", result.err());
+        assertEquals(0, result.exitCode());
+
+        final List<String> lines = result.out().lines().collect(Collectors.toList());
+        final String lastLine = lines.get(lines.size() - 1);
+        assertTrue(
+                lastLine.contains(
+                        "run --rm -i -e START_BROKER=true -e START_MINIO=true -e START_HERDDB=true "
+                                + "-e LANSGSTREAM_TESTER_TENANT=local-docker-run -e LANSGSTREAM_TESTER_APPLICATIONID=my-app "
+                                + "-e LANSGSTREAM_TESTER_STARTWEBSERVICES=true -e LANSGSTREAM_TESTER_DRYRUN=false "
+                                + "-v "
+                                + appDir
+                                + ":/code/application "));
+        assertTrue(
+                lastLine.contains(
+                        "--add-host minio.minio-dev.svc.cluster.local:127.0.0.1 "
+                                + "--add-host herddb.herddb-dev.svc.cluster.local:127.0.0.1 "
+                                + "--add-host my-cluster-kafka-bootstrap.kafka:127.0.0.1 "
+                                + "-p 8091:8091 "
+                                + "-p 8090:8090 "
+                                + "ghcr.io/langstream/langstream-runtime-tester:unknown"));
+
+        final NamedProfile namedProfile = getConfig().getProfiles().get("local-docker-run");
+        assertNotNull(namedProfile);
+        assertEquals("local-docker-run", namedProfile.getTenant());
+        assertEquals("http://localhost:8090", namedProfile.getWebServiceUrl());
+        assertEquals("ws://localhost:8091", namedProfile.getApiGatewayUrl());
+    }
+}

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -43,7 +43,7 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
         assertTrue(
                 lastLine.contains(
                         "run --rm -i -e START_BROKER=true -e START_MINIO=true -e START_HERDDB=true "
-                                + "-e LANSGSTREAM_TESTER_TENANT=local-docker-run -e LANSGSTREAM_TESTER_APPLICATIONID=my-app "
+                                + "-e LANSGSTREAM_TESTER_TENANT=default -e LANSGSTREAM_TESTER_APPLICATIONID=my-app "
                                 + "-e LANSGSTREAM_TESTER_STARTWEBSERVICES=true -e LANSGSTREAM_TESTER_DRYRUN=false "
                                 + "-v "
                                 + appDir
@@ -59,7 +59,7 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
 
         final NamedProfile namedProfile = getConfig().getProfiles().get("local-docker-run");
         assertNotNull(namedProfile);
-        assertEquals("local-docker-run", namedProfile.getTenant());
+        assertEquals("default", namedProfile.getTenant());
         assertEquals("http://localhost:8090", namedProfile.getWebServiceUrl());
         assertEquals("ws://localhost:8091", namedProfile.getApiGatewayUrl());
     }


### PR DESCRIPTION
Changes: 
* use "default" as mock tenant, this is likely to match the default profile when then running gateway commands
* creates/updates a profile named "local-docker-run" that points to the right tenant/urls
* Render markdown is checked by default