### PR TITLE
CLI: cache github repository for faster deployments

### DIFF
--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,19 +1,3 @@
-#
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/langstream-cli/src/main/java/ai/langstream/cli/CLILogger.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/CLILogger.java
@@ -1,0 +1,36 @@
+package ai.langstream.cli;
+
+public interface CLILogger {
+    void log(Object message);
+
+    void error(Object message);
+
+    boolean isDebugEnabled();
+
+    void debug(Object message);
+
+
+    class SystemCliLogger implements CLILogger {
+        @Override
+        public void log(Object message) {
+            System.out.println(message);
+
+        }
+
+        @Override
+        public void error(Object message) {
+            System.err.println(message);
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return true;
+        }
+
+        @Override
+        public void debug(Object message) {
+            log(message);
+        }
+    }
+
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/CLILogger.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/CLILogger.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.cli;
 
 public interface CLILogger {
@@ -9,12 +24,10 @@ public interface CLILogger {
 
     void debug(Object message);
 
-
     class SystemCliLogger implements CLILogger {
         @Override
         public void log(Object message) {
             System.out.println(message);
-
         }
 
         @Override
@@ -32,5 +45,4 @@ public interface CLILogger {
             log(message);
         }
     }
-
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLI.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLI.java
@@ -19,9 +19,23 @@ import ai.langstream.admin.client.HttpRequestFailedException;
 import ai.langstream.cli.commands.RootCmd;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.SneakyThrows;
 import picocli.CommandLine;
 
 public class LangStreamCLI {
+
+    @SneakyThrows
+    public static Path getLangstreamCLIHomeDirectory() {
+        final String userHome = System.getProperty("user.home");
+        if (!userHome.isBlank() && !"?".equals(userHome)) {
+            final Path langstreamDir = Path.of(userHome, ".langstream");
+            Files.createDirectories(langstreamDir);
+            return langstreamDir;
+        }
+        return null;
+    }
 
     public static void main(String... args) {
         int exitCode = execute(args);

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -83,12 +84,12 @@ public abstract class BaseCmd implements Runnable {
 
     @AllArgsConstructor
     static final class CLILoggerImpl implements CLILogger {
-        private final RootCmd rootCmd;
-        protected CommandLine.Model.CommandSpec command;
+        private final Supplier<RootCmd> rootCmd;
+        protected Supplier<CommandLine.Model.CommandSpec> command;
 
         @Override
         public void log(Object message) {
-            command.commandLine().getOut().println(message);
+            command.get().commandLine().getOut().println(message);
         }
 
         @Override
@@ -100,12 +101,12 @@ public abstract class BaseCmd implements Runnable {
             if (error.isBlank()) {
                 return;
             }
-            System.err.println(command.commandLine().getColorScheme().errorText(error));
+            System.err.println(command.get().commandLine().getColorScheme().errorText(error));
         }
 
         @Override
         public boolean isDebugEnabled() {
-            return rootCmd.isVerbose();
+            return rootCmd.get().isVerbose();
         }
 
         @Override
@@ -117,7 +118,7 @@ public abstract class BaseCmd implements Runnable {
     }
 
     @CommandLine.Spec protected CommandLine.Model.CommandSpec command;
-    private final CLILogger logger = new CLILoggerImpl(getRootCmd(), command);
+    private final CLILogger logger = new CLILoggerImpl(() -> getRootCmd(), () -> command);
     private final GithubRepositoryDownloader githubRepositoryDownloader =
             new GithubRepositoryDownloader(
                     new JGitClient(), logger, LangStreamCLI.getLangstreamCLIHomeDirectory());

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -26,7 +26,6 @@ import ai.langstream.cli.LangStreamCLIConfig;
 import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.applications.GithubRepositoryDownloader;
 import ai.langstream.cli.commands.profiles.BaseProfileCmd;
-import ai.langstream.cli.util.GitClient;
 import ai.langstream.cli.util.git.JGitClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -82,8 +81,6 @@ public abstract class BaseCmd implements Runnable {
 
     protected static final ObjectWriter jsonBodyWriter = new ObjectMapper().writer();
 
-
-
     @AllArgsConstructor
     static final class CLILoggerImpl implements CLILogger {
         private final RootCmd rootCmd;
@@ -116,13 +113,14 @@ public abstract class BaseCmd implements Runnable {
             if (isDebugEnabled()) {
                 log(message);
             }
-
         }
     }
 
     @CommandLine.Spec protected CommandLine.Model.CommandSpec command;
     private final CLILogger logger = new CLILoggerImpl(getRootCmd(), command);
-    private final GithubRepositoryDownloader githubRepositoryDownloader = new GithubRepositoryDownloader(new JGitClient(), logger, LangStreamCLI.getLangstreamCLIHomeDirectory());
+    private final GithubRepositoryDownloader githubRepositoryDownloader =
+            new GithubRepositoryDownloader(
+                    new JGitClient(), logger, LangStreamCLI.getLangstreamCLIHomeDirectory());
     private AdminClient client;
     private LangStreamCLIConfig config;
     private Map<String, String> applicationDescriptions = new HashMap<>();
@@ -291,7 +289,6 @@ public abstract class BaseCmd implements Runnable {
 
     protected void log(Object log) {
         logger.log(log);
-
     }
 
     protected void logNoNewline(Object log) {
@@ -300,7 +297,6 @@ public abstract class BaseCmd implements Runnable {
 
     protected void err(Object log) {
         logger.error(log);
-
     }
 
     protected void debug(Object log) {
@@ -438,7 +434,10 @@ public abstract class BaseCmd implements Runnable {
             throw new IllegalArgumentException("http is not supported. Please use https instead.");
         }
         if (path.startsWith("https://")) {
-            return downloadHttpsFile(path, getClient().getHttpClientFacade(), logger,
+            return downloadHttpsFile(
+                    path,
+                    getClient().getHttpClientFacade(),
+                    logger,
                     githubRepositoryDownloader,
                     !getRootCmd().isDisableLocalRepositoriesCache());
         }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/BaseCmd.java
@@ -20,6 +20,7 @@ import ai.langstream.admin.client.AdminClientConfiguration;
 import ai.langstream.admin.client.AdminClientLogger;
 import ai.langstream.admin.client.HttpRequestFailedException;
 import ai.langstream.admin.client.http.HttpClientFacade;
+import ai.langstream.cli.LangStreamCLI;
 import ai.langstream.cli.LangStreamCLIConfig;
 import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.applications.GithubRepositoryDownloader;
@@ -194,11 +195,9 @@ public abstract class BaseCmd implements Runnable {
 
     @SneakyThrows
     private File computeRootConfigFile() {
-        final String userHome = System.getProperty("user.home");
-        if (!userHome.isBlank() && !"?".equals(userHome)) {
-            final Path langstreamDir = Path.of(userHome, ".langstream");
-            Files.createDirectories(langstreamDir);
-            final Path configFile = langstreamDir.resolve("config");
+        final Path langstreamCLIHomeDirectory = LangStreamCLI.getLangstreamCLIHomeDirectory();
+        if (langstreamCLIHomeDirectory != null) {
+            final Path configFile = langstreamCLIHomeDirectory.resolve("config");
             debug(String.format("Using config file %s", configFile));
             if (!Files.exists(configFile)) {
                 debug(String.format("Init config file %s", configFile));

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
@@ -55,4 +55,11 @@ public class RootCmd {
             description = "Verbose mode. Helpful for troubleshooting.")
     @Getter
     private boolean verbose = false;
+
+    @CommandLine.Option(
+            names = {"--disable-local-repositories-cache"},
+            defaultValue = "false",
+            description = "By default the repositories downloaded are cached. In case of corrupted directories, you might want to set add this parameter to always clone the repositories from scratch.")
+    @Getter
+    private boolean disableLocalRepositoriesCache = false;
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/RootCmd.java
@@ -59,7 +59,8 @@ public class RootCmd {
     @CommandLine.Option(
             names = {"--disable-local-repositories-cache"},
             defaultValue = "false",
-            description = "By default the repositories downloaded are cached. In case of corrupted directories, you might want to set add this parameter to always clone the repositories from scratch.")
+            description =
+                    "By default the repositories downloaded are cached. In case of corrupted directories, you might want to set add this parameter to always clone the repositories from scratch.")
     @Getter
     private boolean disableLocalRepositoriesCache = false;
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloader.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloader.java
@@ -21,18 +21,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import lombok.Data;
 import lombok.SneakyThrows;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.RefSpec;
 
@@ -57,7 +53,6 @@ public class GithubRepositoryDownloader {
             this.repository = requestedDirectory.getRepository();
             this.branch = requestedDirectory.getBranch();
         }
-
     }
 
     /**
@@ -77,7 +72,9 @@ public class GithubRepositoryDownloader {
             final long start = System.currentTimeMillis();
             final Path langstreamCLIHomeDirectory = LangStreamCLI.getLangstreamCLIHomeDirectory();
             if (langstreamCLIHomeDirectory != null) {
-                cloneToDirectory = cloneOrUpdateFromGithubReposCache(uri, logger, requestedDirectory, start, langstreamCLIHomeDirectory);
+                cloneToDirectory =
+                        cloneOrUpdateFromGithubReposCache(
+                                uri, logger, requestedDirectory, start, langstreamCLIHomeDirectory);
             } else {
                 cloneToDirectory = Files.createTempDirectory("langstream");
                 cloneRepository(uri, logger, requestedDirectory, cloneToDirectory);
@@ -91,23 +88,36 @@ public class GithubRepositoryDownloader {
         return result.toFile();
     }
 
-    private static Path cloneOrUpdateFromGithubReposCache(URI uri, Consumer<String> logger, RequestedDirectory requestedDirectory, long start,
-                                Path langstreamCLIHomeDirectory) throws GitAPIException, IOException {
+    private static Path cloneOrUpdateFromGithubReposCache(
+            URI uri,
+            Consumer<String> logger,
+            RequestedDirectory requestedDirectory,
+            long start,
+            Path langstreamCLIHomeDirectory)
+            throws GitAPIException, IOException {
         Path cloneToDirectory;
         final Path repos = langstreamCLIHomeDirectory.resolve("ghrepos");
-        cloneToDirectory = repos.resolve(
-                Path.of(requestedDirectory.getOwner(), requestedDirectory.getRepository(),
-                        requestedDirectory.getBranch()));
+        cloneToDirectory =
+                repos.resolve(
+                        Path.of(
+                                requestedDirectory.getOwner(),
+                                requestedDirectory.getRepository(),
+                                requestedDirectory.getBranch()));
         if (cloneToDirectory.toFile().exists()) {
             logger.accept(String.format("Updating local GitHub repository %s", uri));
-            try (final Git open = Git.open(cloneToDirectory.toFile());) {
-                open.fetch().setRefSpecs(new RefSpec("refs/heads/" + requestedDirectory.getBranch())).call();
-                open.reset().setMode(ResetCommand.ResetType.HARD)
-                        .setRef("origin/" + requestedDirectory.getBranch()).call();
+            try (final Git open = Git.open(cloneToDirectory.toFile()); ) {
+                open.fetch()
+                        .setRefSpecs(new RefSpec("refs/heads/" + requestedDirectory.getBranch()))
+                        .call();
+                open.reset()
+                        .setMode(ResetCommand.ResetType.HARD)
+                        .setRef("origin/" + requestedDirectory.getBranch())
+                        .call();
                 final RevCommit revCommit = open.log().setMaxCount(1).call().iterator().next();
                 final String sha = revCommit.getId().abbreviate(8).name();
                 final long time = (System.currentTimeMillis() - start) / 1000;
-                logger.accept(String.format("Updated local GitHub repository to %s (%d s)", sha, time));
+                logger.accept(
+                        String.format("Updated local GitHub repository to %s (%d s)", sha, time));
             }
         } else {
             Files.createDirectories(cloneToDirectory);
@@ -116,8 +126,12 @@ public class GithubRepositoryDownloader {
         return cloneToDirectory;
     }
 
-    private static void cloneRepository(URI uri, Consumer<String> logger, RequestedDirectory requestedDirectory,
-                                  Path cloneToDirectory) throws GitAPIException {
+    private static void cloneRepository(
+            URI uri,
+            Consumer<String> logger,
+            RequestedDirectory requestedDirectory,
+            Path cloneToDirectory)
+            throws GitAPIException {
         final long start = System.currentTimeMillis();
         logger.accept(String.format("Cloning GitHub repository %s locally", uri));
         Git.cloneRepository()

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloader.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloader.java
@@ -15,7 +15,6 @@
  */
 package ai.langstream.cli.commands.applications;
 
-import ai.langstream.cli.LangStreamCLI;
 import ai.langstream.cli.CLILogger;
 import ai.langstream.cli.util.GitClient;
 import java.io.File;
@@ -25,7 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.SneakyThrows;
@@ -57,6 +55,7 @@ public class GithubRepositoryDownloader {
     private final GitClient client;
     private final CLILogger logger;
     private final Path cliHomeDirectory;
+
     /**
      * This cache avoids cloning/updating the same repository multiple times in the same process.
      * For example passing secrets and applications from the same repository in the same command.
@@ -75,8 +74,7 @@ public class GithubRepositoryDownloader {
             if (useLocalGithubRepos && cliHomeDirectory != null) {
                 try {
                     cloneToDirectory =
-                            cloneOrUpdateFromGithubReposCache(
-                                    uri, requestedDirectory, start);
+                            cloneOrUpdateFromGithubReposCache(uri, requestedDirectory, start);
                 } catch (IOException ioException) {
                     logger.log(
                             String.format(
@@ -88,7 +86,8 @@ public class GithubRepositoryDownloader {
                     } catch (IOException e) {
                         logger.log(
                                 String.format(
-                                        "Failed to delete local GitHub repository cache, please remove manually at path: %s, error: %s", githubReposPath, e.getMessage()));
+                                        "Failed to delete local GitHub repository cache, please remove manually at path: %s, error: %s",
+                                        githubReposPath, e.getMessage()));
                     }
                     cloneToDirectory = Files.createTempDirectory("langstream");
                     cloneRepository(uri, requestedDirectory, cloneToDirectory);
@@ -121,10 +120,7 @@ public class GithubRepositoryDownloader {
     }
 
     private Path cloneOrUpdateFromGithubReposCache(
-            URI uri,
-            RequestedDirectory requestedDirectory,
-            long start)
-            throws IOException {
+            URI uri, RequestedDirectory requestedDirectory, long start) throws IOException {
         Path cloneToDirectory;
         final Path repos = resolveGithubReposPath(cliHomeDirectory);
         cloneToDirectory =
@@ -135,7 +131,8 @@ public class GithubRepositoryDownloader {
                                 requestedDirectory.getBranch()));
         if (cloneToDirectory.toFile().exists()) {
             logger.log(String.format("Updating local GitHub repository %s", cloneToDirectory));
-            final String sha = client.updateRepository(cloneToDirectory, requestedDirectory.getBranch());
+            final String sha =
+                    client.updateRepository(cloneToDirectory, requestedDirectory.getBranch());
             final long time = (System.currentTimeMillis() - start) / 1000;
             logger.log(String.format("Updated local GitHub repository to %s (%d s)", sha, time));
         } else {
@@ -146,15 +143,14 @@ public class GithubRepositoryDownloader {
     }
 
     private void cloneRepository(
-            URI uri,
-            RequestedDirectory requestedDirectory,
-            Path cloneToDirectory)
+            URI uri, RequestedDirectory requestedDirectory, Path cloneToDirectory)
             throws IOException {
         final long start = System.currentTimeMillis();
         logger.log(String.format("Cloning GitHub repository %s locally", uri));
-        final String githubUri = String.format(
-                "https://github.com/%s/%s.git",
-                requestedDirectory.getOwner(), requestedDirectory.getRepository());
+        final String githubUri =
+                String.format(
+                        "https://github.com/%s/%s.git",
+                        requestedDirectory.getOwner(), requestedDirectory.getRepository());
         client.cloneRepository(cloneToDirectory, githubUri, requestedDirectory.getBranch());
         final long time = (System.currentTimeMillis() - start) / 1000;
         logger.log(String.format("Downloaded GitHub repository (%d s)", time));

--- a/langstream-cli/src/main/java/ai/langstream/cli/util/GitClient.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/util/GitClient.java
@@ -1,0 +1,12 @@
+package ai.langstream.cli.util;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface GitClient {
+
+    void cloneRepository(Path directory, String uri, String branch) throws IOException;
+
+
+    String updateRepository(Path directory, String branch) throws IOException;
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/util/GitClient.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/util/GitClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.cli.util;
 
 import java.io.IOException;
@@ -6,7 +21,6 @@ import java.nio.file.Path;
 public interface GitClient {
 
     void cloneRepository(Path directory, String uri, String branch) throws IOException;
-
 
     String updateRepository(Path directory, String branch) throws IOException;
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/util/git/JGitClient.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/util/git/JGitClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.cli.util.git;
 
 import ai.langstream.cli.util.GitClient;
@@ -9,7 +24,6 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.RefSpec;
 
 public class JGitClient implements GitClient {
-
 
     @Override
     public void cloneRepository(Path directory, String uri, String branch) throws IOException {
@@ -27,14 +41,9 @@ public class JGitClient implements GitClient {
 
     @Override
     public String updateRepository(Path directory, String branch) throws IOException {
-        try (final Git open = Git.open(directory.toFile());) {
-            open.fetch()
-                    .setRefSpecs(new RefSpec("refs/heads/" + branch))
-                    .call();
-            open.reset()
-                    .setMode(ResetCommand.ResetType.HARD)
-                    .setRef("origin/" + branch)
-                    .call();
+        try (final Git open = Git.open(directory.toFile()); ) {
+            open.fetch().setRefSpecs(new RefSpec("refs/heads/" + branch)).call();
+            open.reset().setMode(ResetCommand.ResetType.HARD).setRef("origin/" + branch).call();
             final RevCommit revCommit = open.log().setMaxCount(1).call().iterator().next();
             return revCommit.getId().abbreviate(8).name();
         } catch (Exception e) {

--- a/langstream-cli/src/main/java/ai/langstream/cli/util/git/JGitClient.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/util/git/JGitClient.java
@@ -1,0 +1,44 @@
+package ai.langstream.cli.util.git;
+
+import ai.langstream.cli.util.GitClient;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.RefSpec;
+
+public class JGitClient implements GitClient {
+
+
+    @Override
+    public void cloneRepository(Path directory, String uri, String branch) throws IOException {
+        try {
+            Git.cloneRepository()
+                    .setURI(uri)
+                    .setDirectory(directory.toFile())
+                    .setBranch(branch)
+                    .setDepth(1)
+                    .call();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public String updateRepository(Path directory, String branch) throws IOException {
+        try (final Git open = Git.open(directory.toFile());) {
+            open.fetch()
+                    .setRefSpecs(new RefSpec("refs/heads/" + branch))
+                    .call();
+            open.reset()
+                    .setMode(ResetCommand.ResetType.HARD)
+                    .setRef("origin/" + branch)
+                    .call();
+            final RevCommit revCommit = open.log().setMaxCount(1).call().iterator().next();
+            return revCommit.getId().abbreviate(8).name();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmdTest.java
@@ -21,6 +21,7 @@ import ai.langstream.admin.client.AdminClient;
 import ai.langstream.admin.client.AdminClientConfiguration;
 import ai.langstream.admin.client.HttpRequestFailedException;
 import ai.langstream.admin.client.http.HttpClientFacade;
+import ai.langstream.cli.CLILogger;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -58,12 +59,14 @@ class AbstractDeployApplicationCmdTest {
                 AbstractDeployApplicationCmd.downloadHttpsFile(
                         wireMockBaseUrl + "/my-remote-dir/my-remote-file",
                         client,
-                        log -> System.out.println(log));
+                        new CLILogger.SystemCliLogger(),
+                        null,
+                        false);
         assertEquals("content!", Files.readString(file.toPath()));
 
         try {
             AbstractDeployApplicationCmd.downloadHttpsFile(
-                    wireMockBaseUrl + "/unknown", client, log -> System.out.println(log));
+                    wireMockBaseUrl + "/unknown", client, new CLILogger.SystemCliLogger(), null, false);
             fail();
         } catch (HttpRequestFailedException ex) {
             assertEquals(404, ex.getResponse().statusCode());

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AbstractDeployApplicationCmdTest.java
@@ -66,7 +66,11 @@ class AbstractDeployApplicationCmdTest {
 
         try {
             AbstractDeployApplicationCmd.downloadHttpsFile(
-                    wireMockBaseUrl + "/unknown", client, new CLILogger.SystemCliLogger(), null, false);
+                    wireMockBaseUrl + "/unknown",
+                    client,
+                    new CLILogger.SystemCliLogger(),
+                    null,
+                    false);
             fail();
         } catch (HttpRequestFailedException ex) {
             assertEquals(404, ex.getResponse().statusCode());

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloaderTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloaderTest.java
@@ -17,9 +17,19 @@ package ai.langstream.cli.commands.applications;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.langstream.cli.CLILogger;
+import ai.langstream.cli.util.GitClient;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 class GithubRepositoryDownloaderTest {
 
     @Test
@@ -55,5 +65,68 @@ class GithubRepositoryDownloaderTest {
         assertEquals("langstream", request.getRepository());
         assertEquals("main", request.getBranch());
         assertNull(request.getDirectory());
+    }
+
+    @Test
+    void testDownload() throws Exception {
+
+        AtomicBoolean injectUpdateFailure = new AtomicBoolean(false);
+
+        final Path home = Files.createTempDirectory("test");
+
+        final GitClient client = new GitClient() {
+            @Override
+            public void cloneRepository(Path directory, String uri, String branch) throws IOException {
+                Files.createDirectories(directory.resolve("examples"));
+                Files.writeString(directory.resolve("examples").resolve("my-file"), "content! " + branch);
+            }
+
+            @Override
+            public String updateRepository(Path directory, String branch) throws IOException {
+                if (injectUpdateFailure.get()) {
+                    throw new IOException("inject failure");
+                }
+                Files.writeString(directory.resolve("examples").resolve("my-file"), "content updated! " + branch);
+                return "xxx";
+            }
+        };
+        final GithubRepositoryDownloader downloader = new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home);
+
+        File file = downloader.downloadGithubRepository(
+                URI.create("https://localhost/LangStream/langstream/tree/main/examples"),
+                false);
+
+        assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
+        assertFalse(home.resolve("ghrepos").toFile().exists());
+
+
+        file = downloader.downloadGithubRepository(
+                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
+                true);
+        assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
+        assertTrue(home.resolve("ghrepos").toFile().exists());
+        assertEquals(home.resolve("ghrepos").resolve("LangStream").resolve("langstream2").resolve("main").resolve("examples").toFile().getAbsolutePath(), file.getAbsolutePath());
+
+        file = downloader.downloadGithubRepository(
+                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
+                true);
+        assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
+        assertTrue(home.resolve("ghrepos").toFile().exists());
+        assertEquals(home.resolve("ghrepos").resolve("LangStream").resolve("langstream2").resolve("main").resolve("examples").toFile().getAbsolutePath(), file.getAbsolutePath());
+
+        file = new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home).downloadGithubRepository(
+                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
+                true);
+        assertEquals("content updated! main", Files.readString(file.toPath().resolve("my-file")));
+        assertTrue(home.resolve("ghrepos").toFile().exists());
+        assertEquals(home.resolve("ghrepos").resolve("LangStream").resolve("langstream2").resolve("main").resolve("examples").toFile().getAbsolutePath(), file.getAbsolutePath());
+
+        injectUpdateFailure.set(true);
+
+        file = new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home).downloadGithubRepository(
+                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
+                true);
+        assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
+        assertFalse(home.resolve("ghrepos").toFile().exists());
     }
 }

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloaderTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/GithubRepositoryDownloaderTest.java
@@ -19,17 +19,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import ai.langstream.cli.CLILogger;
 import ai.langstream.cli.util.GitClient;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 class GithubRepositoryDownloaderTest {
 
     @Test
@@ -74,58 +71,98 @@ class GithubRepositoryDownloaderTest {
 
         final Path home = Files.createTempDirectory("test");
 
-        final GitClient client = new GitClient() {
-            @Override
-            public void cloneRepository(Path directory, String uri, String branch) throws IOException {
-                Files.createDirectories(directory.resolve("examples"));
-                Files.writeString(directory.resolve("examples").resolve("my-file"), "content! " + branch);
-            }
+        final GitClient client =
+                new GitClient() {
+                    @Override
+                    public void cloneRepository(Path directory, String uri, String branch)
+                            throws IOException {
+                        Files.createDirectories(directory.resolve("examples"));
+                        Files.writeString(
+                                directory.resolve("examples").resolve("my-file"),
+                                "content! " + branch);
+                    }
 
-            @Override
-            public String updateRepository(Path directory, String branch) throws IOException {
-                if (injectUpdateFailure.get()) {
-                    throw new IOException("inject failure");
-                }
-                Files.writeString(directory.resolve("examples").resolve("my-file"), "content updated! " + branch);
-                return "xxx";
-            }
-        };
-        final GithubRepositoryDownloader downloader = new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home);
+                    @Override
+                    public String updateRepository(Path directory, String branch)
+                            throws IOException {
+                        if (injectUpdateFailure.get()) {
+                            throw new IOException("inject failure");
+                        }
+                        Files.writeString(
+                                directory.resolve("examples").resolve("my-file"),
+                                "content updated! " + branch);
+                        return "xxx";
+                    }
+                };
+        final GithubRepositoryDownloader downloader =
+                new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home);
 
-        File file = downloader.downloadGithubRepository(
-                URI.create("https://localhost/LangStream/langstream/tree/main/examples"),
-                false);
+        File file =
+                downloader.downloadGithubRepository(
+                        URI.create("https://localhost/LangStream/langstream/tree/main/examples"),
+                        false);
 
         assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
         assertFalse(home.resolve("ghrepos").toFile().exists());
 
-
-        file = downloader.downloadGithubRepository(
-                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
-                true);
+        file =
+                downloader.downloadGithubRepository(
+                        URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
+                        true);
         assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
         assertTrue(home.resolve("ghrepos").toFile().exists());
-        assertEquals(home.resolve("ghrepos").resolve("LangStream").resolve("langstream2").resolve("main").resolve("examples").toFile().getAbsolutePath(), file.getAbsolutePath());
+        assertEquals(
+                home.resolve("ghrepos")
+                        .resolve("LangStream")
+                        .resolve("langstream2")
+                        .resolve("main")
+                        .resolve("examples")
+                        .toFile()
+                        .getAbsolutePath(),
+                file.getAbsolutePath());
 
-        file = downloader.downloadGithubRepository(
-                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
-                true);
+        file =
+                downloader.downloadGithubRepository(
+                        URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
+                        true);
         assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
         assertTrue(home.resolve("ghrepos").toFile().exists());
-        assertEquals(home.resolve("ghrepos").resolve("LangStream").resolve("langstream2").resolve("main").resolve("examples").toFile().getAbsolutePath(), file.getAbsolutePath());
+        assertEquals(
+                home.resolve("ghrepos")
+                        .resolve("LangStream")
+                        .resolve("langstream2")
+                        .resolve("main")
+                        .resolve("examples")
+                        .toFile()
+                        .getAbsolutePath(),
+                file.getAbsolutePath());
 
-        file = new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home).downloadGithubRepository(
-                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
-                true);
+        file =
+                new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home)
+                        .downloadGithubRepository(
+                                URI.create(
+                                        "https://localhost/LangStream/langstream2/tree/main/examples"),
+                                true);
         assertEquals("content updated! main", Files.readString(file.toPath().resolve("my-file")));
         assertTrue(home.resolve("ghrepos").toFile().exists());
-        assertEquals(home.resolve("ghrepos").resolve("LangStream").resolve("langstream2").resolve("main").resolve("examples").toFile().getAbsolutePath(), file.getAbsolutePath());
+        assertEquals(
+                home.resolve("ghrepos")
+                        .resolve("LangStream")
+                        .resolve("langstream2")
+                        .resolve("main")
+                        .resolve("examples")
+                        .toFile()
+                        .getAbsolutePath(),
+                file.getAbsolutePath());
 
         injectUpdateFailure.set(true);
 
-        file = new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home).downloadGithubRepository(
-                URI.create("https://localhost/LangStream/langstream2/tree/main/examples"),
-                true);
+        file =
+                new GithubRepositoryDownloader(client, new CLILogger.SystemCliLogger(), home)
+                        .downloadGithubRepository(
+                                URI.create(
+                                        "https://localhost/LangStream/langstream2/tree/main/examples"),
+                                true);
         assertEquals("content! main", Files.readString(file.toPath().resolve("my-file")));
         assertFalse(home.resolve("ghrepos").toFile().exists());
     }


### PR DESCRIPTION
Currently every time the user specify a github repository for the application/secrets/instance we clone the entire git repository N times. If the user submit the deploy again, the repo is cloned from sctratch again. 99% of use cases are to download from this repo and it takes up to 10 seconds. 

Changes:
* Save git repository clone in ~/.langstream/ghrepos with the repo identifier. If the repo specified already exists, we just reset and fetch to the specified branch. **This is much faster than cloning the repo: ~3-4s vs 10~12s on my machine**
* In case the same command specify the same repository, the second one will be considered up to date and nothing will be done (neither clone or fetch)
* Added `--disable-local-repositories-cache` to fallback to the old behaviour
* In case of failures, the repo is wiped off and it restarts from scratch 

The downside of this solution is that the repository is stored "forever" in the user home but I don't think it's a real issue.
Another possible issue but very very unlikely is that two deployments happen in parallel and If at the same time the remote branch is updated. I don't think it's a real issue too