### PR TITLE
[python] Add support for hot reload of python code in docker mode

### DIFF
--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/AbstractGrpcAgent.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/AbstractGrpcAgent.java
@@ -102,21 +102,25 @@ abstract class AbstractGrpcAgent extends AbstractAgentCode {
     }
 
     protected synchronized void stop() throws Exception {
-        stopChannel(true);
+        stopChannel(false);
     }
 
-    public synchronized void stopChannel(boolean wait) throws Exception {
-        if (channel != null) {
-            ManagedChannel shutdown = channel.shutdown();
+    public void stopChannel(boolean wait) throws Exception {
+        ManagedChannel currentChannel;
+        synchronized(this) {
+            currentChannel = channel;
+        }
+        if (currentChannel != null) {
+            ManagedChannel shutdown = currentChannel.shutdown();
             if (wait) {
-                shutdown.awaitTermination(1, TimeUnit.MINUTES);
+                shutdown.awaitTermination(10, TimeUnit.SECONDS);
             }
         }
     }
 
     @Override
     public synchronized void close() throws Exception {
-        stopChannel(false);
+        stopChannel(true);
     }
 
     protected Object fromGrpc(Value value) throws IOException {

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/AbstractGrpcAgent.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/AbstractGrpcAgent.java
@@ -101,11 +101,22 @@ abstract class AbstractGrpcAgent extends AbstractAgentCode {
         }
     }
 
+    protected synchronized void stop() throws Exception {
+        stopChannel(true);
+    }
+
+    public synchronized void stopChannel(boolean wait) throws Exception {
+        if (channel != null) {
+            ManagedChannel shutdown = channel.shutdown();
+            if (wait) {
+                shutdown.awaitTermination(1, TimeUnit.MINUTES);
+            }
+        }
+    }
+
     @Override
     public synchronized void close() throws Exception {
-        if (channel != null) {
-            channel.shutdown();
-        }
+        stopChannel(false);
     }
 
     protected Object fromGrpc(Value value) throws IOException {

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentProcessor.java
@@ -86,10 +86,7 @@ public class GrpcAgentProcessor extends AbstractGrpcAgent implements AgentProces
 
     @Override
     public synchronized void close() throws Exception {
-        if (request != null) {
-            request.onCompleted();
-        }
-        super.close();
+        stop();
     }
 
     private SourceRecordAndResult fromGrpc(
@@ -162,5 +159,12 @@ public class GrpcAgentProcessor extends AbstractGrpcAgent implements AgentProces
                         new RuntimeException("gRPC server completed the stream unexpectedly"));
             }
         };
+    }
+
+    protected synchronized void stop() throws Exception {
+        if (request != null) {
+            request.onCompleted();
+        }
+        super.stop();
     }
 }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentProcessor.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,6 +40,8 @@ public class GrpcAgentProcessor extends AbstractGrpcAgent implements AgentProces
     private final Map<Long, RecordAndSink> sourceRecords = new ConcurrentHashMap<>();
 
     private final StreamObserver<ProcessorResponse> responseObserver = getResponseObserver();
+
+    private final AtomicBoolean restarting = new AtomicBoolean(false);
 
     private record RecordAndSink(
             ai.langstream.api.runner.code.Record sourceRecord, RecordSink sink) {}
@@ -58,6 +61,7 @@ public class GrpcAgentProcessor extends AbstractGrpcAgent implements AgentProces
 
     @Override
     public void start() throws Exception {
+        restarting.set(false);
         super.start();
         request = AgentServiceGrpc.newStub(channel).withWaitForReady().process(responseObserver);
     }
