### PR TITLE
Add example application about how to write to Slack using the http-request agent

### DIFF
--- a/examples/applications/slack/README.md
+++ b/examples/applications/slack/README.md
@@ -1,0 +1,19 @@
+# Slack channel witer
+
+This sample application shows how to iwrite to a slack channel
+
+
+## Deploy the LangStream application
+```
+langstream docker run slack -app examples/applications/slack -i examples/instances/kafka-docker.yaml  -s examples/secrets/secrets.yaml --docker-args -u --docker-args 0
+```
+
+## write
+
+Since the application opens a gateway, we can use the gateway API to send and consume messages using the use gateway `chat` feature:
+```
+langstream gateway produce slack produce-input -p sessionId=$(uuidgen) -v "hello"
+```
+
+This is currently working because the slack message and token are hardcoded and need to be referenced by variables.
+

--- a/examples/applications/slack/README.md
+++ b/examples/applications/slack/README.md
@@ -1,7 +1,9 @@
 # Slack channel witer
 
-This sample application shows how to iwrite to a slack channel
+This sample application shows how to write to a slack channel
 
+Export the slack incoming webhook (token) (iwebhooks are locked to slack apps channels at creation):
+export SLACK_TOKEN="<token>"
 
 ## Deploy the LangStream application
 ```

--- a/examples/applications/slack/README.md
+++ b/examples/applications/slack/README.md
@@ -5,7 +5,7 @@ This sample application shows how to iwrite to a slack channel
 
 ## Deploy the LangStream application
 ```
-langstream docker run slack -app examples/applications/slack -i examples/instances/kafka-docker.yaml  -s examples/secrets/secrets.yaml --docker-args -u --docker-args 0
+langstream docker run slack -app examples/applications/slack -i examples/instances/kafka-docker.yaml  -s examples/secrets/secrets.yaml
 ```
 
 ## write

--- a/examples/applications/slack/configuration.yaml
+++ b/examples/applications/slack/configuration.yaml
@@ -1,0 +1,25 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+configuration:
+  resources:
+    - type: "slack-configuration"
+      name: "slack configuration"
+      configuration:
+        url: "${secrets.slack.url}"
+        access-key: "${secrets.slack.access-key}"
+        provider: "${secrets.slack.provider}"

--- a/examples/applications/slack/configuration.yaml
+++ b/examples/applications/slack/configuration.yaml
@@ -16,10 +16,7 @@
 #
 
 configuration:
-  resources:
-    - type: "slack-configuration"
-      name: "slack configuration"
-      configuration:
-        url: "${secrets.slack.url}"
-        access-key: "${secrets.slack.access-key}"
-        provider: "${secrets.slack.provider}"
+  defaults:
+    globals:
+      slack:
+        url: "https://hooks.slack.com/services/"

--- a/examples/applications/slack/gateways.yaml
+++ b/examples/applications/slack/gateways.yaml
@@ -1,0 +1,27 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+gateways:
+  - id: produce-input
+    type: produce
+    topic: input-topic
+    parameters:
+      - sessionId
+    produce-options:
+      headers:
+        - key: langstream-client-session-id
+          value-from-parameters: sessionId        

--- a/examples/applications/slack/pipeline.yaml
+++ b/examples/applications/slack/pipeline.yaml
@@ -26,7 +26,7 @@ pipeline:
   - name: "submit to slack API"
     type: "http-request"
     configuration:
-        url: "https://hooks.slack.com/services/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"
-        body: '{"text":"hello from langstream"}'
-        output-field: "field"
-        method: "POST"
+      url: "https://hooks.slack.com/services/${secrets.slack.token}"
+      body: '{"text":"{{ value.text }}"}'
+      output-field: "field"
+      method: "POST"

--- a/examples/applications/slack/pipeline.yaml
+++ b/examples/applications/slack/pipeline.yaml
@@ -28,5 +28,5 @@ pipeline:
     configuration:
       url: "${globals.slack.url}${secrets.slack.token}"
       body: '{"text":"{{ value.text }}"}'
-      output-field: "field"
+      output-field: "value.response"
       method: "POST"

--- a/examples/applications/slack/pipeline.yaml
+++ b/examples/applications/slack/pipeline.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+topics:
+  - name: "input-topic"
+    creation-mode: create-if-not-exists
+pipeline:
+  - name: "convert-to-json"
+    type: "document-to-json"
+    input: "input-topic"
+    configuration:
+      text-field: "text"
+  - name: "submit to slack API"
+    type: "http-request"
+    configuration:
+        url: "https://hooks.slack.com/services/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"
+        body: '{"text":"hello from langstream"}'
+        output-field: "field"
+        method: "POST"

--- a/examples/applications/slack/pipeline.yaml
+++ b/examples/applications/slack/pipeline.yaml
@@ -26,7 +26,7 @@ pipeline:
   - name: "submit to slack API"
     type: "http-request"
     configuration:
-      url: "https://hooks.slack.com/services/${secrets.slack.token}"
+      url: "${globals.slack.url}${secrets.slack.token}"
       body: '{"text":"{{ value.text }}"}'
       output-field: "field"
       method: "POST"

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -124,3 +124,11 @@ secrets:
       secret-key: "${BEDROCK_SECRET_KEY}"
       region: "${REGION:-us-east-1}"
       completions-model: "${BEDROCK_COMPLETIONS_MODEL}"
+  - id: slack 
+    data:
+      token: "${SLACK_TOKEN:-}"
+      url: "${SLACK_URL:-}"
+      provider: "${SLACK_PROVIDER:-slack}"
+#      embeddings-model: "${OPEN_AI_EMBEDDINGS_MODEL:-text-embedding-ada-002}"
+#      chat-completions-model: "${OPEN_AI_CHAT_COMPLETIONS_MODEL:-gpt-3.5-turbo}"
+#      text-completions-model: "${OPEN_AI_TEXT_COMPLETIONS_MODEL:-gpt-3.5-turbo-instruct}"


### PR DESCRIPTION
Just couldn't figure out how to incorporate variables.  Looked at the documentation, but not enough there.  Will need to look at the code for answers. Everything is in langstream/examples/applications/slack.  README.md contains commands I used to start langstream and send a request.