### PR TITLE
Add persistent state directory to python agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,9 @@ jobs:
       - name: Run tests
         run: |
           set -e
-          ./docker/build.sh runtime-base-docker-image && ./docker/build.sh runtime && ./docker/build.sh runtime-tester 
+          ./docker/build.sh runtime-base-docker-image
+          ./docker/build.sh runtime 
+          ./docker/build.sh runtime-tester 
           ./mvnw -ntp install -pl langstream-e2e-tests -DskipTests -Dspotless.skip -Dlicense.skip
           export LANGSTREAM_TESTS_CLI_BIN=$(pwd)/bin/langstream
           ./mvnw -ntp verify -pl langstream-e2e-tests -De2eTests -Dgroups="cli"

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
@@ -30,7 +30,7 @@ public class PythonGrpcAgentProcessor extends GrpcAgentProcessor {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration);
+        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
@@ -30,7 +30,9 @@ public class PythonGrpcAgentProcessor extends GrpcAgentProcessor {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
+        server =
+                new PythonGrpcServer(
+                        agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
@@ -30,7 +30,7 @@ public class PythonGrpcAgentProcessor extends GrpcAgentProcessor {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentContext);
+        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
@@ -30,7 +30,9 @@ public class PythonGrpcAgentSink extends GrpcAgentSink {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
+        server =
+                new PythonGrpcServer(
+                        agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
@@ -30,7 +30,7 @@ public class PythonGrpcAgentSink extends GrpcAgentSink {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration);
+        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
@@ -30,7 +30,7 @@ public class PythonGrpcAgentSink extends GrpcAgentSink {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentContext);
+        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
@@ -30,7 +30,7 @@ public class PythonGrpcAgentSource extends GrpcAgentSource {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration);
+        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
@@ -30,7 +30,7 @@ public class PythonGrpcAgentSource extends GrpcAgentSource {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentContext);
+        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
@@ -30,7 +30,9 @@ public class PythonGrpcAgentSource extends GrpcAgentSource {
 
     @Override
     public void start() throws Exception {
-        server = new PythonGrpcServer(agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
+        server =
+                new PythonGrpcServer(
+                        agentContext.getCodeDirectory(), configuration, agentId(), agentContext);
         channel = server.start();
         super.start();
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
@@ -37,7 +37,11 @@ public class PythonGrpcServer {
     private final AgentContext agentContext;
     private Process pythonProcess;
 
-    public PythonGrpcServer(Path codeDirectory, Map<String, Object> configuration, String agentId, AgentContext agentContext) {
+    public PythonGrpcServer(
+            Path codeDirectory,
+            Map<String, Object> configuration,
+            String agentId,
+            AgentContext agentContext) {
         this.codeDirectory = codeDirectory;
         this.configuration = configuration;
         this.agentId = agentId;
@@ -104,8 +108,12 @@ public class PythonGrpcServer {
         final Optional<Path> persistentStateDirectoryForAgent =
                 agentContext.getPersistentStateDirectoryForAgent(agentId);
 
-        final String persistentStateDirectory = persistentStateDirectoryForAgent.map(p -> p.toFile().getAbsolutePath()).orElse(null);
-        AgentContextConfiguration agentContextConfiguration = new AgentContextConfiguration(persistentStateDirectory);
+        final String persistentStateDirectory =
+                persistentStateDirectoryForAgent
+                        .map(p -> p.toFile().getAbsolutePath())
+                        .orElse(null);
+        AgentContextConfiguration agentContextConfiguration =
+                new AgentContextConfiguration(persistentStateDirectory);
         return agentContextConfiguration;
     }
 

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
@@ -33,12 +33,14 @@ public class PythonGrpcServer {
 
     private final Path codeDirectory;
     private final Map<String, Object> configuration;
+    private final String agentId;
     private final AgentContext agentContext;
     private Process pythonProcess;
 
-    public PythonGrpcServer(Path codeDirectory, Map<String, Object> configuration, AgentContext agentContext) {
+    public PythonGrpcServer(Path codeDirectory, Map<String, Object> configuration, String agentId, AgentContext agentContext) {
         this.codeDirectory = codeDirectory;
         this.configuration = configuration;
+        this.agentId = agentId;
         this.agentContext = agentContext;
     }
 
@@ -100,7 +102,7 @@ public class PythonGrpcServer {
 
     private AgentContextConfiguration computeAgentContextConfiguration() {
         final Optional<Path> persistentStateDirectoryForAgent =
-                agentContext.getPersistentStateDirectoryForAgent(agentContext.getAgentId());
+                agentContext.getPersistentStateDirectoryForAgent(agentId);
 
         final String persistentStateDirectory = persistentStateDirectoryForAgent.map(p -> p.toFile().getAbsolutePath()).orElse(null);
         AgentContextConfiguration agentContextConfiguration = new AgentContextConfiguration(persistentStateDirectory);

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.agents.grpc;
 
+import ai.langstream.api.runner.code.AgentContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;
@@ -22,6 +23,7 @@ import io.grpc.ManagedChannelBuilder;
 import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,11 +33,13 @@ public class PythonGrpcServer {
 
     private final Path codeDirectory;
     private final Map<String, Object> configuration;
+    private final AgentContext agentContext;
     private Process pythonProcess;
 
-    public PythonGrpcServer(Path codeDirectory, Map<String, Object> configuration) {
+    public PythonGrpcServer(Path codeDirectory, Map<String, Object> configuration, AgentContext agentContext) {
         this.codeDirectory = codeDirectory;
         this.configuration = configuration;
+        this.agentContext = agentContext;
     }
 
     public ManagedChannel start() throws Exception {
@@ -57,6 +61,8 @@ public class PythonGrpcServer {
                                 pythonCodeDirectory.toAbsolutePath(),
                                 pythonCodeDirectory.resolve("lib").toAbsolutePath());
 
+        AgentContextConfiguration agentContextConfiguration = computeAgentContextConfiguration();
+
         // copy input/output to standard input/output of the java process
         // this allows to use "kubectl logs" easily
         ProcessBuilder processBuilder =
@@ -65,7 +71,8 @@ public class PythonGrpcServer {
                                 "-m",
                                 "langstream_grpc",
                                 "[::]:%s".formatted(port),
-                                MAPPER.writeValueAsString(configuration))
+                                MAPPER.writeValueAsString(configuration),
+                                MAPPER.writeValueAsString(agentContextConfiguration))
                         .inheritIO()
                         .redirectOutput(ProcessBuilder.Redirect.INHERIT)
                         .redirectError(ProcessBuilder.Redirect.INHERIT);
@@ -91,6 +98,15 @@ public class PythonGrpcServer {
         return channel;
     }
 
+    private AgentContextConfiguration computeAgentContextConfiguration() {
+        final Optional<Path> persistentStateDirectoryForAgent =
+                agentContext.getPersistentStateDirectoryForAgent(agentContext.getAgentId());
+
+        final String persistentStateDirectory = persistentStateDirectoryForAgent.map(p -> p.toFile().getAbsolutePath()).orElse(null);
+        AgentContextConfiguration agentContextConfiguration = new AgentContextConfiguration(persistentStateDirectory);
+        return agentContextConfiguration;
+    }
+
     public void close() throws Exception {
         if (pythonProcess != null) {
             pythonProcess.destroy();
@@ -102,4 +118,6 @@ public class PythonGrpcServer {
             }
         }
     }
+
+    public record AgentContextConfiguration(String persistentStateDirectory) {}
 }

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
@@ -156,9 +156,9 @@ public class BaseEndToEndTest implements TestWatcher {
     }
 
     private static void dumpTest(String prefix) {
-        dumpAllPodsLogs(prefix);
+        dumpAllPodsLogs(prefix + ".logs");
         dumpEvents(prefix);
-        dumpAllResources(prefix);
+        dumpAllResources(prefix + ".resource");
         dumpProcessOutput(prefix, "kubectl-nodes", "kubectl describe nodes".split(" "));
     }
 
@@ -558,7 +558,8 @@ public class BaseEndToEndTest implements TestWatcher {
 
     @AfterEach
     public void cleanupAfterEach() {
-        cleanupAllEndToEndTestsNamespaces();
+        // do not cleanup langstream tenant here otherwise we won't get the logs in case of test
+        // failed
         cleanupEnv();
     }
 
@@ -688,6 +689,8 @@ public class BaseEndToEndTest implements TestWatcher {
                               agentResources:
                                 cpuPerUnit: %s
                                 memPerUnit: %s
+                                storageClassesMapping:
+                                    default: standard
                         client:
                           image:
                             repository: %s/langstream-cli
@@ -941,7 +944,7 @@ public class BaseEndToEndTest implements TestWatcher {
         final File outputFile =
                 new File(
                         TEST_LOGS_DIR,
-                        "%s-%s-%s.txt"
+                        "%s.%s.%s.txt"
                                 .formatted(
                                         filePrefix,
                                         resource.getKind(),

--- a/langstream-e2e-tests/src/test/resources/apps/python-processor/pipeline.yaml
+++ b/langstream-e2e-tests/src/test/resources/apps/python-processor/pipeline.yaml
@@ -35,6 +35,9 @@ pipeline:
   - name: "Process using Python"
     resources:
       size: 2
+      disk:
+        enabled: true
+        size: 50M
     id: "test-python-processor"
     type: "python-processor"
     input: ls-test-topic0

--- a/langstream-e2e-tests/src/test/resources/apps/python-processor/python/example.py
+++ b/langstream-e2e-tests/src/test/resources/apps/python-processor/python/example.py
@@ -20,14 +20,14 @@ import logging, os
 
 class Exclamation(Processor):
     def init(self, config, context: AgentContext):
-        print("init", config)
+        print("init", config, context)
         self.secret_value = config["secret_value"]
         self.context = context
 
     def process(self, record):
         logging.info("Processing record" + str(record))
         directory = self.context.get_persistent_state_directory()
-        counter_file = os.path.resolve(directory, "counter.txt")
+        counter_file = os.path.join(directory, "counter.txt")
         counter = 0
         if os.path.exists(counter_file):
             with open(counter_file, "r") as f:

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/Pipfile
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/Pipfile
@@ -1,4 +1,4 @@
-[packages]
+    [packages]
 grpcio = "*"
 fastavro = "*"
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/Pipfile
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/Pipfile
@@ -1,4 +1,4 @@
-    [packages]
+[packages]
 grpcio = "*"
 fastavro = "*"
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/__init__.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/__init__.py
@@ -15,15 +15,7 @@
 # limitations under the License.
 #
 
-from .api import (
-    Agent,
-    Record,
-    RecordType,
-    Sink,
-    Source,
-    Processor,
-    AgentContext
-)
+from .api import Agent, Record, RecordType, Sink, Source, Processor, AgentContext
 from .util import SimpleRecord, AvroValue
 
 __all__ = [
@@ -35,5 +27,5 @@ __all__ = [
     "Processor",
     "SimpleRecord",
     "AvroValue",
-    "AgentContext"
+    "AgentContext",
 ]

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/__init__.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/__init__.py
@@ -22,6 +22,7 @@ from .api import (
     Sink,
     Source,
     Processor,
+    AgentContext
 )
 from .util import SimpleRecord, AvroValue
 
@@ -34,4 +35,5 @@ __all__ = [
     "Processor",
     "SimpleRecord",
     "AvroValue",
+    "AgentContext"
 ]

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/api.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/api.py
@@ -65,10 +65,6 @@ RecordType = Union[Record, dict, list, tuple]
 class AgentContext(ABC):
     """The Agent context interface"""
 
-    def __init__(self):
-        """Initialize the agent context."""
-        pass
-
     @abstractmethod
     def get_persistent_state_directory(self):
         """Return a path pointing to the stateful agent directory. Return None if not configured in the agent."""

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/api.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/api.py
@@ -26,6 +26,7 @@ __all__ = [
     "Source",
     "Sink",
     "Processor",
+    "AgentContext"
 ]
 
 
@@ -60,11 +61,25 @@ class Record(ABC):
 
 RecordType = Union[Record, dict, list, tuple]
 
+class AgentContext(ABC):
+    """The Agent context interface"""
+
+    def __init__(self):
+        """Initialize the agent context."""
+        pass
+
+
+    @abstractmethod
+    def get_persistent_state_directory(self):
+        """Return a path pointing to the stateful agent directory. Return None if not configured in the agent."""
+        pass
+
+
 
 class Agent(ABC):
     """The Agent interface"""
 
-    def init(self, config: Dict[str, Any]):
+    def init(self, config: Dict[str, Any], context: AgentContext):
         """Initialize the agent from the given configuration."""
         pass
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/api.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream/api.py
@@ -26,7 +26,7 @@ __all__ = [
     "Source",
     "Sink",
     "Processor",
-    "AgentContext"
+    "AgentContext",
 ]
 
 
@@ -61,6 +61,7 @@ class Record(ABC):
 
 RecordType = Union[Record, dict, list, tuple]
 
+
 class AgentContext(ABC):
     """The Agent context interface"""
 
@@ -68,12 +69,10 @@ class AgentContext(ABC):
         """Initialize the agent context."""
         pass
 
-
     @abstractmethod
     def get_persistent_state_directory(self):
         """Return a path pointing to the stateful agent directory. Return None if not configured in the agent."""
         pass
-
 
 
 class Agent(ABC):

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/__main__.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/__main__.py
@@ -27,15 +27,12 @@ if __name__ == "__main__":
         datefmt="%H:%M:%S",
     )
 
-    if len(sys.argv) <= 3:
-        print("Missing gRPC target and python class name")
-        print("usage: python -m langstream_grpc <target> <config>")
+    if len(sys.argv) != 4:
+        print("Missing gRPC target or config or agent context")
+        print("usage: python -m langstream_grpc <target> <config> <agent_context_config>")
         sys.exit(1)
 
-    context_config = {}
-    if len(sys.argv) > 3:
-        context_config = sys.argv[3]
-    server = AgentServer(sys.argv[1], sys.argv[2], context_config)
+    server = AgentServer(sys.argv[1], sys.argv[2], sys.argv[3])
     server.start()
     server.grpc_server.wait_for_termination()
     server.stop()

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/__main__.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/__main__.py
@@ -27,12 +27,15 @@ if __name__ == "__main__":
         datefmt="%H:%M:%S",
     )
 
-    if len(sys.argv) != 3:
+    if len(sys.argv) <= 3:
         print("Missing gRPC target and python class name")
         print("usage: python -m langstream_grpc <target> <config>")
         sys.exit(1)
 
-    server = AgentServer(sys.argv[1], sys.argv[2])
+    context_config = {}
+    if len(sys.argv) > 3:
+        context_config = sys.argv[3]
+    server = AgentServer(sys.argv[1], sys.argv[2], context_config)
     server.start()
     server.grpc_server.wait_for_termination()
     server.stop()

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/__main__.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/__main__.py
@@ -29,7 +29,9 @@ if __name__ == "__main__":
 
     if len(sys.argv) != 4:
         print("Missing gRPC target or config or agent context")
-        print("usage: python -m langstream_grpc <target> <config> <agent_context_config>")
+        print(
+            "usage: python -m langstream_grpc <target> <config> <agent_context_config>"
+        )
         sys.exit(1)
 
     server = AgentServer(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/api.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/api.py
@@ -26,6 +26,7 @@ __all__ = [
     "Source",
     "Sink",
     "Processor",
+    "AgentContext"
 ]
 
 
@@ -61,10 +62,23 @@ class Record(ABC):
 RecordType = Union[Record, dict, list, tuple]
 
 
+class AgentContext(ABC):
+    """The Agent context interface"""
+
+    def __init__(self):
+        """Initialize the agent context."""
+        pass
+
+
+    def get_persistent_state_directory(self):
+        """Return a path pointing to the stateful agent directory. Return None if not configured in the agent."""
+        return None
+
+
 class Agent(ABC):
     """The Agent interface"""
 
-    def init(self, config: Dict[str, Any]):
+    def init(self, config: Dict[str, Any], context: AgentContext):
         """Initialize the agent from the given configuration."""
         pass
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/api.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/api.py
@@ -65,10 +65,7 @@ RecordType = Union[Record, dict, list, tuple]
 class AgentContext(ABC):
     """The Agent context interface"""
 
-    def __init__(self):
-        """Initialize the agent context."""
-        pass
-
+    @abstractmethod
     def get_persistent_state_directory(self):
         """Return a path pointing to the stateful agent directory. Return None if not configured in the agent."""
         return None

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/api.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/api.py
@@ -26,7 +26,7 @@ __all__ = [
     "Source",
     "Sink",
     "Processor",
-    "AgentContext"
+    "AgentContext",
 ]
 
 
@@ -68,7 +68,6 @@ class AgentContext(ABC):
     def __init__(self):
         """Initialize the agent context."""
         pass
-
 
     def get_persistent_state_directory(self):
         """Return a path pointing to the stateful agent directory. Return None if not configured in the agent."""

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/grpc_service.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/grpc_service.py
@@ -333,12 +333,12 @@ def init_agent(configuration, context) -> Agent:
     module_name = full_class_name[: -len(class_name) - 1]
     module = importlib.import_module(module_name)
     agent = getattr(module, class_name)()
-    context_impl = AgentContextImpl(configuration, context)
+    context_impl = DefaultAgentContext(configuration, context)
     call_method_if_exists(agent, "init", configuration, context_impl)
     return agent
 
 
-class AgentContextImpl(AgentContext):
+class DefaultAgentContext(AgentContext):
     def __init__(self, configuration: dict, context: dict):
         self.configuration = configuration
         self.context = context

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/grpc_service.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/grpc_service.py
@@ -26,6 +26,7 @@ from typing import Iterable, Union, List, Tuple, Any, Optional, Dict
 
 import fastavro
 import grpc
+import inspect
 
 from langstream_grpc.proto import agent_pb2_grpc
 from langstream_grpc.proto.agent_pb2 import (
@@ -49,6 +50,7 @@ from .api import (
     Processor,
     Record,
     Agent,
+    AgentContext
 )
 from .util import SimpleRecord, AvroValue
 
@@ -324,27 +326,43 @@ class AgentService(AgentServiceServicer):
 def call_method_if_exists(klass, method, *args, **kwargs):
     method = getattr(klass, method, None)
     if callable(method):
-        return method(*args, **kwargs)
+        defined_positional_parameters_count = len(inspect.signature(method).parameters)
+        if defined_positional_parameters_count >= len(args):
+            return method(*args, **kwargs)
+        else:
+            return method(*args[:defined_positional_parameters_count], **kwargs)
     return None
 
 
-def init_agent(configuration) -> Agent:
+def init_agent(configuration, context) -> Agent:
     full_class_name = configuration["className"]
     class_name = full_class_name.split(".")[-1]
     module_name = full_class_name[: -len(class_name) - 1]
     module = importlib.import_module(module_name)
     agent = getattr(module, class_name)()
-    call_method_if_exists(agent, "init", configuration)
+    context_impl = AgentContextImpl(configuration, context)
+    call_method_if_exists(agent, "init", configuration, context_impl)
     return agent
+
+class AgentContextImpl(AgentContext):
+    def __init__(self, configuration: dict, context: dict):
+        self.configuration = configuration
+        self.context = context
+
+    def get_persistent_state_directory(self) -> str:
+        dir = self.context.get("persistentStateDirectory", "")
+        if not dir:
+            return None
+        return dir
 
 
 class AgentServer(object):
-    def __init__(self, target: str, config: str):
+    def __init__(self, target: str, config: str, context: str):
         self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=10)
         self.target = target
         self.grpc_server = grpc.server(self.thread_pool)
         self.port = self.grpc_server.add_insecure_port(target)
-        self.agent = init_agent(json.loads(config))
+        self.agent = init_agent(json.loads(config), json.loads(context))
 
     def start(self):
         call_method_if_exists(self.agent, "start")

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/grpc_service.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/grpc_service.py
@@ -44,14 +44,7 @@ from langstream_grpc.proto.agent_pb2 import (
     SinkResponse,
 )
 from langstream_grpc.proto.agent_pb2_grpc import AgentServiceServicer
-from .api import (
-    Source,
-    Sink,
-    Processor,
-    Record,
-    Agent,
-    AgentContext
-)
+from .api import Source, Sink, Processor, Record, Agent, AgentContext
 from .util import SimpleRecord, AvroValue
 
 
@@ -343,6 +336,7 @@ def init_agent(configuration, context) -> Agent:
     context_impl = AgentContextImpl(configuration, context)
     call_method_if_exists(agent, "init", configuration, context_impl)
     return agent
+
 
 class AgentContextImpl(AgentContext):
     def __init__(self, configuration: dict, context: dict):

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/tests/server_and_stub.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/tests/server_and_stub.py
@@ -16,14 +16,15 @@
 
 from typing import Optional
 
-import grpc, json
+import grpc
+import json
 
 from langstream_grpc.grpc_service import AgentServer
 from langstream_grpc.proto.agent_pb2_grpc import AgentServiceStub
 
 
 class ServerAndStub(object):
-    def __init__(self, class_name, agent_config = {}, context = {}):
+    def __init__(self, class_name, agent_config={}, context={}):
         self.config = agent_config.copy()
         self.config["className"] = class_name
         self.context = context
@@ -32,7 +33,9 @@ class ServerAndStub(object):
         self.stub: Optional[AgentServiceStub] = None
 
     def __enter__(self):
-        self.server = AgentServer("[::]:0", json.dumps(self.config), json.dumps(self.context))
+        self.server = AgentServer(
+            "[::]:0", json.dumps(self.config), json.dumps(self.context)
+        )
         self.server.start()
         self.channel = grpc.insecure_channel("localhost:%d" % self.server.port)
         self.stub = AgentServiceStub(channel=self.channel)

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/tests/test_grpc_processor.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/tests/test_grpc_processor.py
@@ -212,11 +212,10 @@ def test_info():
         assert info.json_info == '{"test-info-key": "test-info-value"}'
 
 
-
 def test_init_one_parameter():
     with ServerAndStub(
         "langstream_grpc.tests.test_grpc_processor.ProcessorInitOneParameter",
-            {"my-param": "my-value"}
+        {"my-param": "my-value"},
     ) as server_and_stub:
         for response in server_and_stub.stub.process(
             iter([ProcessorRequest(records=[GrpcRecord()])])
@@ -228,16 +227,17 @@ def test_init_one_parameter():
 
 def test_processor_use_context():
     with ServerAndStub(
-            "langstream_grpc.tests.test_grpc_processor.ProcessorUseContext",
-            {"my-param": "my-value"},
-            {"persistentStateDirectory": "/tmp/processor"}
+        "langstream_grpc.tests.test_grpc_processor.ProcessorUseContext",
+        {"my-param": "my-value"},
+        {"persistentStateDirectory": "/tmp/processor"},
     ) as server_and_stub:
         for response in server_and_stub.stub.process(
-                iter([ProcessorRequest(records=[GrpcRecord()])])
+            iter([ProcessorRequest(records=[GrpcRecord()])])
         ):
             assert len(response.results) == 1
             result = response.results[0].records[0]
             assert result.value.string_value == "directory is /tmp/processor"
+
 
 class MyProcessor(Processor):
     def agent_info(self) -> Dict[str, Any]:
@@ -281,15 +281,13 @@ class MyFutureProcessor(Processor):
         return self.executor.submit(lambda r: [r], record)
 
 
-
 class ProcessorInitOneParameter(Processor):
     def init(self, agent_config):
         self.myparam = agent_config["my-param"]
 
     def process(self, record: Record) -> List[RecordType]:
-        return [{
-            "value": self.myparam
-        }]
+        return [{"value": self.myparam}]
+
 
 class ProcessorUseContext(Processor):
     def init(self, agent_config, context: AgentContext):
@@ -297,6 +295,9 @@ class ProcessorUseContext(Processor):
         self.context = context
 
     def process(self, record: Record) -> List[RecordType]:
-        return [{
-            "value": "directory is " + str(self.context.get_persistent_state_directory())
-        }]
+        return [
+            {
+                "value": "directory is "
+                + str(self.context.get_persistent_state_directory())
+            }
+        ]

--- a/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/tests/test_grpc_processor.py
+++ b/langstream-runtime/langstream-runtime-impl/src/main/python/langstream_grpc/tests/test_grpc_processor.py
@@ -23,7 +23,7 @@ import fastavro
 import pytest
 from google.protobuf import empty_pb2
 
-from langstream_grpc.api import Record, RecordType, Processor
+from langstream_grpc.api import Record, RecordType, Processor, AgentContext
 from langstream_grpc.proto.agent_pb2 import (
     ProcessorRequest,
     Record as GrpcRecord,
@@ -212,6 +212,33 @@ def test_info():
         assert info.json_info == '{"test-info-key": "test-info-value"}'
 
 
+
+def test_init_one_parameter():
+    with ServerAndStub(
+        "langstream_grpc.tests.test_grpc_processor.ProcessorInitOneParameter",
+            {"my-param": "my-value"}
+    ) as server_and_stub:
+        for response in server_and_stub.stub.process(
+            iter([ProcessorRequest(records=[GrpcRecord()])])
+        ):
+            assert len(response.results) == 1
+            result = response.results[0].records[0]
+            assert result.value.string_value == "my-value"
+
+
+def test_processor_use_context():
+    with ServerAndStub(
+            "langstream_grpc.tests.test_grpc_processor.ProcessorUseContext",
+            {"my-param": "my-value"},
+            {"persistentStateDirectory": "/tmp/processor"}
+    ) as server_and_stub:
+        for response in server_and_stub.stub.process(
+                iter([ProcessorRequest(records=[GrpcRecord()])])
+        ):
+            assert len(response.results) == 1
+            result = response.results[0].records[0]
+            assert result.value.string_value == "directory is /tmp/processor"
+
 class MyProcessor(Processor):
     def agent_info(self) -> Dict[str, Any]:
         return {"test-info-key": "test-info-value"}
@@ -252,3 +279,24 @@ class MyFutureProcessor(Processor):
 
     def process(self, record: Record) -> Future[List[RecordType]]:
         return self.executor.submit(lambda r: [r], record)
+
+
+
+class ProcessorInitOneParameter(Processor):
+    def init(self, agent_config):
+        self.myparam = agent_config["my-param"]
+
+    def process(self, record: Record) -> List[RecordType]:
+        return [{
+            "value": self.myparam
+        }]
+
+class ProcessorUseContext(Processor):
+    def init(self, agent_config, context: AgentContext):
+        self.myparam = agent_config["my-param"]
+        self.context = context
+
+    def process(self, record: Record) -> List[RecordType]:
+        return [{
+            "value": "directory is " + str(self.context.get_persistent_state_directory())
+        }]


### PR DESCRIPTION
Changes:
- Added new Python AgentContext class to the API
- An agent can access it by defining
```
from langstream import SimpleRecord, Processor, AgentContext
import logging, os


class Exclamation(Processor):
    def init(self, config, context: AgentContext):
        self.context = context
    def process(self, record):
        directory = self.context.get_persistent_state_directory() 
``` 

if the agent declares init with only argument, it works as before
- Added end to end test 