@@ -147,21 +151,31 @@ public class GrpcAgentProcessor extends AbstractGrpcAgent implements AgentProces
 
             @Override
             public void onError(Throwable throwable) {
-                agentContext.criticalFailure(
-                        new RuntimeException(
-                                "gRPC server sent error: %s".formatted(throwable.getMessage()),
-                                throwable));
+                if (!restarting.get()) {
+                    agentContext.criticalFailure(
+                            new RuntimeException(
+                                    "gRPC server sent error: %s".formatted(throwable.getMessage()),
+                                    throwable));
+                } else {
+                    log.info("Ignoring error during restart {}", throwable + "");
+                }
             }
 
             @Override
             public void onCompleted() {
-                agentContext.criticalFailure(
+                if (!restarting.get()) {
+                    agentContext.criticalFailure(
                         new RuntimeException("gRPC server completed the stream unexpectedly"));
+                } else {
+                    log.info("Ignoring error server stop during restart");
+                }
             }
         };
     }
 
     protected synchronized void stop() throws Exception {
+        log.info("Restarting...");
+        restarting.set(true);
         if (request != null) {
             request.onCompleted();
         }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
@@ -39,20 +39,19 @@ public class PythonGrpcAgentProcessor extends GrpcAgentProcessor {
 
     @Override
     public synchronized void close() throws Exception {
-        stop();
+        if (server != null) server.close(false);
     }
 
     @Override
     protected synchronized void stop() throws Exception {
-        if (server != null) server.close();
+        if (server != null) server.close(true);
     }
 
     @Override
     public void restart() throws Exception {
-        stop();
         super.stop();
-
-        super.start();
+        stop();
         start();
+        super.start();
     }
 }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentProcessor.java
@@ -39,7 +39,20 @@ public class PythonGrpcAgentProcessor extends GrpcAgentProcessor {
 
     @Override
     public synchronized void close() throws Exception {
+        stop();
+    }
+
+    @Override
+    protected synchronized void stop() throws Exception {
         if (server != null) server.close();
-        super.close();
+    }
+
+    @Override
+    public void restart() throws Exception {
+        stop();
+        super.stop();
+
+        super.start();
+        start();
     }
 }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
@@ -42,4 +42,17 @@ public class PythonGrpcAgentSink extends GrpcAgentSink {
         if (server != null) server.close(false);
         super.close();
     }
+
+    @Override
+    protected synchronized void stop() throws Exception {
+        if (server != null) server.close(true);
+    }
+
+    @Override
+    public void restart() throws Exception {
+        super.stop();
+        stop();
+        start();
+        super.start();
+    }
 }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSink.java
@@ -39,7 +39,7 @@ public class PythonGrpcAgentSink extends GrpcAgentSink {
 
     @Override
     public synchronized void close() throws Exception {
-        if (server != null) server.close();
+        if (server != null) server.close(false);
         super.close();
     }
 }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
@@ -42,4 +42,17 @@ public class PythonGrpcAgentSource extends GrpcAgentSource {
         if (server != null) server.close(false);
         super.close();
     }
+
+    @Override
+    protected synchronized void stop() throws Exception {
+        if (server != null) server.close(true);
+    }
+
+    @Override
+    public void restart() throws Exception {
+        super.stop();
+        stop();
+        start();
+        super.start();
+    }
 }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcAgentSource.java
@@ -39,7 +39,7 @@ public class PythonGrpcAgentSource extends GrpcAgentSource {
 
     @Override
     public synchronized void close() throws Exception {
-        if (server != null) server.close();
+        if (server != null) server.close(false);
         super.close();
     }
 }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/PythonGrpcServer.java
@@ -117,14 +117,16 @@ public class PythonGrpcServer {
         return agentContextConfiguration;
     }
 
