### PR TITLE
Cli: fix docker run on linux

### DIFF
--- a/bin/get-cli.sh
+++ b/bin/get-cli.sh
@@ -59,7 +59,6 @@ echo "$(tput setaf 6)Checking archive:$(tput setaf 7)"
 if [ -z "$LANGSTREAM_CLI_URL" ]; then
   echo "$(tput setaf 2)LANGSTREAM_CLI_URL$(tput setaf 7) environment not set, checking for the latest release"
   if ! command -v jq > /dev/null; then
-    	echo "Not found."
     	echo "======================================================================================================"
     	echo " Please install jq on your system using your favourite package manager."
     	echo ""
@@ -102,7 +101,6 @@ esac
 echo "$(tput setaf 2)[OK]$(tput setaf 7) - Ready to install $(basename $downloaded_extracted_dir)."
 
 if ! command -v unzip > /dev/null; then
-	echo "Not found."
 	echo "======================================================================================================"
 	echo " Please install unzip on your system using your favourite package manager."
 	echo ""
@@ -114,7 +112,6 @@ fi
 echo "$(tput setaf 2)[OK]$(tput setaf 7) - unzip command is available"
 
 if ! command -v curl > /dev/null; then
-	echo "Not found."
 	echo ""
 	echo "======================================================================================================"
 	echo " Please install curl on your system using your favourite package manager."

--- a/bin/get-cli.sh
+++ b/bin/get-cli.sh
@@ -45,18 +45,7 @@ echo "                   |___/                                    ";
 
 
 get_latest_release_tarball_url() {
-  if ! command -v jq > /dev/null; then
-  	echo "Not found."
-  	echo "======================================================================================================"
-  	echo " Please install jq on your system using your favourite package manager."
-  	echo ""
-  	echo " Restart after installing jq."
-  	echo "======================================================================================================"
-  	echo " In alternative you can set a fixed LangStream CLI version by setting LANGSTREAM_CLI_URL."
-    echo "======================================================================================================"
-  	echo ""
-  	exit 1
-  fi
+
    curl -Ss https://api.github.com/repos/LangStream/langstream/releases/latest | jq -r '.assets[] | select((.name | contains("langstream-cli")) and (.name | contains(".zip"))) | .browser_download_url'
 }
 
@@ -69,6 +58,18 @@ echo ""
 echo "$(tput setaf 6)Checking archive:$(tput setaf 7)"
 if [ -z "$LANGSTREAM_CLI_URL" ]; then
   echo "$(tput setaf 2)LANGSTREAM_CLI_URL$(tput setaf 7) environment not set, checking for the latest release"
+  if ! command -v jq > /dev/null; then
+    	echo "Not found."
+    	echo "======================================================================================================"
+    	echo " Please install jq on your system using your favourite package manager."
+    	echo ""
+    	echo " Restart after installing jq."
+    	echo "======================================================================================================"
+    	echo " In alternative you can set a fixed LangStream CLI version by setting LANGSTREAM_CLI_URL."
+      echo "======================================================================================================"
+    	echo ""
+    	exit 1
+  fi
   LANGSTREAM_CLI_URL=$(get_latest_release_tarball_url)
   echo "$(tput setaf 2)[OK]$(tput setaf 7) - Using $LANGSTREAM_CLI_URL"
 else

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,19 +1,3 @@
-#
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,19 +1,3 @@
-#
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"
@@ -23,7 +7,7 @@ profiles:
   local-docker-run:
     webServiceUrl: "http://localhost:8090"
     apiGatewayUrl: "ws://localhost:8091"
-    tenant: "local-docker-run"
+    tenant: "default"
     token: null
     name: "local-docker-run"
 currentProfile: "default"

