### PR TITLE
Improve missing AI service validation

### DIFF
--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/GenAIToolKitFunctionAgentProvider.java
@@ -228,11 +228,12 @@ public class GenAIToolKitFunctionAgentProvider extends AbstractAgentProvider {
                 }
             }
             if (!found) {
-                final String errString = ClassConfigValidator.formatErrString(
-                        new ClassConfigValidator.AgentEntityRef(agentConfiguration),
-                        "No ai service resource found in application configuration. One of " + AI_SERVICES.stream()
-                                .collect(
-                                        Collectors.joining(", ")) + " must be defined.");
+                final String errString =
+                        ClassConfigValidator.formatErrString(
+                                new ClassConfigValidator.AgentEntityRef(agentConfiguration),
+                                "No ai service resource found in application configuration. One of "
+                                        + AI_SERVICES.stream().collect(Collectors.joining(", "))
+                                        + " must be defined.");
                 throw new IllegalArgumentException(errString);
             }
         }

--- a/langstream-core/src/main/java/ai/langstream/impl/uti/ClassConfigValidator.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/uti/ClassConfigValidator.java
@@ -260,6 +260,10 @@ public class ClassConfigValidator {
         return "Found error on %s. Property '%s' %s".formatted(entityRef.ref(), property, message);
     }
 
+    public static String formatErrString(EntityRef entityRef, String message) {
+        return "Found error on %s. %s".formatted(entityRef.ref(), message);
+    }
+
     private static void validateProperties(
             EntityRef entityRef,
             String parentProp,

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/AgentValidationTestUtil.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/AgentValidationTestUtil.java
@@ -32,12 +32,14 @@ public class AgentValidationTestUtil {
         validate(pipeline, null, expectErrMessage);
     }
 
-    public static void validate(String pipeline, String configuration, String expectErrMessage) throws Exception {
+    public static void validate(String pipeline, String configuration, String expectErrMessage)
+            throws Exception {
         if (expectErrMessage != null && expectErrMessage.isBlank()) {
             throw new IllegalArgumentException("expectErrMessage cannot be blank");
         }
         if (configuration == null) {
-            configuration = """
+            configuration =
+                    """
                     configuration:
                         resources:
                           - type: "datasource"

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/KubernetesGenAIToolKitFunctionAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/KubernetesGenAIToolKitFunctionAgentProviderTest.java
@@ -74,6 +74,46 @@ class KubernetesGenAIToolKitFunctionAgentProviderTest {
                 null);
     }
 
+
+    @Test
+    @SneakyThrows
+    public void testValidationAiChatCompletions() {
+        validate(
+                """
+                topics: []
+                pipeline:
+                  - name: "chat"
+                    type: "ai-chat-completions"
+                    configuration:
+                        model: my-model
+                        messages:
+                         - role: system
+                           content: "Hello"
+                """,
+                "Found error on agent configuration (agent: 'chat', type: 'ai-chat-completions'). No ai service resource found in application configuration. One of vertex-configuration, hugging-face-configuration, open-ai-configuration must be defined.");
+
+        AgentValidationTestUtil.validate("""
+                topics: []
+                pipeline:
+                  - name: "chat"
+                    type: "ai-chat-completions"
+                    configuration:
+                        model: my-model
+                        messages:
+                         - role: system
+                           content: "Hello"
+                """,
+                """
+                        configuration:
+                            resources:
+                                - type: "open-ai-configuration"
+                                  name: "OpenAI Azure configuration"
+                                  configuration:
+                                    access-key: "yy"
+                        """, null);
+
+    }
+
     private void validate(String pipeline, String expectErrMessage) throws Exception {
         AgentValidationTestUtil.validate(pipeline, expectErrMessage);
     }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/KubernetesGenAIToolKitFunctionAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/KubernetesGenAIToolKitFunctionAgentProviderTest.java
@@ -74,7 +74,6 @@ class KubernetesGenAIToolKitFunctionAgentProviderTest {
                 null);
     }
 
-
     @Test
     @SneakyThrows
     public void testValidationAiChatCompletions() {
@@ -92,7 +91,8 @@ class KubernetesGenAIToolKitFunctionAgentProviderTest {
                 """,
                 "Found error on agent configuration (agent: 'chat', type: 'ai-chat-completions'). No ai service resource found in application configuration. One of vertex-configuration, hugging-face-configuration, open-ai-configuration must be defined.");
 
-        AgentValidationTestUtil.validate("""
+        AgentValidationTestUtil.validate(
+                """
                 topics: []
                 pipeline:
                   - name: "chat"
@@ -110,8 +110,8 @@ class KubernetesGenAIToolKitFunctionAgentProviderTest {
                                   name: "OpenAI Azure configuration"
                                   configuration:
                                     access-key: "yy"
-                        """, null);
-
+                        """,
+                null);
     }
 
     private void validate(String pipeline, String expectErrMessage) throws Exception {


### PR DESCRIPTION
Fixes https://github.com/LangStream/langstream/issues/595

The control plane should validate and provide meaningful message when the ai service cannot be found