-    public void close() throws Exception {
+    public void close(boolean ignoreErrors) throws Exception {
         if (pythonProcess != null) {
             pythonProcess.destroy();
             int exitCode = pythonProcess.waitFor();
             log.info("Python process exited with code {}", exitCode);
 
-            if (exitCode != 0) {
-                throw new RuntimeException("Python code exited with code " + exitCode);
+            if (!ignoreErrors) {
+                if (exitCode != 0) {
+                    throw new RuntimeException("Python code exited with code " + exitCode);
+                }
             }
         }
     }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCode.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCode.java
@@ -16,11 +16,17 @@
 package ai.langstream.api.runner.code;
 
 import ai.langstream.api.runtime.ComponentType;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.Map;
 
 /** Body of the agent */
 public interface AgentCode extends AutoCloseable {
+
+    static final Logger log = LoggerFactory.getLogger(AgentCode.class);
 
     String agentId();
 
@@ -65,7 +71,6 @@ public interface AgentCode extends AutoCloseable {
      * @throws Exception
      */
     default void restart() throws Exception {
-        throw new UnsupportedOperationException(
-                "Restart is not supported for agent type " + agentType());
+        log.info("Restart is not supported for agent type {}", agentType());
     }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCode.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCode.java
@@ -58,4 +58,14 @@ public interface AgentCode extends AutoCloseable {
      * @return information about the agent
      */
     List<AgentStatusResponse> getAgentStatus();
+
+    /**
+     * Gracefully restart the agent.
+     *
+     * @throws Exception
+     */
+    default void restart() throws Exception {
+        throw new UnsupportedOperationException(
+                "Restart is not supported for agent type " + agentType());
+    }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeAndLoader.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentCodeAndLoader.java
@@ -135,6 +135,11 @@ public record AgentCodeAndLoader(AgentCode agentCode, ClassLoader classLoader) {
             }
 
             @Override
+            public void restart() throws Exception {
+                executeWithContextClassloader(AgentCode::restart);
+            }
+
+            @Override
             public ComponentType componentType() {
                 return callNoExceptionWithContextClassloader(AgentCode::componentType);
             }
@@ -193,6 +198,11 @@ public record AgentCodeAndLoader(AgentCode agentCode, ClassLoader classLoader) {
             }
 
             @Override
+            public void restart() throws Exception {
+                executeWithContextClassloader(AgentCode::restart);
+            }
+
+            @Override
             public ComponentType componentType() {
                 return callNoExceptionWithContextClassloader(AgentCode::componentType);
             }
@@ -247,6 +257,11 @@ public record AgentCodeAndLoader(AgentCode agentCode, ClassLoader classLoader) {
             @Override
             public void close() throws Exception {
                 executeWithContextClassloader(AgentCode::close);
+            }
+
+            @Override
+            public void restart() throws Exception {
+                executeWithContextClassloader(AgentCode::restart);
             }
 
             @Override

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/ApplicationWatcher.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/ApplicationWatcher.java
@@ -38,11 +38,9 @@ public class ApplicationWatcher {
                 new Thread(
                         () -> {
                             try {
-                                System.out.println("Watching files in " + codeDirectory);
                                 watchFiles(watcher, codeDirectory, changedFiles);
                             } catch (Throwable e) {
                                 e.printStackTrace();
-                                log.error("Error while watching files", e);
                             }
                         });
 
@@ -54,23 +52,18 @@ public class ApplicationWatcher {
         WatchKey register = dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
 
         log.info("Watching files in {}, key {}", dir, register);
-        System.out.println("Watching files in " + dir + ", key " + register);
         for (; ; ) {
 
             // wait for key to be signaled
             WatchKey key;
             try {
                 key = watcher.take();
-                log.info("Received key {}", key);
-                System.out.println("Received key " + key);
             } catch (InterruptedException x) {
                 return;
             }
 
             for (WatchEvent<?> event : key.pollEvents()) {
                 WatchEvent.Kind<?> kind = event.kind();
-                log.info("Event kind {}", kind);
-                System.out.println("Event kind " + kind);
 
                 // This key is registered only
                 // for ENTRY_CREATE events,
@@ -93,7 +86,6 @@ public class ApplicationWatcher {
                     // If the filename is "test" and the directory is "foo",
                     // the resolved name is "test/foo".
                     Path child = dir.resolve(filename);
-                    log.info("File {} changed", child);
                     changedFiles.accept(filename.toAbsolutePath().toString());
                 } catch (Exception x) {
                     log.error("Error while watching files", x);

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/ApplicationWatcher.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/ApplicationWatcher.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.cli.commands.docker;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ApplicationWatcher {
+
+    public static void watchApplication(Path codeDirectory) throws Exception {
+        try (WatchService watcher = FileSystems.getDefault().newWatchService(); ) {
+
+            Thread watchThread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    watchFiles(watcher, codeDirectory);
+                                } catch (Exception e) {
+                                    log.error("Error while watching files", e);
+                                }
+                            });
+
+            watchThread.start();
+        }
+    }
+
+    private static void watchFiles(WatchService watcher, Path dir) throws Exception {
+        WatchKey register = dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+
+        log.info("Watching files in {}, key {}", dir, register);
+        for (; ; ) {
+
+            // wait for key to be signaled
+            WatchKey key;
+            try {
+                key = watcher.take();
+                log.info("Received key {}", key);
+            } catch (InterruptedException x) {
+                return;
+            }
+
+            for (WatchEvent<?> event : key.pollEvents()) {
+                WatchEvent.Kind<?> kind = event.kind();
+                log.info("Event kind {}", kind);
+
+                // This key is registered only
+                // for ENTRY_CREATE events,
+                // but an OVERFLOW event can
+                // occur regardless if events
+                // are lost or discarded.
+                if (kind == OVERFLOW) {
+                    continue;
+                }
+
+                // The filename is the
+                // context of the event.
+                WatchEvent<Path> ev = (WatchEvent<Path>) event;
+                Path filename = ev.context();
+
+                // Verify that the new
+                //  file is a text file.
+                try {
+                    // Resolve the filename against the directory.
+                    // If the filename is "test" and the directory is "foo",
+                    // the resolved name is "test/foo".
+                    Path child = dir.resolve(filename);
+                    log.info("File {} changed", child);
+                } catch (Exception x) {
+                    log.error("Error while watching files", x);
+                    continue;
+                }
+            }
+
+            // Reset the key -- this step is critical if you want to
+            // receive further watch events.  If the key is no longer valid,
+            // the directory is inaccessible so exit the loop.
+            boolean valid = key.reset();
+            if (!valid) {
+                log.info("Key is not valid, exiting");
+                break;
+            }
+        }
+    }
+}

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -102,7 +102,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
 
     @CommandLine.Option(
             names = {"--watch-files"},
-            description = "Start the UI")
+            description = "Watch files and apply the changes automatically (only Python files)")
     private boolean watchFiles = true;
 
     @CommandLine.Option(
@@ -447,17 +447,15 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
                 watcher);
     }
 
-    private static void restartAgents() {
+    private void restartAgents() {
         HttpURLConnection urlConnection = null;
         try {
             URL url = new URL("http://localhost:8790/commands/restart");
-            System.out.println("Calling " + url + " to restart the agents");
             urlConnection = (HttpURLConnection) url.openConnection();
             urlConnection.setRequestMethod("POST");
-            Object content = urlConnection.getContent();
-            System.out.println("Response: " + content);
+            urlConnection.getContent();
         } catch (Exception e) {
-            System.err.println("Could not restart the agents: " + e.getMessage());
+            log("Could not reload the agents: " + e);
         } finally {
             if (urlConnection != null) {
                 urlConnection.disconnect();

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -395,7 +395,15 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
 
         try (WatchService watcher = FileSystems.getDefault().newWatchService(); ) {
             if (watchFiles) {
-                startWatchService(appTmp.toPath(), watcher);
+                Path python = appTmp.toPath().resolve("python");
+                if (Files.isDirectory(python)) { // only watch if python is present
+                    startWatchService(appTmp.toPath(), watcher);
+                } else {
+                    log(
+                            "Python directory "
+                                    + python.toAbsolutePath()
+                                    + " not found, not watching files");
+                }
             }
 
             final Path outputLog = Files.createTempFile("langstream", ".log");
@@ -442,7 +450,7 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
     private static void restartAgents() {
         HttpURLConnection urlConnection = null;
         try {
-            URL url = new URL("http://localhost:7890/commands/restart");
+            URL url = new URL("http://localhost:8790/commands/restart");
             System.out.println("Calling " + url + " to restart the agents");
             urlConnection = (HttpURLConnection) url.openConnection();
             urlConnection.setRequestMethod("POST");

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -359,6 +359,10 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
         commandLine.add("-p");
         commandLine.add("8090:8090");
 
+        // agent control
+        commandLine.add("-p");
+        commandLine.add("8790:8790");
+
         if (memory != null && !memory.isEmpty()) {
             commandLine.add("--memory");
             commandLine.add(memory);

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmdTest.java
@@ -29,9 +29,12 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
 
+@Slf4j
 class LocalRunApplicationCmdTest extends CommandTestBase {
 
     @Test
@@ -60,6 +63,7 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
 
         final List<String> lines = result.out().lines().collect(Collectors.toList());
         final String lastLine = lines.get(lines.size() - 1);
+        log.info("Last line: {}", lastLine);
         assertTrue(
                 lastLine.contains(
                         "run --rm -i -e START_BROKER=true -e START_MINIO=true -e START_HERDDB=true "
@@ -72,6 +76,7 @@ class LocalRunApplicationCmdTest extends CommandTestBase {
                                 + "--add-host my-cluster-kafka-bootstrap.kafka:127.0.0.1 "
                                 + "-p 8091:8091 "
                                 + "-p 8090:8090 "
+                                + "-p 8790:8790 "
                                 + "ghcr.io/langstream/langstream-runtime-tester:unknown"));
 
         final List<String> volumes = extractVolumes(lastLine);

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
@@ -25,7 +25,7 @@ import static ai.langstream.runtime.api.agent.AgentRunnerConstants.POD_CONFIG_EN
 import static ai.langstream.runtime.api.agent.AgentRunnerConstants.POD_CONFIG_ENV_DEFAULT;
 
 import ai.langstream.runtime.RuntimeStarter;
-import ai.langstream.runtime.agent.api.AgentInfo;
+import ai.langstream.runtime.agent.api.AgentAPIController;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -122,7 +122,7 @@ public class AgentRunnerStarter extends RuntimeStarter {
                 codeDirectory,
                 agentsDirectory,
                 basePersistentStateDirectory,
-                new AgentInfo(),
+                new AgentAPIController(),
                 continueLoop::get,
                 null,
                 true,

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
@@ -240,4 +240,11 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
         }
         return result;
     }
+
+    @Override
+    public void restart() throws Exception {
+        for (AgentProcessor processor : processors) {
+            processor.restart();
+        }
+    }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/api/AgentAPIController.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/api/AgentAPIController.java
@@ -20,8 +20,9 @@ import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.AgentStatusResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-public class AgentInfo {
+public class AgentAPIController {
     private AgentProcessor processor;
     private AgentCode source;
     private AgentCode sink;
@@ -56,5 +57,18 @@ public class AgentInfo {
             result.addAll(sink.getAgentStatus());
         }
         return result;
+    }
+
+    public Map<String, Object> restart() throws Exception {
+        if (source != null) {
+            source.restart();
+        }
+        if (processor != null) {
+            processor.restart();
+        }
+        if (sink != null) {
+            sink.restart();
+        }
+        return Map.of();
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AbstractKafkaApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/AbstractKafkaApplicationRunner.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.langstream.AbstractApplicationRunner;
 import ai.langstream.kafka.extensions.KafkaContainerExtension;
-import ai.langstream.runtime.agent.api.AgentInfo;
+import ai.langstream.runtime.agent.api.AgentAPIController;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -230,11 +230,11 @@ public abstract class AbstractKafkaApplicationRunner extends AbstractApplication
     }
 
     @Override
-    protected void validateAgentInfoBeforeStop(AgentInfo agentInfo) {
+    protected void validateAgentInfoBeforeStop(AgentAPIController agentAPIController) {
         if (!validateConsumerOffsets) {
             return;
         }
-        agentInfo
+        agentAPIController
                 .serveWorkerStatus()
                 .forEach(
                         workerStatus -> {

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/LocalApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/LocalApplicationRunner.java
@@ -27,7 +27,7 @@ import ai.langstream.impl.deploy.ApplicationDeployer;
 import ai.langstream.impl.nar.NarFileHandler;
 import ai.langstream.impl.parser.ModelBuilder;
 import ai.langstream.runtime.agent.AgentRunner;
-import ai.langstream.runtime.agent.api.AgentInfo;
+import ai.langstream.runtime.agent.api.AgentAPIController;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -75,7 +75,7 @@ public class LocalApplicationRunner
 
     final AtomicBoolean started = new AtomicBoolean();
 
-    final Map<String, AgentInfo> allAgentsInfo = new ConcurrentHashMap<>();
+    final Map<String, AgentAPIController> allAgentsInfo = new ConcurrentHashMap<>();
 
     public LocalApplicationRunner(
             Path agentsDirectory, Path codeDirectory, Path basePersistentStateDirectory)
@@ -160,11 +160,11 @@ public class LocalApplicationRunner
     }
 
     @Override
-    public Map<String, AgentInfo> collectAgentsStatus() {
+    public Map<String, AgentAPIController> collectAgentsStatus() {
         return new HashMap<>(allAgentsInfo);
     }
 
-    public record AgentRunResult(Map<String, AgentInfo> info) {}
+    public record AgentRunResult(Map<String, AgentAPIController> info) {}
 
     public void start() {
         kubeServer.start();
@@ -222,19 +222,19 @@ public class LocalApplicationRunner
                                         "{} AgentPod {} Started",
                                         runnerExecutionId,
                                         podConfiguration.agent().agentId());
-                                AgentInfo agentInfo = new AgentInfo();
-                                allAgentsInfo.put(podConfiguration.agent().agentId(), agentInfo);
+                                AgentAPIController agentAPIController = new AgentAPIController();
+                                allAgentsInfo.put(podConfiguration.agent().agentId(), agentAPIController);
                                 AgentRunner.runAgent(
                                         podConfiguration,
                                         codeDirectory,
                                         agentsDirectory,
                                         basePersistentStateDirectory,
-                                        agentInfo,
+                                        agentAPIController,
                                         continueLoop::get,
                                         () -> {},
                                         false,
                                         narFileHandler);
-                                List<?> infos = agentInfo.serveWorkerStatus();
+                                List<?> infos = agentAPIController.serveWorkerStatus();
                                 log.info(
                                         "{} AgentPod {} AgentInfo {}",
                                         runnerExecutionId,

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/Main.java
@@ -235,7 +235,7 @@ public class Main {
         context.setContextPath("/");
         server.setHandler(context);
         context.addServlet(new ServletHolder(new MetricsHttpServlet()), "/metrics");
-        context.addServlet(new ServletHolder(new AgentControllerServlet(runner)), "/info");
+        context.addServlet(new ServletHolder(new AgentControllerServlet(runner)), "/commands/*");
         server.start();
         return server;
     }
@@ -252,6 +252,7 @@ public class Main {
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             resp.setContentType("application/json");
+            log.info("Received request {}", req.getRequestURI());
             String uri = req.getRequestURI();
             if (uri.endsWith("/restart")) {
                 try {


### PR DESCRIPTION
Summary:

When you are working locally, add the ability to automatically reload python code without restarting the container

In "docker run" mode the cli start watching on the python files.
In case of any python file that has changed the python agent is restarted, picking up the new version of the code.

The is a new flag "--watch-files=false" to disable the feature.

The watcher starts only if there is a "python" directory in the application

Follow up:
- if there is a syntax error the Python process crashes, so the docker container exists
- add test cases