### PR TITLE
Enhance the example applications: chat history and webcrawler (and add the 'log-event' agent)

### DIFF
--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,19 +1,3 @@
-#
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/examples/applications/docker-chatbot/crawler.yaml
+++ b/examples/applications/docker-chatbot/crawler.yaml
@@ -112,6 +112,15 @@ pipeline:
       text: "{{ value.text }}"
       batch-size: 10
       flush-interval: 500
+  - name: "Delete stale chunks"
+    input: "chunks-topic"
+    type: "query"
+    configuration:
+      datasource: "JdbcDatasource"
+      when: "fn:toInt(properties.text_num_chunks) == (fn:toInt(properties.chunk_id) + 1)"
+      mode: "execute"
+      query: "DELETE FROM documents WHERE filename = ? AND chunk_id > ?"
+      output-field: "value.delete-results"
   - name: "Write"
     type: "vector-db-sink"
     input: chunks-topic

--- a/examples/applications/docker-chatbot/crawler.yaml
+++ b/examples/applications/docker-chatbot/crawler.yaml
@@ -116,6 +116,9 @@ pipeline:
       mode: "execute"
       query: "DELETE FROM documents WHERE filename = ? AND chunk_id > ?"
       output-field: "value.delete-results"
+      fields:
+        - "value.filename"
+        - "fn:toInt(value.chunk_id)"
   - name: "Write"
     type: "vector-db-sink"
     configuration:

--- a/examples/applications/docker-chatbot/crawler.yaml
+++ b/examples/applications/docker-chatbot/crawler.yaml
@@ -15,9 +15,6 @@
 #
 
 name: "Crawl a website"
-topics:
-  - name: "chunks-topic"
-    creation-mode: create-if-not-exists
 assets:
   - name: "documents-table"
     asset-type: "jdbc-table"
@@ -105,7 +102,6 @@ pipeline:
   - name: "compute-embeddings"
     id: "step1"
     type: "compute-ai-embeddings"
-    output: chunks-topic
     configuration:
       model: "text-embedding-ada-002" # This needs to match the name of the model deployment, not the base model
       embeddings-field: "value.embeddings_vector"
@@ -113,7 +109,6 @@ pipeline:
       batch-size: 10
       flush-interval: 500
   - name: "Delete stale chunks"
-    input: "chunks-topic"
     type: "query"
     configuration:
       datasource: "JdbcDatasource"
@@ -123,7 +118,6 @@ pipeline:
       output-field: "value.delete-results"
   - name: "Write"
     type: "vector-db-sink"
-    input: chunks-topic
     configuration:
       datasource: "JdbcDatasource"
       table-name: "documents"

--- a/examples/applications/query-postgresql-chat-history/clean-history.yaml
+++ b/examples/applications/query-postgresql-chat-history/clean-history.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Automatic purge of chat history"
+assets:
+pipeline:
+  - name: "timer"
+    id: "clean-history"
+    type: "timer-source"
+    configuration:
+      period-seconds: 10
+  - name: "clean-up-old-data"
+    type: "query"
+    configuration:
+      datasource: "JdbcDatasource"
+      mode: "execute"
+      query: "DELETE FROM chat_history WHERE TIMESTAMP <= ?"
+      output-field: "value.command-results"
+      fields:
+        - "fn:toSQLTimestamp(fn:timestampAdd(fn:now(), -1, 'hours'))"
+  - type: "log-event"
+    configuration:
+      fields:
+        - name: "current results"
+          expression: "value.command-results"

--- a/examples/applications/query-postgresql-chat-history/clean-history.yaml
+++ b/examples/applications/query-postgresql-chat-history/clean-history.yaml
@@ -34,5 +34,5 @@ pipeline:
   - type: "log-event"
     configuration:
       fields:
-        - name: "results"
+        - name: "deleted chat history records"
           expression: "value.command_results"

--- a/examples/applications/query-postgresql-chat-history/clean-history.yaml
+++ b/examples/applications/query-postgresql-chat-history/clean-history.yaml
@@ -28,11 +28,11 @@ pipeline:
       datasource: "JdbcDatasource"
       mode: "execute"
       query: "DELETE FROM chat_history WHERE TIMESTAMP <= ?"
-      output-field: "value.command-results"
+      output-field: "value.command_results"
       fields:
         - "fn:toSQLTimestamp(fn:timestampAdd(fn:now(), -1, 'hours'))"
   - type: "log-event"
     configuration:
       fields:
-        - name: "current results"
-          expression: "value.command-results"
+        - name: "results"
+          expression: "value.command_results"

--- a/examples/applications/webcrawler-source/write-to-astra.yaml
+++ b/examples/applications/webcrawler-source/write-to-astra.yaml
@@ -43,11 +43,14 @@ pipeline:
     input: "chunks-topic"
     type: "query"
     configuration:
-      datasource: "JdbcDatasource"
+      datasource: "AstraDatasource"
       when: "fn:toInt(properties.text_num_chunks) == (fn:toInt(properties.chunk_id) + 1)"
       mode: "execute"
-      query: "DELETE FROM documents WHERE filename = ? AND chunk_id > ?"
+      query: "DELETE FROM documents.documents WHERE filename = ? AND chunk_id > ?"
       output-field: "value.delete-results"
+      fields:
+        - "value.filename"
+        - "fn:toInt(value.chunk_id)"
   - name: "Write to Astra"
     type: "vector-db-sink"
     resources:

--- a/examples/applications/webcrawler-source/write-to-astra.yaml
+++ b/examples/applications/webcrawler-source/write-to-astra.yaml
@@ -39,9 +39,17 @@ assets:
         - |
           CREATE CUSTOM INDEX IF NOT EXISTS documents_ann_index ON documents.documents(embeddings_vector) USING 'StorageAttachedIndex';
 pipeline:
+  - name: "Delete stale chunks"
+    input: "chunks-topic"
+    type: "query"
+    configuration:
+      datasource: "JdbcDatasource"
+      when: "fn:toInt(properties.text_num_chunks) == (fn:toInt(properties.chunk_id) + 1)"
+      mode: "execute"
+      query: "DELETE FROM documents WHERE filename = ? AND chunk_id > ?"
+      output-field: "value.delete-results"
   - name: "Write to Astra"
     type: "vector-db-sink"