--- a/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLI.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLI.java
@@ -19,9 +19,23 @@ import ai.langstream.admin.client.HttpRequestFailedException;
 import ai.langstream.cli.commands.RootCmd;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.SneakyThrows;
 import picocli.CommandLine;
 
 public class LangStreamCLI {
+
+    @SneakyThrows
+    public static Path getLangstreamCLIHomeDirectory() {
+        final String userHome = System.getProperty("user.home");
+        if (!userHome.isBlank() && !"?".equals(userHome)) {
+            final Path langstreamDir = Path.of(userHome, ".langstream");
+            Files.createDirectories(langstreamDir);
+            return langstreamDir;
+        }
+        return null;
+    }
 
     public static void main(String... args) {
         int exitCode = execute(args);

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -441,7 +441,6 @@ public abstract class BaseCmd implements Runnable {
                             + response.body());
         }
         Files.write(tempFile, response.body());
-        tempFile.toFile().setReadable(true, false);
         final long time = (System.currentTimeMillis() - start) / 1000;
         logger.accept(String.format("downloaded remote file %s (%d s)", path, time));
         return tempFile.toFile();

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -441,6 +441,7 @@ public abstract class BaseCmd implements Runnable {
                             + response.body());
         }
         Files.write(tempFile, response.body());
+        tempFile.toFile().setReadable(true, false);
         final long time = (System.currentTimeMillis() - start) / 1000;
         logger.accept(String.format("downloaded remote file %s (%d s)", path, time));
         return tempFile.toFile();

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -381,7 +380,8 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         }
     }
 
-    private static File createReadableTempFile(String prefix, String instanceContents) throws IOException {
+    private static File createReadableTempFile(String prefix, String instanceContents)
+            throws IOException {
         File tempFile = Files.createTempFile(prefix, ".yaml").toFile();
         tempFile.setReadable(true, false);
         Files.write(tempFile.toPath(), instanceContents.getBytes(StandardCharsets.UTF_8));

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -79,17 +79,15 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                     final String hostPath = volume.split(":")[0];
                     final File file = new File(hostPath);
                     assertTrue(file.exists());
-                    final Path langstreamTmp = Path.of(System.getProperty("user.home"), ".langstream", "tmp");
+                    final Path langstreamTmp =
+                            Path.of(System.getProperty("user.home"), ".langstream", "tmp");
                     assertEquals(langstreamTmp, file.toPath().getParent());
                     final Set<PosixFilePermission> posixFilePermissions;
                     try {
                         posixFilePermissions = Files.getPosixFilePermissions(file.toPath());
-                        assertTrue(
-                                posixFilePermissions.contains(PosixFilePermission.OTHERS_READ));
-                        assertTrue(
-                                posixFilePermissions.contains(PosixFilePermission.OWNER_READ));
-                        assertTrue(
-                                posixFilePermissions.contains(PosixFilePermission.GROUP_READ));
+                        assertTrue(posixFilePermissions.contains(PosixFilePermission.OTHERS_READ));
+                        assertTrue(posixFilePermissions.contains(PosixFilePermission.OWNER_READ));
+                        assertTrue(posixFilePermissions.contains(PosixFilePermission.GROUP_READ));
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -44,7 +44,15 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
         final String appDir = tempDir.toFile().getAbsolutePath();
         CommandResult result =
                 executeCommand(
-                        "docker", "run", "my-app", "-app", appDir, "-s", secrets.toFile().getAbsolutePath(), "--docker-command", "echo");
+                        "docker",
+                        "run",
+                        "my-app",
+                        "-app",
+                        appDir,
+                        "-s",
+                        secrets.toFile().getAbsolutePath(),
+                        "--docker-command",
+                        "echo");
         assertEquals("", result.err());
         assertEquals(0, result.exitCode());
 
@@ -67,7 +75,6 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                                 + "-p 8090:8090 "
                                 + "ghcr.io/langstream/langstream-runtime-tester:unknown"));
 
