### PR TITLE
Move OpenSearch configuration to use a single index

### DIFF
--- a/examples/applications/query-opensearch/configuration.yaml
+++ b/examples/applications/query-opensearch/configuration.yaml
@@ -33,3 +33,4 @@ configuration:
         port: "${secrets.opensearch.port}"
         https: "${secrets.opensearch.https}"
         region: "${secrets.opensearch.region}"
+        index-name: "langstream-index"

--- a/examples/applications/query-opensearch/query.yaml
+++ b/examples/applications/query-opensearch/query.yaml
@@ -40,7 +40,7 @@ pipeline:
       datasource: "opensearch-datasource"
       query: |
         {
-          "index": "langstream-index",
+          "size": 1,
           "query": {
             "knn": {
               "embeddings": {

--- a/examples/applications/query-opensearch/write.yaml
+++ b/examples/applications/query-opensearch/write.yaml
@@ -23,7 +23,6 @@ assets:
     asset-type: "opensearch-index"
     creation-mode: create-if-not-exists
     config:
-      index-name: "langstream-index"
       datasource: "opensearch-datasource"
       settings: |
         {
@@ -64,9 +63,8 @@ pipeline:
     type: "vector-db-sink"
     configuration:
       datasource: "opensearch-datasource"
-      index-name: langstream-index
       bulk-parameters:
-        refresh: "wait_for"
+        refresh: "wait_for" # this is not compatible with AWS OpenSearch, set to false if using AWS OpenSearch
       fields:
         - name: "embeddings"
           expression: "value.embeddings"

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/opensearch/OpenSearchAssetsManagerProvider.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/opensearch/OpenSearchAssetsManagerProvider.java
@@ -73,9 +73,7 @@ public class OpenSearchAssetsManagerProvider implements AssetManagerProvider {
         }
 
         private String getIndexName() {
-            String tableName =
-                    ConfigurationUtils.getString("index-name", null, assetDefinition.getConfig());
-            return tableName;
+            return datasource.getClientConfig().getIndexName();
         }
 
         @Override

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/opensearch/OpenSearchDataSource.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/opensearch/OpenSearchDataSource.java
@@ -77,6 +77,7 @@ public class OpenSearchDataSource implements DataSourceProvider {
         // BASIC AUTH
         private String username;
         private String password;
+
         @JsonProperty("index-name")
         private String indexName;
     }
@@ -155,7 +156,8 @@ public class OpenSearchDataSource implements DataSourceProvider {
         @SneakyThrows
         public List<Map<String, Object>> fetchData(String query, List<Object> params) {
             try {
-                final SearchRequest searchRequest = convertSearchRequest(query, params, clientConfig.getIndexName());
+                final SearchRequest searchRequest =
+                        convertSearchRequest(query, params, clientConfig.getIndexName());
 
                 final SearchResponse<Map> result = client.search(searchRequest, Map.class);
                 return result.hits().hits().stream()
@@ -194,7 +196,8 @@ public class OpenSearchDataSource implements DataSourceProvider {
         }
 
         @NotNull
-        static SearchRequest convertSearchRequest(String query, List<Object> params, String indexName) throws IllegalAccessException {
+        static SearchRequest convertSearchRequest(
+                String query, List<Object> params, String indexName) throws IllegalAccessException {
             final Map asMap = buildObjectFromJson(query, Map.class, params, OBJECT_MAPPER);
             final SearchRequest searchRequest =
                     OpenSearchDataSource.parseOpenSearchRequestBodyJson(

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/opensearch/OpenSearchWriter.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/opensearch/OpenSearchWriter.java
@@ -111,7 +111,7 @@ public class OpenSearchWriter implements VectorDatabaseWriterProvider {
         @Override
         public void initialise(Map<String, Object> agentConfiguration) throws Exception {
             dataSource.initialize(null);
-            indexName = (String) agentConfiguration.get("index-name");
+            indexName = dataSource.getClientConfig().getIndexName();
             List<Map<String, Object>> fields =
                     (List<Map<String, Object>>)
                             agentConfiguration.getOrDefault("fields", List.of());

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/OpenSearchDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/OpenSearchDataSourceTest.java
@@ -42,7 +42,7 @@ class OpenSearchDataSourceTest {
             new OpensearchContainer(DockerImageName.parse("opensearchproject/opensearch:2"))
                     .withEnv("discovery.type", "single-node");
 
-    private static Map<String, Object> getDatasourceConfig() {
+    private static Map<String, Object> getDatasourceConfig(String indexName) {
         return Map.of(
                 "https",
                 false,
@@ -53,15 +53,14 @@ class OpenSearchDataSourceTest {
                 "username",
                 "admin",
                 "password",
-                "admin");
+                "admin",
+                "index-name", indexName);
     }
 
     @Test
     void testAsset() throws Exception {
         final Map<String, Object> assetConfig =
                 Map.of(
-                        "index-name",
-                        "test-index",
                         "settings",
                         """
                        {
@@ -82,7 +81,7 @@ class OpenSearchDataSourceTest {
                         }
                         """,
                         "datasource",
-                        Map.of("configuration", getDatasourceConfig()));
+                        Map.of("configuration", getDatasourceConfig("test-index")));
         final AssetManager instance = createAssetManager(assetConfig);
 
         instance.deployAsset();
@@ -104,14 +103,12 @@ class OpenSearchDataSourceTest {
         final String indexName = "test-index-000";
         final Map<String, Object> assetConfig =
                 Map.of(
-                        "index-name",
-                        indexName,
                         "datasource",
-                        Map.of("configuration", getDatasourceConfig()));
+                        Map.of("configuration", getDatasourceConfig(indexName)));
         createAssetManager(assetConfig).deleteAssetIfExists();
         createAssetManager(assetConfig).deployAsset();
         try (final OpenSearchWriter.OpenSearchVectorDatabaseWriter writer =
-                new OpenSearchWriter().createImplementation(getDatasourceConfig()); ) {
+                new OpenSearchWriter().createImplementation(getDatasourceConfig(indexName)); ) {
 
             writer.initialise(
                     Map.of(
@@ -208,8 +205,6 @@ class OpenSearchDataSourceTest {
         final String indexName = "test-index-000";
         final Map<String, Object> assetConfig =
                 Map.of(
-                        "index-name",
-                        indexName,
                         "settings",
                         """
                         {
@@ -241,11 +236,11 @@ class OpenSearchDataSourceTest {
 
                         """,
                         "datasource",
-                        Map.of("configuration", getDatasourceConfig()));
+                        Map.of("configuration", getDatasourceConfig(indexName)));
         createAssetManager(assetConfig).deleteAssetIfExists();
         createAssetManager(assetConfig).deployAsset();
         try (final OpenSearchWriter.OpenSearchVectorDatabaseWriter writer =
-                new OpenSearchWriter().createImplementation(getDatasourceConfig()); ) {
+                new OpenSearchWriter().createImplementation(getDatasourceConfig(indexName)); ) {
 
             writer.initialise(
                     Map.of(

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/OpenSearchDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/OpenSearchDataSourceTest.java
@@ -54,7 +54,8 @@ class OpenSearchDataSourceTest {
                 "admin",
                 "password",
                 "admin",
-                "index-name", indexName);
+                "index-name",
+                indexName);
     }
 
     @Test
@@ -102,9 +103,7 @@ class OpenSearchDataSourceTest {
     void testWriteBasicData() throws Exception {
         final String indexName = "test-index-000";
         final Map<String, Object> assetConfig =
-                Map.of(
-                        "datasource",
-                        Map.of("configuration", getDatasourceConfig(indexName)));
+                Map.of("datasource", Map.of("configuration", getDatasourceConfig(indexName)));
         createAssetManager(assetConfig).deleteAssetIfExists();
         createAssetManager(assetConfig).deployAsset();
         try (final OpenSearchWriter.OpenSearchVectorDatabaseWriter writer =

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/opensearch/OpenSearchDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/opensearch/OpenSearchDataSourceTest.java
@@ -1,27 +1,46 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.agents.vector.opensearch;
 
 import static ai.langstream.agents.vector.opensearch.OpenSearchDataSource.OpenSearchQueryStepDataSource.convertSearchRequest;
 import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.List;
-import java.util.Map;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.core.SearchRequest;
 
 class OpenSearchDataSourceTest {
     @Test
     void test() throws Exception {
-        SearchRequest searchRequest = convertSearchRequest("""
+        SearchRequest searchRequest =
+                convertSearchRequest(
+                        """
                 {
                     "query": {
                         "match_all": {}
                     }
-                }""", List.of(), "index1"
-        );
+                }""",
+                        List.of(),
+                        "index1");
         assertEquals("index1", searchRequest.index().get(0));
         assertNotNull(searchRequest.query().matchAll());
 
-        searchRequest = convertSearchRequest("""
+        searchRequest =
+                convertSearchRequest(
+                        """
                 {
                     "size": 12,
                     "query": {
@@ -31,15 +50,15 @@ class OpenSearchDataSourceTest {
                           "k": 12
                         }
                       }
-                    }  
-                }""", List.of(List.of(0.1f, 0.2f)), "index1"
-        );
+                    }
+                }""",
+                        List.of(List.of(0.1f, 0.2f)),
+                        "index1");
         assertEquals("index1", searchRequest.index().get(0));
         assertEquals("embeddings", searchRequest.query().knn().field());
         assertEquals(0.1f, searchRequest.query().knn().vector()[0]);
         assertEquals(0.2f, searchRequest.query().knn().vector()[1]);
         assertEquals(12, searchRequest.query().knn().k());
         assertEquals(12, searchRequest.size());
-
     }
 }

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/opensearch/OpenSearchDataSourceTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/opensearch/OpenSearchDataSourceTest.java
@@ -1,0 +1,45 @@
+package ai.langstream.agents.vector.opensearch;
+
+import static ai.langstream.agents.vector.opensearch.OpenSearchDataSource.OpenSearchQueryStepDataSource.convertSearchRequest;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+class OpenSearchDataSourceTest {
+    @Test
+    void test() throws Exception {
+        SearchRequest searchRequest = convertSearchRequest("""
+                {
+                    "query": {
+                        "match_all": {}
+                    }
+                }""", List.of(), "index1"
+        );
+        assertEquals("index1", searchRequest.index().get(0));
+        assertNotNull(searchRequest.query().matchAll());
+
+        searchRequest = convertSearchRequest("""
+                {
+                    "size": 12,
+                    "query": {
+                      "knn": {
+                        "embeddings": {
+                          "vector": ?,
+                          "k": 12
+                        }
+                      }
+                    }  
+                }""", List.of(List.of(0.1f, 0.2f)), "index1"
+        );
+        assertEquals("index1", searchRequest.index().get(0));
+        assertEquals("embeddings", searchRequest.query().knn().field());
+        assertEquals(0.1f, searchRequest.query().knn().vector()[0]);
+        assertEquals(0.2f, searchRequest.query().knn().vector()[1]);
+        assertEquals(12, searchRequest.query().knn().k());
+        assertEquals(12, searchRequest.size());
+
+    }
+}

--- a/langstream-core/src/main/java/ai/langstream/impl/assets/OpenSearchAssetsProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/assets/OpenSearchAssetsProvider.java
@@ -57,14 +57,6 @@ public class OpenSearchAssetsProvider extends AbstractAssetProvider {
         private String datasource;
 
         @ConfigProperty(
-                description = """
-                       Index name.
-                       """,
-                required = true)
-        @JsonProperty("index-name")
-        private String indexName;
-
-        @ConfigProperty(
                 description =
                         """
                        JSON containing index mappings configuration.

--- a/langstream-core/src/main/java/ai/langstream/impl/assets/OpenSearchAssetsProvider.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/assets/OpenSearchAssetsProvider.java
@@ -18,7 +18,6 @@ package ai.langstream.impl.assets;
 import ai.langstream.api.doc.AssetConfig;
 import ai.langstream.api.doc.ConfigProperty;
 import ai.langstream.impl.common.AbstractAssetProvider;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Set;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/OpenSearchDatasourceConfig.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/OpenSearchDatasourceConfig.java
@@ -20,6 +20,7 @@ import ai.langstream.api.doc.ResourceConfig;
 import ai.langstream.api.model.Resource;
 import ai.langstream.impl.resources.BaseDataSourceResourceProvider;
 import ai.langstream.impl.uti.ClassConfigValidator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
@@ -93,4 +94,13 @@ public class OpenSearchDatasourceConfig extends BaseDatasourceConfig {
                     In case of AWS OpenSearch Service/Serverless, this is the secret key.
                     """)
     private String password;
+
+    @ConfigProperty(
+            description =
+                    """
+                    Name of the index to to connect to.
+                    """,
+            required = true)
+    @JsonProperty("index-name")
+    private String indexName;
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/vectors/OpenSearchVectorDatabaseWriterConfig.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/vectors/OpenSearchVectorDatabaseWriterConfig.java
@@ -108,12 +108,6 @@ public class OpenSearchVectorDatabaseWriterConfig
         String waitForActiveShards;
     }
 
-    @ConfigProperty(
-            description = "The name of the index to write to. The index must already exist.",
-            required = true)
-    @JsonProperty("index-name")
-    String indexName;
-
     @ConfigProperty(description = "Index fields definition.", required = true)
     List<IndexField> fields;
 

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
@@ -15,8 +15,6 @@
  */
 package ai.langstream.runtime.impl.k8s.agents;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import ai.langstream.api.doc.AgentConfigurationModel;
 import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.deployer.k8s.util.SerializationUtil;
@@ -404,11 +402,6 @@ class QueryVectorDBAgentProviderTest {
                               "id" : {
                                 "description" : "JSTL Expression to compute the index _id field. Leave it empty to let OpenSearch auto-generate the _id field.",
                                 "required" : false,
-                                "type" : "string"
-                              },
-                              "index-name" : {
-                                "description" : "The name of the index to write to. The index must already exist.",
-                                "required" : true,
                                 "type" : "string"
                               }
                             }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/OpenSearchVectorIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/OpenSearchVectorIT.java
@@ -52,6 +52,7 @@ class OpenSearchVectorIT extends AbstractApplicationRunner {
                                 host: "localhost"
                                 username: "admin"
                                 password: "admin"
+                                index-name: "my-index-1"
                         """
                                 .formatted(OPENSEARCH.getMappedPort(9200)),
                         "pipeline-write.yaml",
@@ -64,7 +65,6 @@ class OpenSearchVectorIT extends AbstractApplicationRunner {
                                     asset-type: "opensearch-index"
                                     creation-mode: create-if-not-exists
                                     config:
-                                       index-name: "my-index-1"
                                        datasource: "OSDatasource"
                                        settings: |
                                            {
@@ -92,7 +92,6 @@ class OpenSearchVectorIT extends AbstractApplicationRunner {
                                     input: "insert-topic"
                                     configuration:
                                       datasource: "OSDatasource"
-                                      index-name: "my-index-1"
                                       bulk-parameters:
                                         refresh: "true"
                                       id: "key"


### PR DESCRIPTION
Currently the query can't be filtered by index and that is very problematic. The only solution that makes sense for the query agent is that the index is defined in the datasource itself. this also helps assets and writer to not need the index declared twice.

This change adds the "index-name" to the opensearch config and removes it from asset and vector-db-sink.
With this, you cannot perform query to multiple indices but it's fine 