-    input: "chunks-topic"
     resources:
       size: 2
     configuration:

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerStatus.java
@@ -187,14 +187,18 @@ public class WebCrawlerStatus {
     }
 
     public String nextUrl() {
-        log.info("PendingUrls: {} Uncommitted {}", pendingUrls.size(), remainingUrls.size());
+        if (log.isDebugEnabled()) {
+            log.debug("PendingUrls: {} Uncommitted {}", pendingUrls.size(), remainingUrls.size());
+        }
         return pendingUrls.poll();
     }
 
     public void urlProcessed(String url) {
         // this method is called on "commit()", then the page has been successfully processed
         // downstream (for instance stored in the Vector database)
-        log.info("Url {} completely processed", url);
+        if (log.isDebugEnabled()) {
+            log.debug("Url {} completely processed", url);
+        }
         remainingUrls.remove(url);
 
         // forget the errors about the page

--- a/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlEvaluator.java
+++ b/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlEvaluator.java
@@ -192,6 +192,13 @@ public class JstlEvaluator<T> {
                 .getFunctionMapper()
                 .mapFunction(
                         "fn",
+                        "toSQLTimestamp",
+                        JstlFunctions.class.getMethod(
+                                "toSQLTimestamp", Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
                         "decimalFromUnscaled",
                         JstlFunctions.class.getMethod("toBigDecimal", Object.class, Object.class));
 

--- a/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlEvaluator.java
+++ b/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlEvaluator.java
@@ -193,8 +193,7 @@ public class JstlEvaluator<T> {
                 .mapFunction(
                         "fn",
                         "toSQLTimestamp",
-                        JstlFunctions.class.getMethod(
-                                "toSQLTimestamp", Object.class));
+                        JstlFunctions.class.getMethod("toSQLTimestamp", Object.class));
         this.expressionContext
                 .getFunctionMapper()
                 .mapFunction(

--- a/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlFunctions.java
+++ b/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlFunctions.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -333,6 +334,23 @@ public class JstlFunctions {
         }
         Integer maxValue = (Integer) toInt(max);
         return ThreadLocalRandom.current().nextInt(maxValue);
+    }
+
+    public static java.sql.Timestamp toSQLTimestamp(Object input) {
+        if (input == null) {
+            return null;
+        }
+        if (input instanceof java.sql.Timestamp t) {
+            return t;
+        } else if (input instanceof Instant i) {
+            return java.sql.Timestamp.from(i);
+        } else if (input instanceof String s) {
+            return java.sql.Timestamp.valueOf(s);
+        } else if (input instanceof Number) {
+            return new java.sql.Timestamp(((Number) input).longValue());
+        } else {
+            throw new IllegalArgumentException("Cannot convert "+input+" ("+input.getClass()+") to a java.sql.Timestamp");
+        }
     }
 
     public static Instant timestampAdd(Object input, Object delta, Object unit) {

--- a/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlFunctions.java
+++ b/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlFunctions.java
@@ -24,7 +24,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -349,7 +348,12 @@ public class JstlFunctions {
         } else if (input instanceof Number) {
             return new java.sql.Timestamp(((Number) input).longValue());
         } else {
-            throw new IllegalArgumentException("Cannot convert "+input+" ("+input.getClass()+") to a java.sql.Timestamp");
+            throw new IllegalArgumentException(
+                    "Cannot convert "
+                            + input
+                            + " ("
+                            + input.getClass()
+                            + ") to a java.sql.Timestamp");
         }
     }
 

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/FlowControlAgentsCodeProvider.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/FlowControlAgentsCodeProvider.java
@@ -29,7 +29,9 @@ public class FlowControlAgentsCodeProvider implements AgentCodeProvider {
                     "trigger-event",
                     TriggerEventProcessor::new,
                     "timer-source",
-                    TimerSource::new);
+                    TimerSource::new,
+                    "log-event",
+                    LogEventProcessor::new);
 
     @Override
     public boolean supports(String agentType) {

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
@@ -26,6 +26,7 @@ import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.util.ConfigurationUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -69,7 +70,8 @@ public class LogEventProcessor extends AbstractAgentCode implements AgentProcess
         if (fields.isEmpty()) {
             log.info("{}", originalRecord);
         } else {
-            Map<String, Object> values = new HashMap<>();
+            // using LinkedHashMap in order to keep the order
+            Map<String, Object> values = new LinkedHashMap<>();
             for (FieldDefinition field : fields) {
                 values.put(field.name, field.expressionEvaluator.evaluate(mutableRecord));
             }

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
@@ -25,7 +25,6 @@ import ai.langstream.api.runner.code.RecordSink;
 import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.util.ConfigurationUtils;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
@@ -66,27 +66,27 @@ public class LogEventProcessor extends AbstractAgentCode implements AgentProcess
         if (!predicate.test(mutableRecord)) {
             return;
         }
-        Map<String, Object> values = new HashMap<>();
-        for (FieldDefinition field : fields) {
-            values.put(field.name, field.expressionEvaluator.evaluate(mutableRecord));
+        if (fields.isEmpty()) {
+            log.info("{}", originalRecord);
+        } else {
+            Map<String, Object> values = new HashMap<>();
+            for (FieldDefinition field : fields) {
+                values.put(field.name, field.expressionEvaluator.evaluate(mutableRecord));
+            }
+            log.info("{}", values);
         }
-        log.info("{}", values);
     }
 
     @Override
     public void process(List<Record> records, RecordSink recordSink) {
         for (Record r : records) {
-            processRecordAsync(r, recordSink);
-        }
-    }
-
-    private void processRecordAsync(Record r, RecordSink recordSink) {
-        try {
-            logRecord(r);
-        } catch (RuntimeException error) {
-            log.error("Error while processing record {}", r, error);
-        } finally {
-            recordSink.emitSingleResult(r, r);
+            try {
+                logRecord(r);
+            } catch (RuntimeException error) {
+                log.error("Error while processing record {}", r, error);
+            } finally {
+                recordSink.emitSingleResult(r, r);
+            }
         }
     }
 }

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
@@ -19,19 +19,16 @@ import ai.langstream.ai.agents.commons.MutableRecord;
 import ai.langstream.ai.agents.commons.jstl.JstlEvaluator;
 import ai.langstream.ai.agents.commons.jstl.predicate.JstlPredicate;
 import ai.langstream.api.runner.code.AbstractAgentCode;
-import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.RecordSink;
-import ai.langstream.api.runner.topics.TopicProducer;
 import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.util.ConfigurationUtils;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class LogEventProcessor extends AbstractAgentCode implements AgentProcessor {
@@ -65,8 +62,7 @@ public class LogEventProcessor extends AbstractAgentCode implements AgentProcess
     }
 
     private void logRecord(Record originalRecord) {
-        MutableRecord mutableRecord =
-                MutableRecord.recordToMutableRecord(originalRecord, true);
+        MutableRecord mutableRecord = MutableRecord.recordToMutableRecord(originalRecord, true);
         if (!predicate.test(mutableRecord)) {
             return;
         }
@@ -92,6 +88,5 @@ public class LogEventProcessor extends AbstractAgentCode implements AgentProcess
         } finally {
             recordSink.emitSingleResult(r, r);
         }
-
     }
 }

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/LogEventProcessor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.agents.flow;
+
+import ai.langstream.ai.agents.commons.MutableRecord;
+import ai.langstream.ai.agents.commons.jstl.JstlEvaluator;
+import ai.langstream.ai.agents.commons.jstl.predicate.JstlPredicate;
+import ai.langstream.api.runner.code.AbstractAgentCode;
+import ai.langstream.api.runner.code.AgentContext;
+import ai.langstream.api.runner.code.AgentProcessor;
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.code.RecordSink;
+import ai.langstream.api.runner.topics.TopicProducer;
+import ai.langstream.api.runtime.ComponentType;
+import ai.langstream.api.util.ConfigurationUtils;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class LogEventProcessor extends AbstractAgentCode implements AgentProcessor {
+
+    record FieldDefinition(String name, JstlEvaluator<Object> expressionEvaluator) {}
+
+    private final List<FieldDefinition> fields = new ArrayList<>();
+    private JstlPredicate predicate;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void init(Map<String, Object> configuration) {
+        String when = ConfigurationUtils.getString("when", "true", configuration);
+        predicate = new JstlPredicate(when);
+        List<Map<String, Object>> fields =
+                (List<Map<String, Object>>) configuration.getOrDefault("fields", List.of());
+        fields.forEach(
+                r -> {
+                    String name = ConfigurationUtils.getString("name", "", r);
+                    String expression = ConfigurationUtils.getString("expression", "", r);
+                    log.info("Emitting field with name {} computed as {}", name, expression);
+                    JstlEvaluator<Object> expressionEvaluator =
+                            new JstlEvaluator<>("${" + expression + "}", Object.class);
+                    this.fields.add(new FieldDefinition(name, expressionEvaluator));
+                });
+    }
+
+    @Override
+    public ComponentType componentType() {
+        return ComponentType.PROCESSOR;
+    }
+
+    private void logRecord(Record originalRecord) {
+        MutableRecord mutableRecord =
+                MutableRecord.recordToMutableRecord(originalRecord, true);
+        if (!predicate.test(mutableRecord)) {
+            return;
+        }
+        Map<String, Object> values = new HashMap<>();
+        for (FieldDefinition field : fields) {
+            values.put(field.name, field.expressionEvaluator.evaluate(mutableRecord));
+        }
+        log.info("{}", values);
+    }
+
+    @Override
+    public void process(List<Record> records, RecordSink recordSink) {
+        for (Record r : records) {
+            processRecordAsync(r, recordSink);
+        }
+    }
+
+    private void processRecordAsync(Record r, RecordSink recordSink) {
+        try {
+            logRecord(r);
+        } catch (RuntimeException error) {
+            log.error("Error while processing record {}", r, error);
+        } finally {
+            recordSink.emitSingleResult(r, r);
+        }
+
+    }
+}

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/TimerSource.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/TimerSource.java
@@ -84,7 +84,9 @@ public class TimerSource extends AbstractAgentCode implements AgentSource {
                     });
             Record record = MutableRecord.mutableRecordToRecord(mutableRecord).orElseThrow();
             queue.put(record);