-
         final List<String> volumes = extractVolumes(lastLine);
         assertEquals(3, volumes.size());
         volumes.forEach(
@@ -79,15 +86,18 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                         final Set<PosixFilePermission> posixFilePermissions;
                         try {
                             posixFilePermissions = Files.getPosixFilePermissions(file.toPath());
-                            System.out.println("permissions: " + posixFilePermissions + " for " + file);
-                            assertTrue(posixFilePermissions.contains(PosixFilePermission.OTHERS_READ));
-                            assertTrue(posixFilePermissions.contains(PosixFilePermission.OWNER_READ));
-                            assertTrue(posixFilePermissions.contains(PosixFilePermission.GROUP_READ));
+                            System.out.println(
+                                    "permissions: " + posixFilePermissions + " for " + file);
+                            assertTrue(
+                                    posixFilePermissions.contains(PosixFilePermission.OTHERS_READ));
+                            assertTrue(
+                                    posixFilePermissions.contains(PosixFilePermission.OWNER_READ));
+                            assertTrue(
+                                    posixFilePermissions.contains(PosixFilePermission.GROUP_READ));
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }
                     }
-
                 });
 
         final NamedProfile namedProfile = getConfig().getProfiles().get("local-docker-run");
@@ -108,5 +118,4 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
 
         return volumes;
     }
-
 }

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -19,9 +19,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.applications.CommandTestBase;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
@@ -30,11 +38,13 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
     @Test
     void testArgs() throws Exception {
         final Path tempDir = Files.createTempDirectory(this.tempDir, "langstream");
+        final Path secrets = Files.createTempFile("langstream", ".yaml");
+        Files.write(secrets, "secrets: []".getBytes(StandardCharsets.UTF_8));
 
         final String appDir = tempDir.toFile().getAbsolutePath();
         CommandResult result =
                 executeCommand(
-                        "docker", "run", "my-app", "-app", appDir, "--docker-command", "echo");
+                        "docker", "run", "my-app", "-app", appDir, "-s", secrets.toFile().getAbsolutePath(), "--docker-command", "echo");
         assertEquals("", result.err());
         assertEquals(0, result.exitCode());
 
@@ -57,10 +67,46 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                                 + "-p 8090:8090 "
                                 + "ghcr.io/langstream/langstream-runtime-tester:unknown"));
 
