### PR TITLE
Add severity filter for logs to UI

### DIFF
--- a/langstream-cli/src/main/resources/app-ui/index.html
+++ b/langstream-cli/src/main/resources/app-ui/index.html
@@ -68,23 +68,33 @@
                 <div class="text-white w-full text-xs mb-2 h-full" id="logs">
                 </div>
             </div>
-            <div class="flex w-full">
-                <label class="block text-gray-700 text-xs p-3">
+            <div class="flex w-full items-center p-3">
+                <label class="text-gray-700 text-xs mr-3">
                     Auto scroll
                 </label>
                 <input type="checkbox"
-                       class="border rounded-l-lg p-3 "
+                       class="border rounded-l-lg mr-3"
                        id="auto-scroll-logs"/>
-
-                <label class="block text-gray-700 text-xs p-3">
+            
+                <label class="text-gray-700 text-xs mr-3">
                     Stop tailing
                 </label>
                 <input type="checkbox"
-                       class="border rounded-l-lg p-3 "
+                       class="border rounded-l-lg mr-3"
                        id="stop-tailing"
                        onchange="onChangeStopTailing()"
                 />
+                <div class="ml-auto flex items-center">
+                    <label for="log-filter" class="text-gray-700 text-xs mr-2">Filter by Severity:</label>
+                    <select id="log-filter" class="border rounded-lg p-2" onchange="filterLogs()">
+                        <option value="ALL">ALL</option>
+                        <option value="ERROR">ERROR</option>
+                        <option value="WARN">WARN</option>
+                        <option value="INFO">INFO</option>
+                    </select>
+                </div>
             </div>
+            
         </div>
         <!--Gateway-->
         <div class="flex flex-col  flex-1 min-w-4xl max-w-5xl w-full mx-auto bg-white shadow-lg rounded-lg" style="height: 38rem; max-height: 38rem;">
@@ -550,6 +560,19 @@
 
     }
 
+    function filterLogs() {
+        const filterValue = document.getElementById('log-filter').value;
+        const logEntries = document.getElementById('logs').getElementsByTagName('p');
+        for (let i = 0; i < logEntries.length; i++) {
+            const logEntry = logEntries[i];
+            if (filterValue === 'ALL' || logEntry.textContent.includes(filterValue)) {
+                logEntry.style.display = 'block';
+            } else {
+                logEntry.style.display = 'none';
+            }
+        }
+    }
+
     function onLineRead(text) {
         const logsEl = document.getElementById('logs');
         if (logsEl.style.display === "none") {
@@ -562,6 +585,7 @@
         if (document.getElementById("auto-scroll-logs").checked) {
             document.getElementById('logs-box').scrollTop = document.getElementById('logs-box').scrollHeight;
         }
+        filterLogs();
     }
 
     async function readLine(reader) {


### PR DESCRIPTION
Adding a feature that I have wanted ever since we introduced the logs API--a way to filter the log responses by severity. This is pretty easy to do in the UI.

The filter looks like this:

![image](https://github.com/LangStream/langstream/assets/22917476/43a46f4c-04c8-4c5f-9077-ab19e73abc65)

It is not super strict, so sometimes it will show lines that are not at the log level, for example when the API returns multiple lines at a time. If at least one of the logs matches, they will all be displayed. However, I think this limitation is good enough for now.