### PR TITLE
Add sample integration with LangSmith

### DIFF
--- a/examples/applications/langchain-chat/pipeline.yaml
+++ b/examples/applications/langchain-chat/pipeline.yaml
@@ -35,3 +35,5 @@ pipeline:
       astra-db-id: "${ secrets.astra-langchain.database-id }"
       astra-db-keyspace: "${ secrets.astra-langchain.keyspace }"
       astra-db-table: "${ secrets.astra-langchain.table }"
+      lang-smith-api_url:  "${ secrets.lang-smith.api-url }"
+      lang-smith-api-key:  "${ secrets.lang-smith.api-key }"

--- a/examples/applications/langchain-chat/python/langchain_chat.py
+++ b/examples/applications/langchain-chat/python/langchain_chat.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-
+import os
 from langstream import Processor, SimpleRecord
 from operator import itemgetter
 from typing import Dict, List, Optional, Sequence, Any
@@ -22,7 +22,6 @@ from langchain.vectorstores.cassandra import Cassandra
 from langchain.callbacks.manager import Callbacks, collect_runs
 from langchain.chat_models import ChatOpenAI
 from langchain.embeddings import OpenAIEmbeddings
-from langchain.indexes.vectorstore import VectorStoreIndexWrapper
 from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder, PromptTemplate
 from langchain.schema import Document
 from langchain.schema.language_model import BaseLanguageModel
@@ -207,6 +206,13 @@ class LangChainChat(Processor):
         self.astra_db_id = config.get("astra-db-id", "")
         self.astra_keyspace = config.get("astra-db-keyspace", "")
         self.astra_table_name = config.get("astra-db-table", "")
+
+        self.langsmith_url = config.get("lang-smith-api-url", "https://api.smith.langchain.com")
+        self.langsmith_key = config.get("lang-smith-api-key", "")
+
+        os.environ["LANGCHAIN_TRACING_V2"] = "true"
+        os.environ["LANGCHAIN_ENDPOINT"] = self.langsmith_url
+        os.environ["LANGCHAIN_API_KEY"] = self.langsmith_key
 
         cassio.init(token=self.astra_db_token, database_id=self.astra_db_id)
 

--- a/examples/secrets/secrets.yaml
+++ b/examples/secrets/secrets.yaml
@@ -66,6 +66,11 @@ secrets:
       table: "${ASTRA_LANGCHAIN_TABLE:-}"
       clientId: "${ASTRA_LANGCHAIN_CLIENT_ID:-}"
       secret: "${ASTRA_LANGCHAIN_SECRET:-}"
+  - name: lang-smith
+    id: lang-smith
+    data:
+      api-url: "${LANGSMITH_API_URL:-https://api.smith.langchain.com}"
+      api-key: "${LANGSMITH_APIKEY:-}"
   - id: cassandra
     data:
       username: "${CASSANDRA_USERNAME:-}"


### PR DESCRIPTION
Summary:
- add to the chatbot sample with LangChain the ability to configure the connection to LangSmith
- add default "secrets" to read from the ENV the variables to connect to LangSmith


<img width="1728" alt="image" src="https://github.com/LangStream/langstream/assets/9469110/e11e080d-194c-4efc-a4fb-1761ba0ecb5b">