+
+        final List<String> volumes = extractVolumes(lastLine);
+        assertEquals(3, volumes.size());
+        volumes.forEach(
+                volume -> {
+                    final String hostPath = volume.split(":")[0];
+                    final File file = new File(hostPath);
+                    assertTrue(file.exists());
+                    if (!Files.isDirectory(file.toPath())) {
+                        final Set<PosixFilePermission> posixFilePermissions;
+                        try {
+                            posixFilePermissions = Files.getPosixFilePermissions(file.toPath());
+                            System.out.println("permissions: " + posixFilePermissions + " for " + file);
+                            assertTrue(posixFilePermissions.contains(PosixFilePermission.OTHERS_READ));
+                            assertTrue(posixFilePermissions.contains(PosixFilePermission.OWNER_READ));
+                            assertTrue(posixFilePermissions.contains(PosixFilePermission.GROUP_READ));
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                });
+
         final NamedProfile namedProfile = getConfig().getProfiles().get("local-docker-run");
         assertNotNull(namedProfile);
         assertEquals("default", namedProfile.getTenant());
         assertEquals("http://localhost:8090", namedProfile.getWebServiceUrl());
         assertEquals("ws://localhost:8091", namedProfile.getApiGatewayUrl());
     }
+
+    private static List<String> extractVolumes(String input) {
+        List<String> volumes = new ArrayList<>();
+        Pattern pattern = Pattern.compile("-v\\s+([^\\s]+)");
+        Matcher matcher = pattern.matcher(input);
+
+        while (matcher.find()) {
+            volumes.add(matcher.group(1));
+        }
+
+        return volumes;
+    }
+
 }

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -62,10 +62,7 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                 lastLine.contains(
                         "run --rm -i -e START_BROKER=true -e START_MINIO=true -e START_HERDDB=true "
                                 + "-e LANSGSTREAM_TESTER_TENANT=default -e LANSGSTREAM_TESTER_APPLICATIONID=my-app "
-                                + "-e LANSGSTREAM_TESTER_STARTWEBSERVICES=true -e LANSGSTREAM_TESTER_DRYRUN=false "
-                                + "-v "
-                                + appDir
-                                + ":/code/application "));
+                                + "-e LANSGSTREAM_TESTER_STARTWEBSERVICES=true -e LANSGSTREAM_TESTER_DRYRUN=false "));
         assertTrue(
                 lastLine.contains(
                         "--add-host minio.minio-dev.svc.cluster.local:127.0.0.1 "
@@ -82,21 +79,19 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                     final String hostPath = volume.split(":")[0];
                     final File file = new File(hostPath);
                     assertTrue(file.exists());
-                    if (!Files.isDirectory(file.toPath())) {
-                        final Set<PosixFilePermission> posixFilePermissions;
-                        try {
-                            posixFilePermissions = Files.getPosixFilePermissions(file.toPath());
-                            System.out.println(
-                                    "permissions: " + posixFilePermissions + " for " + file);
-                            assertTrue(
-                                    posixFilePermissions.contains(PosixFilePermission.OTHERS_READ));
-                            assertTrue(
-                                    posixFilePermissions.contains(PosixFilePermission.OWNER_READ));
-                            assertTrue(
-                                    posixFilePermissions.contains(PosixFilePermission.GROUP_READ));
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
+                    final Path langstreamTmp = Path.of(System.getProperty("user.home"), ".langstream", "tmp");
+                    assertEquals(langstreamTmp, file.toPath().getParent());
+                    final Set<PosixFilePermission> posixFilePermissions;
+                    try {
+                        posixFilePermissions = Files.getPosixFilePermissions(file.toPath());
+                        assertTrue(
+                                posixFilePermissions.contains(PosixFilePermission.OTHERS_READ));
+                        assertTrue(
+                                posixFilePermissions.contains(PosixFilePermission.OWNER_READ));
+                        assertTrue(
+                                posixFilePermissions.contains(PosixFilePermission.GROUP_READ));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
                     }
                 });
 

--- a/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
+++ b/langstream-runtime/langstream-runtime-tester/src/main/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN chmod -R g+w /kafka \
        && bin/kafka-storage.sh format -t $UUID -c config/kraft/server.properties \
        && mkdir -p /tmp/kraft-combined-logs \
        && chmod a+rwx /tmp/kraft-combined-logs \
+       && rm -rf /kafka/kafka.tgz \
        && chmod a+x /minio/minio \
        && chmod a+x /herddb \
        && cd /herddb \
@@ -38,6 +39,7 @@ RUN chmod -R g+w /kafka \
        && mv herddb-services-0.28.0 herddb \
        && chmod a+x /herddb/herddb \
        && chmod a+x /herddb/herddb/bin/* \
+       && rm -rf herddb-services-0.28.0.zip \
        && chown 10000:0 -R /herddb
 
 # Add the runtime code at the end. This optimizes docker layers to not depend on artifacts-specific changes.


### PR DESCRIPTION
Changes: 
* Set generated files readable for every user to avoid permissions error. The files are copied to $HOME/.langstream/tmp directory which is protected to other unix machine users but still readable from the container
* Improve the installation script error message

After these changes, I successfully setup an amazon linux machine to run langstream (I'll add it to the doc):
```
sudo yum update
sudo yum install -y docker jq unzip  java-11-amazon-corretto-headless
sudo usermod -a -G docker ec2-user
id ec2-user
newgrp docker
sudo systemctl enable docker.service
sudo systemctl start docker.service
curl -Ls "https://raw.githubusercontent.com/LangStream/langstream/main/bin/get-cli.sh" | bash
source ~/.bashrc
export OPEN_AI_ACCESS_KEY=your-key-here
langstream docker run test -app https://github.com/LangStream/langstream/blob/main/examples/applications/openai-completions -s https://github.com/LangStream/langstream/blob/main/examples/secrets/secrets.yaml
``` 