### PR TITLE
Add post-release test for brew and CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,3 +101,7 @@ jobs:
           homebrew-tap: LangStream/homebrew-langstream
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+
+      - uses: ./.github/workflows/test-cli-macos.yml
+        with:
+          version: ${{ steps.vars.outputs.version }}

--- a/.github/workflows/test-cli-macos.yml
+++ b/.github/workflows/test-cli-macos.yml
@@ -1,0 +1,54 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: LangStream Release CLI Tests
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  test-with-homebrew:
+    name: Test
+    runs-on: macos-latest
+    steps:
+      - name: 'Setup: checkout project'
+        uses: actions/checkout@v2
+      - name: 'Setup: Java 17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17.x'
+      - name: 'Setup: Docker'
+        run: |
+          set -e
+          brew install docker
+          colima start
+
+      - name: 'Test'
+        run: |
+          set -e
+          ./dev/cli-post-release-tests.sh "${{ inputs.version || github.event.inputs.version }}"

--- a/dev/cli-post-release-tests.sh
+++ b/dev/cli-post-release-tests.sh
@@ -1,0 +1,32 @@
+#
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+version=$1
+if [ -z "$version" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+brew install LangStream/langstream/langstream
+langstream -V
+langstream -V | grep $version
+langstream -h | grep "Usage: langstream"
+
+./mvnw -ntp install -pl langstream-e2e-tests -am -DskipTests -Dspotless.skip -Dlicense.skip
+./mvnw -ntp verify -pl langstream-e2e-tests -De2eTests -Dgroups="cli"


### PR DESCRIPTION
* After the release we run a test that
  * Run brew install to get the CLI
  * It verifies the expected version
  * It runs a e2e test with the downloaded binary