-            log.info("Generated record {}", record);
+            if (log.isDebugEnabled()) {
+                log.info("Generated record {}", record);
+            }
         } catch (Throwable e) {
             log.error("Error while emitting record", e);
         }

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/TimerSource.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/TimerSource.java
@@ -85,7 +85,7 @@ public class TimerSource extends AbstractAgentCode implements AgentSource {
             Record record = MutableRecord.mutableRecordToRecord(mutableRecord).orElseThrow();
             queue.put(record);
             if (log.isDebugEnabled()) {
-                log.info("Generated record {}", record);
+                log.debug("Generated record {}", record);
             }
         } catch (Throwable e) {
             log.error("Error while emitting record", e);

--- a/langstream-agents/langstream-agents-flow-control/src/main/resources/META-INF/ai.langstream.agents.index
+++ b/langstream-agents/langstream-agents-flow-control/src/main/resources/META-INF/ai.langstream.agents.index
@@ -1,3 +1,4 @@
 dispatch
 trigger-event
 timer-source
+log-event

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
@@ -150,6 +150,10 @@ public class CassandraDataSource implements QueryStepDataSource {
 
         ColumnDefinitions variableDefinitions = preparedStatement.getVariableDefinitions();
         List<Object> adaptedParameters = new ArrayList<>();
+        if (variableDefinitions.size() != params.size()) {
+            throw new IllegalArgumentException("Wrong number of parameters, your query needs "
+                    + variableDefinitions.size() + " parameters but you provided " + params.size() + " fields in the agent definition");
+        }
         for (int i = 0; i < variableDefinitions.size(); i++) {
             Object value = params.get(i);
             ColumnDefinition columnDefinition = variableDefinitions.get(i);

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
@@ -151,8 +151,12 @@ public class CassandraDataSource implements QueryStepDataSource {
         ColumnDefinitions variableDefinitions = preparedStatement.getVariableDefinitions();
         List<Object> adaptedParameters = new ArrayList<>();
         if (variableDefinitions.size() != params.size()) {
-            throw new IllegalArgumentException("Wrong number of parameters, your query needs "
-                    + variableDefinitions.size() + " parameters but you provided " + params.size() + " fields in the agent definition");
+            throw new IllegalArgumentException(
+                    "Wrong number of parameters, your query needs "
+                            + variableDefinitions.size()
+                            + " parameters but you provided "
+                            + params.size()
+                            + " fields in the agent definition");
         }
         for (int i = 0; i < variableDefinitions.size(); i++) {
             Object value = params.get(i);

--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/ComputeConfiguration.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/ComputeConfiguration.java
@@ -17,6 +17,7 @@ package ai.langstream.impl.agents.ai.steps;
 
 import ai.langstream.api.doc.AgentConfig;
 import ai.langstream.api.doc.ConfigProperty;
+import ai.langstream.api.doc.ExtendedValidationType;
 import ai.langstream.impl.agents.ai.GenAIToolKitFunctionAgentProvider;
 import java.util.List;
 import lombok.Data;
@@ -54,7 +55,7 @@ public class ComputeConfiguration extends BaseGenAIStepConfiguration {
                                 It is evaluated at runtime and the result of the evaluation is assigned to the field.
                                 Refer to the language expression documentation for more information on the expression syntax.
                                 """,
-                required = true)
+                required = true, extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
         private String expression;
 
         @ConfigProperty(

--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/ComputeConfiguration.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/ComputeConfiguration.java
@@ -55,7 +55,8 @@ public class ComputeConfiguration extends BaseGenAIStepConfiguration {
                                 It is evaluated at runtime and the result of the evaluation is assigned to the field.
                                 Refer to the language expression documentation for more information on the expression syntax.
                                 """,
-                required = true, extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
+                required = true,
+                extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
         private String expression;
 
         @ConfigProperty(

--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/QueryConfiguration.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/QueryConfiguration.java
@@ -17,6 +17,7 @@ package ai.langstream.impl.agents.ai.steps;
 
 import ai.langstream.api.doc.AgentConfig;
 import ai.langstream.api.doc.ConfigProperty;
+import ai.langstream.api.doc.ExtendedValidationType;
 import ai.langstream.api.model.AgentConfiguration;
 import ai.langstream.impl.agents.ai.GenAIToolKitFunctionAgentProvider;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -83,7 +84,7 @@ public class QueryConfiguration extends BaseGenAIStepConfiguration {
                    but be like "record.fieldname" in order to replace or set a field in each record
                    with the results of the query. In the query parameters you can refer to the
                    record fields using "record.field".
-                   """)
+                   """, extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
     @JsonProperty("loop-over")
     private String loopOver;
 
@@ -91,7 +92,7 @@ public class QueryConfiguration extends BaseGenAIStepConfiguration {
             description =
                     """
                    Fields of the record to use as input parameters for the query.
-                   """)
+                   """, extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
     private List<String> fields;
 
     @ConfigProperty(

--- a/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/QueryConfiguration.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/agents/ai/steps/QueryConfiguration.java
@@ -84,7 +84,8 @@ public class QueryConfiguration extends BaseGenAIStepConfiguration {
                    but be like "record.fieldname" in order to replace or set a field in each record
                    with the results of the query. In the query parameters you can refer to the
                    record fields using "record.field".
-                   """, extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
+                   """,
+            extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
     @JsonProperty("loop-over")
     private String loopOver;
 
@@ -92,7 +93,8 @@ public class QueryConfiguration extends BaseGenAIStepConfiguration {
             description =
                     """
                    Fields of the record to use as input parameters for the query.
-                   """, extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
+                   """,
+            extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
     private List<String> fields;
 
     @ConfigProperty(

--- a/langstream-core/src/main/java/ai/langstream/impl/uti/ClassConfigValidator.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/uti/ClassConfigValidator.java
@@ -45,6 +45,8 @@ import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
+
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -528,9 +530,18 @@ public class ClassConfigValidator {
             ExtendedValidationType extendedValidationType, Object actualValue) {
         switch (extendedValidationType) {
             case EL_EXPRESSION -> {
-                String expression = actualValue.toString();
-                log.info("Validating EL expression: {}", expression);
-                new JstlEvaluator(actualValue.toString(), Object.class);
+                if (actualValue instanceof String expression) {
+                    log.info("Validating EL expression: {}", expression);
+                    new JstlEvaluator(actualValue.toString(), Object.class);
+                } else if (actualValue instanceof Collection collection) {
+                    log.info("Validating EL expressions {}", collection);
+                    for (Object o : collection) {
+                        if (o == null) {
+                            throw new IllegalArgumentException("A null value is not allowed in a list of EL expressions");
+                        }
+                        new JstlEvaluator(o.toString(), Object.class);
+                    }
+                }
             }
             case NONE -> {}
         }

--- a/langstream-core/src/main/java/ai/langstream/impl/uti/ClassConfigValidator.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/uti/ClassConfigValidator.java
@@ -45,7 +45,6 @@ import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
-
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -537,7 +536,8 @@ public class ClassConfigValidator {
                     log.info("Validating EL expressions {}", collection);
                     for (Object o : collection) {
                         if (o == null) {
-                            throw new IllegalArgumentException("A null value is not allowed in a list of EL expressions");
+                            throw new IllegalArgumentException(
+                                    "A null value is not allowed in a list of EL expressions");
                         }
                         new JstlEvaluator(o.toString(), Object.class);
                     }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/FlowControlAgentsProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/FlowControlAgentsProvider.java
@@ -183,7 +183,6 @@ public class FlowControlAgentsProvider extends AbstractComposableAgentProvider {
                 extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
         @JsonProperty("when")
         String when;
-
     }
 
     @AgentConfig(

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/FlowControlAgentsProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/FlowControlAgentsProvider.java
@@ -163,7 +163,7 @@ public class FlowControlAgentsProvider extends AbstractComposableAgentProvider {
             name = "Log an event",
             description =
                     """
-            Emits a record on a side destination when a record is received.
+            Log a line in the agent logs when a record is received.
             """)
     @Data
     public static class LogEventProcessorConfig {

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/FlowControlAgentsProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/FlowControlAgentsProvider.java
@@ -43,8 +43,10 @@ public class FlowControlAgentsProvider extends AbstractComposableAgentProvider {
     protected static final String DISPATCH = "dispatch";
     protected static final String TIMER_SOURCE = "timer-source";
     protected static final String TRIGGER_EVENT = "trigger-event";
+
+    protected static final String LOG_EVENT = "log-event";
     private static final Set<String> SUPPORTED_AGENT_TYPES =
-            Set.of(DISPATCH, TIMER_SOURCE, TRIGGER_EVENT);
+            Set.of(DISPATCH, TIMER_SOURCE, TRIGGER_EVENT, LOG_EVENT);
 
     public FlowControlAgentsProvider() {
         super(SUPPORTED_AGENT_TYPES, List.of(KubernetesClusterRuntime.CLUSTER_TYPE, "none"));
@@ -56,6 +58,7 @@ public class FlowControlAgentsProvider extends AbstractComposableAgentProvider {
             case DISPATCH -> ComponentType.PROCESSOR;
             case TIMER_SOURCE -> ComponentType.SOURCE;
             case TRIGGER_EVENT -> ComponentType.PROCESSOR;
+            case LOG_EVENT -> ComponentType.PROCESSOR;
             default -> throw new IllegalArgumentException(
                     "Unsupported agent type: " + agentConfiguration.getType());
         };
@@ -126,6 +129,7 @@ public class FlowControlAgentsProvider extends AbstractComposableAgentProvider {
             case DISPATCH -> DispatchConfig.class;
             case TIMER_SOURCE -> TimeSourceConfig.class;
             case TRIGGER_EVENT -> TriggerEventProcessorConfig.class;
+            case LOG_EVENT -> LogEventProcessorConfig.class;
             default -> throw new IllegalArgumentException("Unsupported agent type: " + type);
         };
     }
@@ -153,6 +157,33 @@ public class FlowControlAgentsProvider extends AbstractComposableAgentProvider {
                 defaultValue = "60")
         @JsonProperty("period-seconds")
         int periodInSeconds;
+    }
+
+    @AgentConfig(
+            name = "Log an event",
+            description =
+                    """
+            Emits a record on a side destination when a record is received.
+            """)
+    @Data
+    public static class LogEventProcessorConfig {
+        @ConfigProperty(
+                description =
+                        """
+                        Fields to log.
+                                """)
+        List<FieldConfiguration> fields;
+
+        @ConfigProperty(
+                description =
+                        """
+                        Condition to trigger the operation. This is a standard EL expression.
+                                """,
+                defaultValue = "true",
+                extendedValidationType = ExtendedValidationType.EL_EXPRESSION)
+        @JsonProperty("when")
+        String when;
+
     }
 
     @AgentConfig(

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/KubernetesGenAIToolKitFunctionAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/KubernetesGenAIToolKitFunctionAgentProviderTest.java
@@ -130,607 +130,611 @@ class KubernetesGenAIToolKitFunctionAgentProviderTest {
 
         Assertions.assertEquals(
                 """
-                                                {
-                                                  "ai-chat-completions" : {
-                                                    "name" : "Compute chat completions",
-                                                    "description" : "Sends the messages to the AI Service to compute chat completions. The result is stored in the specified field.",
-                                                    "properties" : {
-                                                      "ai-service" : {
-                                                        "description" : "In case of multiple AI services configured, specify the id of the AI service to use.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "completion-field" : {
-                                                        "description" : "Field to use to store the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "frequency-penalty" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "log-field" : {
-                                                        "description" : "Field to use to store the log of the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.\\nThe log contains useful information for debugging the completion prompts.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "logit-bias" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "object"
-                                                      },
-                                                      "max-tokens" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "integer"
-                                                      },
-                                                      "messages" : {
-                                                        "description" : "Messages to use for chat completions. You can use the Mustache syntax.",
-                                                        "required" : true,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "Messages to use for chat completions. You can use the Mustache syntax.",
-                                                          "required" : true,
-                                                          "type" : "object",
-                                                          "properties" : {
-                                                            "content" : {
-                                                              "description" : "Content of the message. You can use the Mustache syntax.",
-                                                              "required" : true,
-                                                              "type" : "string"
-                                                            },
-                                                            "role" : {
-                                                              "description" : "Role of the message. The role is used to identify the speaker in the chat.",
-                                                              "required" : true,
-                                                              "type" : "string"
-                                                            }
-                                                          }
-                                                        }
-                                                      },
-                                                      "min-chunks-per-message" : {
-                                                        "description" : "Minimum number of chunks to send to the stream-to-topic topic. The chunks are sent as soon as they are available.\\nThe chunks are sent in the order they are received from the AI Service.\\nTo improve the TTFB (Time-To-First-Byte), the chunk size starts from 1 and doubles until it reaches the max-chunks-per-message value.",
-                                                        "required" : false,
-                                                        "type" : "integer",
-                                                        "defaultValue" : "20"
-                                                      },
-                                                      "model" : {
-                                                        "description" : "The model to use for chat completions. The model must be available in the AI Service.",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "options" : {
-                                                        "description" : "Additional options for the model configuration. The structure depends on the model and AI provider.",
-                                                        "required" : false,
-                                                        "type" : "object"
-                                                      },
-                                                      "presence-penalty" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "stop" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                          "required" : false,
-                                                          "type" : "string"
-                                                        }
-                                                      },
-                                                      "stream" : {
-                                                        "description" : "Enable streaming of the results. Use in conjunction with the stream-to-topic parameter.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "stream-response-completion-field" : {
-                                                        "description" : "Field to use to store the completion results in the stream-to-topic topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "stream-to-topic" : {
-                                                        "description" : "Enable streaming of the results. If enabled, the results are streamed to the specified topic in small chunks. The entire messages will be sent to the output topic instead.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "temperature" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "top-p" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "user" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "ai-text-completions" : {
-                                                    "name" : "Compute text completions",
-                                                    "description" : "Sends the text to the AI Service to compute text completions. The result is stored in the specified field.",
-                                                    "properties" : {
-                                                      "ai-service" : {
-                                                        "description" : "In case of multiple AI services configured, specify the id of the AI service to use.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "completion-field" : {
-                                                        "description" : "Field to use to store the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "frequency-penalty" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "log-field" : {
-                                                        "description" : "Field to use to store the log of the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.\\nThe log contains useful information for debugging the completion prompts.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "logit-bias" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "object"
-                                                      },
-                                                      "logprobs" : {
-                                                        "description" : "Logprobs parameter (only valid for OpenAI).",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "logprobs-field" : {
-                                                        "description" : "Log probabilities to a field.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "max-tokens" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "integer"
-                                                      },
-                                                      "min-chunks-per-message" : {
-                                                        "description" : "Minimum number of chunks to send to the stream-to-topic topic. The chunks are sent as soon as they are available.\\nThe chunks are sent in the order they are received from the AI Service.\\nTo improve the TTFB (Time-To-First-Byte), the chunk size starts from 1 and doubles until it reaches the max-chunks-per-message value.",
-                                                        "required" : false,
-                                                        "type" : "integer",
-                                                        "defaultValue" : "20"
-                                                      },
-                                                      "model" : {
-                                                        "description" : "The model to use for text completions. The model must be available in the AI Service.",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "options" : {
-                                                        "description" : "Additional options for the model configuration. The structure depends on the model and AI provider.",
-                                                        "required" : false,
-                                                        "type" : "object"
-                                                      },
-                                                      "presence-penalty" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "prompt" : {
-                                                        "description" : "Prompt to use for text completions. You can use the Mustache syntax.",
-                                                        "required" : true,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "Prompt to use for text completions. You can use the Mustache syntax.",
-                                                          "required" : true,
-                                                          "type" : "string"
-                                                        }
-                                                      },
-                                                      "stop" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                          "required" : false,
-                                                          "type" : "string"
-                                                        }
-                                                      },
-                                                      "stream" : {
-                                                        "description" : "Enable streaming of the results. Use in conjunction with the stream-to-topic parameter.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "stream-response-completion-field" : {
-                                                        "description" : "Field to use to store the completion results in the stream-to-topic topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "stream-to-topic" : {
-                                                        "description" : "Enable streaming of the results. If enabled, the results are streamed to the specified topic in small chunks. The entire messages will be sent to the output topic instead.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "temperature" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "top-p" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "number"
-                                                      },
-                                                      "user" : {
-                                                        "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "cast" : {
-                                                    "name" : "Cast record to another schema",
-                                                    "description" : "Transforms the data to a target compatible schema.\\nSome step operations like cast or compute involve conversions from a type to another. When this happens the rules are:\\n    - timestamp, date and time related object conversions assume UTC time zone if it is not explicit.\\n    - date and time related object conversions to/from STRING use the RFC3339 format.\\n    - timestamp related object conversions to/from LONG and DOUBLE are done using the number of milliseconds since EPOCH (1970-01-01T00:00:00Z).\\n    - date related object conversions to/from INTEGER, LONG, FLOAT and DOUBLE are done using the number of days since EPOCH (1970-01-01).\\n    - time related object conversions to/from INTEGER, LONG and DOUBLE are done using the number of milliseconds since midnight (00:00:00).",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "part" : {
-                                                        "description" : "When used with KeyValue data, defines if the transformation is done on the key or on the value. If empty, the transformation applies to both the key and the value.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "schema-type" : {
-                                                        "description" : "The target schema type.",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "compute" : {
-                                                    "name" : "Compute values from the record",
-                                                    "description" : "Computes new properties, values or field values based on an expression evaluated at runtime. If the field already exists, it will be overwritten.",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "fields" : {
-                                                        "description" : "An array of objects describing how to calculate the field values",
-                                                        "required" : true,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "An array of objects describing how to calculate the field values",
-                                                          "required" : true,
-                                                          "type" : "object",
-                                                          "properties" : {
-                                                            "expression" : {
-                                                              "description" : "It is evaluated at runtime and the result of the evaluation is assigned to the field.\\nRefer to the language expression documentation for more information on the expression syntax.",
-                                                              "required" : true,
-                                                              "type" : "string"
-                                                            },
-                                                            "name" : {
-                                                              "description" : "The name of the field to be computed. Prefix with key. or value. to compute the fields in the key or value parts of the message.\\nIn addition, you can compute values on the following message headers [destinationTopic, messageKey, properties.].\\nPlease note that properties is a map of key/value pairs that are referenced by the dot notation, for example properties.key0.",
-                                                              "required" : true,
-                                                              "type" : "string"
-                                                            },
-                                                            "optional" : {
-                                                              "description" : "If true, it marks the field as optional in the schema of the transformed message. This is useful when null is a possible value of the compute expression.",
-                                                              "required" : false,
-                                                              "type" : "boolean",
-                                                              "defaultValue" : "false"
-                                                            },
-                                                            "type" : {
-                                                              "description" : "The type of the computed field. This\\n will translate to the schema type of the new field in the transformed message.\\n The following types are currently supported :STRING, INT8, INT16, INT32, INT64, FLOAT, DOUBLE, BOOLEAN, DATE, TIME, TIMESTAMP, LOCAL_DATE_TIME, LOCAL_TIME, LOCAL_DATE, INSTANT.\\n  The type field is not required for the message headers [destinationTopic, messageKey, properties.] and STRING will be used.\\n  For the value and key, if it is not provided, then the type will be inferred from the result of the expression evaluation.",
-                                                              "required" : true,
-                                                              "type" : "string"
-                                                            }
-                                                          }
-                                                        }
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "compute-ai-embeddings" : {
-                                                    "name" : "Compute embeddings of the record",
-                                                    "description" : "Compute embeddings of the record. The embeddings are stored in the record under a specific field.",
-                                                    "properties" : {
-                                                      "ai-service" : {
-                                                        "description" : "In case of multiple AI services configured, specify the id of the AI service to use.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "arguments" : {
-                                                        "description" : "Additional arguments to pass to the AI Service. (HuggingFace only)",
-                                                        "required" : false,
-                                                        "type" : "object"
-                                                      },
-                                                      "batch-size" : {
-                                                        "description" : "Batch size for submitting the embeddings requests.",
-                                                        "required" : false,
-                                                        "type" : "integer",
-                                                        "defaultValue" : "10"
-                                                      },
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "concurrency" : {
-                                                        "description" : "Max number of concurrent requests to the AI Service.",
-                                                        "required" : false,
-                                                        "type" : "integer",
-                                                        "defaultValue" : "4"
-                                                      },
-                                                      "embeddings-field" : {
-                                                        "description" : "Field where to store the embeddings.",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "flush-interval" : {
-                                                        "description" : "Flushing is disabled by default in order to avoid latency spikes.\\nYou should enable this feature in the case of background processing.",
-                                                        "required" : false,
-                                                        "type" : "integer",
-                                                        "defaultValue" : "0"
-                                                      },
-                                                      "loop-over" : {
-                                                        "description" : "Execute the agent over a list of documents",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "model" : {
-                                                        "description" : "Model to use for the embeddings. The model must be available in the configured AI Service.",
-                                                        "required" : false,
-                                                        "type" : "string",
-                                                        "defaultValue" : "text-embedding-ada-002"
-                                                      },
-                                                      "model-url" : {
-                                                        "description" : "URL of the model to use. (HuggingFace only). The default is computed from the model: \\"djl://ai.djl.huggingface.pytorch/{model}\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "options" : {
-                                                        "description" : "Additional options to pass to the AI Service. (HuggingFace only)",
-                                                        "required" : false,
-                                                        "type" : "object"
-                                                      },
-                                                      "text" : {
-                                                        "description" : "Text to create embeddings from. You can use Mustache syntax to compose multiple fields into a single text. Example:\\ntext: \\"{{{ value.field1 }}} {{{ value.field2 }}}\\"",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "drop" : {
-                                                    "name" : "Drop the record",
-                                                    "description" : "Drops the record from further processing. Use in conjunction with when to selectively drop records.",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "drop-fields" : {
-                                                    "name" : "Drop fields",
-                                                    "description" : "Drops the record fields.",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "fields" : {
-                                                        "description" : "Fields to drop from the input record.",
-                                                        "required" : true,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "Fields to drop from the input record.",
-                                                          "required" : true,
-                                                          "type" : "string"
-                                                        }
-                                                      },
-                                                      "part" : {
-                                                        "description" : "Part to drop. (value or key)",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "flatten" : {
-                                                    "name" : "Flatten record fields",
-                                                    "description" : "Converts structured nested data into a new single-hierarchy-level structured data. The names of the new fields are built by concatenating the intermediate level field names.",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "delimiter" : {
-                                                        "description" : "The delimiter to use when concatenating the field names.",
-                                                        "required" : false,
-                                                        "type" : "string",
-                                                        "defaultValue" : "_"
-                                                      },
-                                                      "part" : {
-                                                        "description" : "When used with KeyValue data, defines if the transformation is done on the key or on the value. If empty, the transformation applies to both the key and the value.",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "merge-key-value" : {
-                                                    "name" : "Merge key-value format",
-                                                    "description" : "Merges the fields of KeyValue records where both the key and value are structured types of the same schema type. Only AVRO and JSON are supported.",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "query" : {
-                                                    "name" : "Query",
-                                                    "description" : "Perform a vector search or simple query against a datasource.",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "datasource" : {
-                                                        "description" : "Reference to a datasource id configured in the application.",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "fields" : {
-                                                        "description" : "Fields of the record to use as input parameters for the query.",
-                                                        "required" : false,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "Fields of the record to use as input parameters for the query.",
-                                                          "required" : false,
-                                                          "type" : "string"
-                                                        }
-                                                      },
-                                                      "generated-keys" : {
-                                                        "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
-                                                        "required" : false,
-                                                        "type" : "array",
-                                                        "items" : {
-                                                          "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
-                                                          "required" : false,
-                                                          "type" : "string"
-                                                        }
-                                                      },
-                                                      "loop-over" : {
-                                                        "description" : "Loop over a list of items taken from the record. For instance value.documents.\\nIt must refer to a list of maps. In this case the output-field parameter\\nbut be like \\"record.fieldname\\" in order to replace or set a field in each record\\nwith the results of the query. In the query parameters you can refer to the\\nrecord fields using \\"record.field\\".",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      },
-                                                      "mode" : {
-                                                        "description" : "Execution mode: query or execute. In query mode, the query is executed and the results are returned. In execute mode, the query is executed and the result is the number of rows affected (depending on the database).",
-                                                        "required" : false,
-                                                        "type" : "string",
-                                                        "defaultValue" : "query"
-                                                      },
-                                                      "only-first" : {
-                                                        "description" : "If true, only the first result of the query is stored in the output field.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "false"
-                                                      },
-                                                      "output-field" : {
-                                                        "description" : "The name of the field to use to store the query result.",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "query" : {
-                                                        "description" : "The query to use to extract the data.",
-                                                        "required" : true,
-                                                        "type" : "string"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "unwrap-key-value" : {
-                                                    "name" : "Unwrap key-value format",
-                                                    "description" : "If the record value is in KeyValue format, extracts the KeyValue's key or value and make it the record value.",
-                                                    "properties" : {
-                                                      "composable" : {
-                                                        "description" : "Whether this step can be composed with other steps.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "true"
-                                                      },
-                                                      "unwrapKey" : {
-                                                        "description" : "Whether to unwrap the key instead of the value.",
-                                                        "required" : false,
-                                                        "type" : "boolean",
-                                                        "defaultValue" : "false"
-                                                      },
-                                                      "when" : {
-                                                        "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
-                                                        "required" : false,
-                                                        "type" : "string"
-                                                      }
-                                                    }
-                                                  }
-                                                }""",
+                          {
+                            "ai-chat-completions" : {
+                              "name" : "Compute chat completions",
+                              "description" : "Sends the messages to the AI Service to compute chat completions. The result is stored in the specified field.",
+                              "properties" : {
+                                "ai-service" : {
+                                  "description" : "In case of multiple AI services configured, specify the id of the AI service to use.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "completion-field" : {
+                                  "description" : "Field to use to store the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "frequency-penalty" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "log-field" : {
+                                  "description" : "Field to use to store the log of the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.\\nThe log contains useful information for debugging the completion prompts.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "logit-bias" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "object"
+                                },
+                                "max-tokens" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "integer"
+                                },
+                                "messages" : {
+                                  "description" : "Messages to use for chat completions. You can use the Mustache syntax.",
+                                  "required" : true,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "Messages to use for chat completions. You can use the Mustache syntax.",
+                                    "required" : true,
+                                    "type" : "object",
+                                    "properties" : {
+                                      "content" : {
+                                        "description" : "Content of the message. You can use the Mustache syntax.",
+                                        "required" : true,
+                                        "type" : "string"
+                                      },
+                                      "role" : {
+                                        "description" : "Role of the message. The role is used to identify the speaker in the chat.",
+                                        "required" : true,
+                                        "type" : "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "min-chunks-per-message" : {
+                                  "description" : "Minimum number of chunks to send to the stream-to-topic topic. The chunks are sent as soon as they are available.\\nThe chunks are sent in the order they are received from the AI Service.\\nTo improve the TTFB (Time-To-First-Byte), the chunk size starts from 1 and doubles until it reaches the max-chunks-per-message value.",
+                                  "required" : false,
+                                  "type" : "integer",
+                                  "defaultValue" : "20"
+                                },
+                                "model" : {
+                                  "description" : "The model to use for chat completions. The model must be available in the AI Service.",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "options" : {
+                                  "description" : "Additional options for the model configuration. The structure depends on the model and AI provider.",
+                                  "required" : false,
+                                  "type" : "object"
+                                },
+                                "presence-penalty" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "stop" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  }
+                                },
+                                "stream" : {
+                                  "description" : "Enable streaming of the results. Use in conjunction with the stream-to-topic parameter.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "stream-response-completion-field" : {
+                                  "description" : "Field to use to store the completion results in the stream-to-topic topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "stream-to-topic" : {
+                                  "description" : "Enable streaming of the results. If enabled, the results are streamed to the specified topic in small chunks. The entire messages will be sent to the output topic instead.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "temperature" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "top-p" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "user" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "ai-text-completions" : {
+                              "name" : "Compute text completions",
+                              "description" : "Sends the text to the AI Service to compute text completions. The result is stored in the specified field.",
+                              "properties" : {
+                                "ai-service" : {
+                                  "description" : "In case of multiple AI services configured, specify the id of the AI service to use.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "completion-field" : {
+                                  "description" : "Field to use to store the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "frequency-penalty" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "log-field" : {
+                                  "description" : "Field to use to store the log of the completion results in the output topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.\\nThe log contains useful information for debugging the completion prompts.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "logit-bias" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "object"
+                                },
+                                "logprobs" : {
+                                  "description" : "Logprobs parameter (only valid for OpenAI).",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "logprobs-field" : {
+                                  "description" : "Log probabilities to a field.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "max-tokens" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "integer"
+                                },
+                                "min-chunks-per-message" : {
+                                  "description" : "Minimum number of chunks to send to the stream-to-topic topic. The chunks are sent as soon as they are available.\\nThe chunks are sent in the order they are received from the AI Service.\\nTo improve the TTFB (Time-To-First-Byte), the chunk size starts from 1 and doubles until it reaches the max-chunks-per-message value.",
+                                  "required" : false,
+                                  "type" : "integer",
+                                  "defaultValue" : "20"
+                                },
+                                "model" : {
+                                  "description" : "The model to use for text completions. The model must be available in the AI Service.",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "options" : {
+                                  "description" : "Additional options for the model configuration. The structure depends on the model and AI provider.",
+                                  "required" : false,
+                                  "type" : "object"
+                                },
+                                "presence-penalty" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "prompt" : {
+                                  "description" : "Prompt to use for text completions. You can use the Mustache syntax.",
+                                  "required" : true,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "Prompt to use for text completions. You can use the Mustache syntax.",
+                                    "required" : true,
+                                    "type" : "string"
+                                  }
+                                },
+                                "stop" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  }
+                                },
+                                "stream" : {
+                                  "description" : "Enable streaming of the results. Use in conjunction with the stream-to-topic parameter.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "stream-response-completion-field" : {
+                                  "description" : "Field to use to store the completion results in the stream-to-topic topic. Use \\"value\\" to write the result without a structured schema. Use \\"value.<field>\\" to write the result in a specific field.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "stream-to-topic" : {
+                                  "description" : "Enable streaming of the results. If enabled, the results are streamed to the specified topic in small chunks. The entire messages will be sent to the output topic instead.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "temperature" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "top-p" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "number"
+                                },
+                                "user" : {
+                                  "description" : "Parameter for the completion request. The parameters are passed to the AI Service as is.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "cast" : {
+                              "name" : "Cast record to another schema",
+                              "description" : "Transforms the data to a target compatible schema.\\nSome step operations like cast or compute involve conversions from a type to another. When this happens the rules are:\\n    - timestamp, date and time related object conversions assume UTC time zone if it is not explicit.\\n    - date and time related object conversions to/from STRING use the RFC3339 format.\\n    - timestamp related object conversions to/from LONG and DOUBLE are done using the number of milliseconds since EPOCH (1970-01-01T00:00:00Z).\\n    - date related object conversions to/from INTEGER, LONG, FLOAT and DOUBLE are done using the number of days since EPOCH (1970-01-01).\\n    - time related object conversions to/from INTEGER, LONG and DOUBLE are done using the number of milliseconds since midnight (00:00:00).",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "part" : {
+                                  "description" : "When used with KeyValue data, defines if the transformation is done on the key or on the value. If empty, the transformation applies to both the key and the value.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "schema-type" : {
+                                  "description" : "The target schema type.",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "compute" : {
+                              "name" : "Compute values from the record",
+                              "description" : "Computes new properties, values or field values based on an expression evaluated at runtime. If the field already exists, it will be overwritten.",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "fields" : {
+                                  "description" : "An array of objects describing how to calculate the field values",
+                                  "required" : true,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "An array of objects describing how to calculate the field values",
+                                    "required" : true,
+                                    "type" : "object",
+                                    "properties" : {
+                                      "expression" : {
+                                        "description" : "It is evaluated at runtime and the result of the evaluation is assigned to the field.\\nRefer to the language expression documentation for more information on the expression syntax.",
+                                        "required" : true,
+                                        "type" : "string",
+                                        "extendedValidationType" : "EL_EXPRESSION"
+                                      },
+                                      "name" : {
+                                        "description" : "The name of the field to be computed. Prefix with key. or value. to compute the fields in the key or value parts of the message.\\nIn addition, you can compute values on the following message headers [destinationTopic, messageKey, properties.].\\nPlease note that properties is a map of key/value pairs that are referenced by the dot notation, for example properties.key0.",
+                                        "required" : true,
+                                        "type" : "string"
+                                      },
+                                      "optional" : {
+                                        "description" : "If true, it marks the field as optional in the schema of the transformed message. This is useful when null is a possible value of the compute expression.",
+                                        "required" : false,
+                                        "type" : "boolean",
+                                        "defaultValue" : "false"
+                                      },
+                                      "type" : {
+                                        "description" : "The type of the computed field. This\\n will translate to the schema type of the new field in the transformed message.\\n The following types are currently supported :STRING, INT8, INT16, INT32, INT64, FLOAT, DOUBLE, BOOLEAN, DATE, TIME, TIMESTAMP, LOCAL_DATE_TIME, LOCAL_TIME, LOCAL_DATE, INSTANT.\\n  The type field is not required for the message headers [destinationTopic, messageKey, properties.] and STRING will be used.\\n  For the value and key, if it is not provided, then the type will be inferred from the result of the expression evaluation.",
+                                        "required" : true,
+                                        "type" : "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "compute-ai-embeddings" : {
+                              "name" : "Compute embeddings of the record",
+                              "description" : "Compute embeddings of the record. The embeddings are stored in the record under a specific field.",
+                              "properties" : {
+                                "ai-service" : {
+                                  "description" : "In case of multiple AI services configured, specify the id of the AI service to use.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "arguments" : {
+                                  "description" : "Additional arguments to pass to the AI Service. (HuggingFace only)",
+                                  "required" : false,
+                                  "type" : "object"
+                                },
+                                "batch-size" : {
+                                  "description" : "Batch size for submitting the embeddings requests.",
+                                  "required" : false,
+                                  "type" : "integer",
+                                  "defaultValue" : "10"
+                                },
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "concurrency" : {
+                                  "description" : "Max number of concurrent requests to the AI Service.",
+                                  "required" : false,
+                                  "type" : "integer",
+                                  "defaultValue" : "4"
+                                },
+                                "embeddings-field" : {
+                                  "description" : "Field where to store the embeddings.",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "flush-interval" : {
+                                  "description" : "Flushing is disabled by default in order to avoid latency spikes.\\nYou should enable this feature in the case of background processing.",
+                                  "required" : false,
+                                  "type" : "integer",
+                                  "defaultValue" : "0"
+                                },
+                                "loop-over" : {
+                                  "description" : "Execute the agent over a list of documents",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "model" : {
+                                  "description" : "Model to use for the embeddings. The model must be available in the configured AI Service.",
+                                  "required" : false,
+                                  "type" : "string",
+                                  "defaultValue" : "text-embedding-ada-002"
+                                },
+                                "model-url" : {
+                                  "description" : "URL of the model to use. (HuggingFace only). The default is computed from the model: \\"djl://ai.djl.huggingface.pytorch/{model}\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "options" : {
+                                  "description" : "Additional options to pass to the AI Service. (HuggingFace only)",
+                                  "required" : false,
+                                  "type" : "object"
+                                },
+                                "text" : {
+                                  "description" : "Text to create embeddings from. You can use Mustache syntax to compose multiple fields into a single text. Example:\\ntext: \\"{{{ value.field1 }}} {{{ value.field2 }}}\\"",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "drop" : {
+                              "name" : "Drop the record",
+                              "description" : "Drops the record from further processing. Use in conjunction with when to selectively drop records.",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "drop-fields" : {
+                              "name" : "Drop fields",
+                              "description" : "Drops the record fields.",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "fields" : {
+                                  "description" : "Fields to drop from the input record.",
+                                  "required" : true,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "Fields to drop from the input record.",
+                                    "required" : true,
+                                    "type" : "string"
+                                  }
+                                },
+                                "part" : {
+                                  "description" : "Part to drop. (value or key)",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "flatten" : {
+                              "name" : "Flatten record fields",
+                              "description" : "Converts structured nested data into a new single-hierarchy-level structured data. The names of the new fields are built by concatenating the intermediate level field names.",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "delimiter" : {
+                                  "description" : "The delimiter to use when concatenating the field names.",
+                                  "required" : false,
+                                  "type" : "string",
+                                  "defaultValue" : "_"
+                                },
+                                "part" : {
+                                  "description" : "When used with KeyValue data, defines if the transformation is done on the key or on the value. If empty, the transformation applies to both the key and the value.",
+                                  "required" : false,
+                                  "type" : "string"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "merge-key-value" : {
+                              "name" : "Merge key-value format",
+                              "description" : "Merges the fields of KeyValue records where both the key and value are structured types of the same schema type. Only AVRO and JSON are supported.",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "query" : {
+                              "name" : "Query",
+                              "description" : "Perform a vector search or simple query against a datasource.",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "datasource" : {
+                                  "description" : "Reference to a datasource id configured in the application.",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "fields" : {
+                                  "description" : "Fields of the record to use as input parameters for the query.",
+                                  "required" : false,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "Fields of the record to use as input parameters for the query.",
+                                    "required" : false,
+                                    "type" : "string",
+                                    "extendedValidationType" : "EL_EXPRESSION"
+                                  },
+                                  "extendedValidationType" : "EL_EXPRESSION"
+                                },
+                                "generated-keys" : {
+                                  "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
+                                  "required" : false,
+                                  "type" : "array",
+                                  "items" : {
+                                    "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
+                                    "required" : false,
+                                    "type" : "string"
+                                  }
+                                },
+                                "loop-over" : {
+                                  "description" : "Loop over a list of items taken from the record. For instance value.documents.\\nIt must refer to a list of maps. In this case the output-field parameter\\nbut be like \\"record.fieldname\\" in order to replace or set a field in each record\\nwith the results of the query. In the query parameters you can refer to the\\nrecord fields using \\"record.field\\".",
+                                  "required" : false,
+                                  "type" : "string",
+                                  "extendedValidationType" : "EL_EXPRESSION"
+                                },
+                                "mode" : {
+                                  "description" : "Execution mode: query or execute. In query mode, the query is executed and the results are returned. In execute mode, the query is executed and the result is the number of rows affected (depending on the database).",
+                                  "required" : false,
+                                  "type" : "string",
+                                  "defaultValue" : "query"
+                                },
+                                "only-first" : {
+                                  "description" : "If true, only the first result of the query is stored in the output field.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "false"
+                                },
+                                "output-field" : {
+                                  "description" : "The name of the field to use to store the query result.",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "query" : {
+                                  "description" : "The query to use to extract the data.",
+                                  "required" : true,
+                                  "type" : "string"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            },
+                            "unwrap-key-value" : {
+                              "name" : "Unwrap key-value format",
+                              "description" : "If the record value is in KeyValue format, extracts the KeyValue's key or value and make it the record value.",
+                              "properties" : {
+                                "composable" : {
+                                  "description" : "Whether this step can be composed with other steps.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "true"
+                                },
+                                "unwrapKey" : {
+                                  "description" : "Whether to unwrap the key instead of the value.",
+                                  "required" : false,
+                                  "type" : "boolean",
+                                  "defaultValue" : "false"
+                                },
+                                "when" : {
+                                  "description" : "Execute the step only when the condition is met.\\nYou can use the expression language to reference the message.\\nExample: when: \\"value.first == 'f1' && value.last.toUpperCase() == 'L1'\\"",
+                                  "required" : false,
+                                  "type" : "string"
+                                }
+                              }
+                            }
+                          }""",
                 SerializationUtil.prettyPrintJson(model));
     }
 }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
@@ -144,8 +144,10 @@ class QueryVectorDBAgentProviderTest {
                                 "items" : {
                                   "description" : "Fields of the record to use as input parameters for the query.",
                                   "required" : false,
-                                  "type" : "string"
-                                }
+                                  "type" : "string",
+                                  "extendedValidationType" : "EL_EXPRESSION"
+                                },
+                                "extendedValidationType" : "EL_EXPRESSION"
                               },
                               "generated-keys" : {
                                 "description" : "List of fields to use as generated keys. The generated keys are returned in the output, depending on the database.",
@@ -160,7 +162,8 @@ class QueryVectorDBAgentProviderTest {
                               "loop-over" : {
                                 "description" : "Loop over a list of items taken from the record. For instance value.documents.\\nIt must refer to a list of maps. In this case the output-field parameter\\nbut be like \\"record.fieldname\\" in order to replace or set a field in each record\\nwith the results of the query. In the query parameters you can refer to the\\nrecord fields using \\"record.field\\".",
                                 "required" : false,
-                                "type" : "string"
+                                "type" : "string",
+                                "extendedValidationType" : "EL_EXPRESSION"
                               },
                               "mode" : {
                                 "description" : "Execution mode: query or execute. In query mode, the query is executed and the results are returned. In execute mode, the query is executed and the result is the number of rows affected (depending on the database).",

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/SourceRecordTracker.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/SourceRecordTracker.java
@@ -67,7 +67,10 @@ class SourceRecordTracker {
                 sourceRecordsToCommit.add(record);
             } else {
                 if (log.isDebugEnabled()) {
-                    log.debug("record {} still has {} sink records to commit", record, remaining.get());
+                    log.debug(
+                            "record {} still has {} sink records to commit",
+                            record,
+                            remaining.get());
                 }
                 break;
             }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/SourceRecordTracker.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/SourceRecordTracker.java
@@ -66,7 +66,9 @@ class SourceRecordTracker {
             if (remaining.get() == 0) {
                 sourceRecordsToCommit.add(record);
             } else {
-                log.info("record {} still has {} sink records to commit", record, remaining.get());
+                if (log.isDebugEnabled()) {
+                    log.debug("record {} still has {} sink records to commit", record, remaining.get());
+                }
                 break;
             }
         }


### PR DESCRIPTION
Summary:
- add new EL function fn:toSQLTimestamp to work with SQL databases (like PostGRE)
- add automatic purge of the chat history in the PostgreSQL chat history example application
- add automatic deletion of stale chunks in the webcrawler and the docker-chatbot example applications
- reduce logging
- add a new "log-event" agent, that allows you to write to the log in order to debug what's happening in the pipeline