### PR TITLE
CLI: fix temp file permissions

### DIFF
--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,19 +1,3 @@
-#
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -413,8 +413,10 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
 
     private File prepareAppDirectory(File appDirectory) throws IOException {
         // depending on the docker engine, we should ensure the permissions are properly set.
-        // On MacOs, Docker runs on a VM, so the user mapping between the host and the container is performed by the engine.
-        // On Linux, we need to make sure all the mounted volumes are readable from others because the docker container runs with a different user than the file owner.
+        // On MacOs, Docker runs on a VM, so the user mapping between the host and the container is
+        // performed by the engine.
+        // On Linux, we need to make sure all the mounted volumes are readable from others because
+        // the docker container runs with a different user than the file owner.
         if (SystemUtils.IS_OS_MAC) {
             return appDirectory;
         }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -272,7 +272,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         log("Cleaning environment");
         for (Path temporaryFile : temporaryFiles) {
             debug("Deleting temporary file: " + temporaryFile);
-            // FileUtils.deleteQuietly(temporaryFile.toFile());
+            FileUtils.deleteQuietly(temporaryFile.toFile());
         }
     }
 
@@ -416,11 +416,12 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
             for (File child : file.listFiles()) {
                 makeDirOrFileReadable(child);
             }
-            Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("rwxr-xr-x"));
+            Files.setPosixFilePermissions(
+                    file.toPath(), PosixFilePermissions.fromString("rwxr-xr-x"));
         } else {
-            Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("rw-r--r--"));
+            Files.setPosixFilePermissions(
+                    file.toPath(), PosixFilePermissions.fromString("rw-r--r--"));
         }
-
     }
 
     @SneakyThrows

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -272,7 +272,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         log("Cleaning environment");
         for (Path temporaryFile : temporaryFiles) {
             debug("Deleting temporary file: " + temporaryFile);
-            FileUtils.deleteQuietly(temporaryFile.toFile());
+            // FileUtils.deleteQuietly(temporaryFile.toFile());
         }
     }
 
@@ -416,8 +416,11 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
             for (File child : file.listFiles()) {
                 makeDirOrFileReadable(child);
             }
+            Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("rwxr-xr-x"));
+        } else {
+            Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("rw-r--r--"));
         }
-        Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("rw-r--r--"));
+
     }
 
     @SneakyThrows

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -21,7 +21,6 @@ import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.applications.CommandTestBase;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
@@ -89,19 +88,22 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                     try {
                         posixFilePermissions = Files.getPosixFilePermissions(file.toPath());
                         if (file.getName().contains("app")) {
-                            assertEquals(Set.of(
-                                    PosixFilePermission.OWNER_READ,
-                                    PosixFilePermission.OWNER_WRITE,
-                                    PosixFilePermission.GROUP_READ,
-                                    PosixFilePermission.OTHERS_READ,
-                                    PosixFilePermission.OWNER_EXECUTE,
-                                    PosixFilePermission.GROUP_EXECUTE,
-                                    PosixFilePermission.OTHERS_EXECUTE
-                            ), posixFilePermissions);
+                            assertEquals(
+                                    Set.of(
+                                            PosixFilePermission.OWNER_READ,
+                                            PosixFilePermission.OWNER_WRITE,
+                                            PosixFilePermission.GROUP_READ,
+                                            PosixFilePermission.OTHERS_READ,
+                                            PosixFilePermission.OWNER_EXECUTE,
+                                            PosixFilePermission.GROUP_EXECUTE,
+                                            PosixFilePermission.OTHERS_EXECUTE),
+                                    posixFilePermissions);
                             assertTrue(file.isDirectory());
                             final String[] children = file.list();
                             assertEquals(1, children.length);
-                            assertFileReadable(Files.getPosixFilePermissions(Path.of(file.getAbsolutePath(), children[0])));
+                            assertFileReadable(
+                                    Files.getPosixFilePermissions(
+                                            Path.of(file.getAbsolutePath(), children[0])));
                         } else {
                             assertFileReadable(posixFilePermissions);
                         }
@@ -119,11 +121,13 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
     }
 
     private void assertFileReadable(Set<PosixFilePermission> posixFilePermissions) {
-        assertEquals(Set.of(
-                PosixFilePermission.OWNER_READ,
-                PosixFilePermission.OWNER_WRITE,
-                PosixFilePermission.GROUP_READ,
-                PosixFilePermission.OTHERS_READ), posixFilePermissions);
+        assertEquals(
+                Set.of(
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.GROUP_READ,
+                        PosixFilePermission.OTHERS_READ),
+                posixFilePermissions);
     }
 
     private static List<String> extractVolumes(String input) {

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.commands.applications.CommandTestBase;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
@@ -64,16 +63,16 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
         assertTrue(
                 lastLine.contains(
                         "run --rm -i -e START_BROKER=true -e START_MINIO=true -e START_HERDDB=true "
-                        + "-e LANSGSTREAM_TESTER_TENANT=default -e LANSGSTREAM_TESTER_APPLICATIONID=my-app "
-                        + "-e LANSGSTREAM_TESTER_STARTWEBSERVICES=true -e LANSGSTREAM_TESTER_DRYRUN=false "));
+                                + "-e LANSGSTREAM_TESTER_TENANT=default -e LANSGSTREAM_TESTER_APPLICATIONID=my-app "
+                                + "-e LANSGSTREAM_TESTER_STARTWEBSERVICES=true -e LANSGSTREAM_TESTER_DRYRUN=false "));
         assertTrue(
                 lastLine.contains(
                         "--add-host minio.minio-dev.svc.cluster.local:127.0.0.1 "
-                        + "--add-host herddb.herddb-dev.svc.cluster.local:127.0.0.1 "
-                        + "--add-host my-cluster-kafka-bootstrap.kafka:127.0.0.1 "
-                        + "-p 8091:8091 "
-                        + "-p 8090:8090 "
-                        + "ghcr.io/langstream/langstream-runtime-tester:unknown"));
+                                + "--add-host herddb.herddb-dev.svc.cluster.local:127.0.0.1 "
+                                + "--add-host my-cluster-kafka-bootstrap.kafka:127.0.0.1 "
+                                + "-p 8091:8091 "
+                                + "-p 8090:8090 "
+                                + "ghcr.io/langstream/langstream-runtime-tester:unknown"));
 
         final List<String> volumes = extractVolumes(lastLine);
         assertEquals(3, volumes.size());
@@ -85,7 +84,8 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
             final Path langstreamTmp =
                     Path.of(System.getProperty("user.home"), ".langstream", "tmp");
 
-            final Set<PosixFilePermission> posixFilePermissions = Files.getPosixFilePermissions(file.toPath());
+            final Set<PosixFilePermission> posixFilePermissions =
+                    Files.getPosixFilePermissions(file.toPath());
             if (file.isDirectory()) {
                 if (SystemUtils.IS_OS_MAC) {
                     assertNotEquals(langstreamTmp, file.toPath().getParent());


### PR DESCRIPTION
After the recent changes on 0.3.0, the temporary directory containing the application is only readable (not executable). UNIX permissions require the "execute" permission on a directory to perform listing

Since on Mac copying the app directory is not needed, we only perform the copy on linux