### PR TITLE
Gateway: accept HTTP request for producing messages

### DIFF
--- a/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
@@ -61,7 +61,8 @@ public class GoogleAuthenticationProvider implements GatewayAuthenticationProvid
         try {
             final String credentials = context.credentials();
             if (credentials == null) {
-                return GatewayAuthenticationResult.authenticationFailed("Credentials not provided.");
+                return GatewayAuthenticationResult.authenticationFailed(
+                        "Credentials not provided.");
             }
             GoogleIdToken idToken = verifier.verify(credentials);
             if (idToken != null) {

--- a/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
@@ -61,7 +61,7 @@ public class GoogleAuthenticationProvider implements GatewayAuthenticationProvid
         try {
             final String credentials = context.credentials();
             if (credentials == null) {
-                return GatewayAuthenticationResult.authenticationFailed("Token not found.");
+                return GatewayAuthenticationResult.authenticationFailed("Credentials not provided.");
             }
             GoogleIdToken idToken = verifier.verify(credentials);
             if (idToken != null) {
@@ -73,7 +73,7 @@ public class GoogleAuthenticationProvider implements GatewayAuthenticationProvid
                 result.put(FIELD_LOCALE, (String) payload.get("locale"));
                 return GatewayAuthenticationResult.authenticationSuccessful(result);
             } else {
-                return GatewayAuthenticationResult.authenticationFailed("Invalid token.");
+                return GatewayAuthenticationResult.authenticationFailed("Invalid credentials.");
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-google-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/google/GoogleAuthenticationProvider.java
@@ -59,7 +59,11 @@ public class GoogleAuthenticationProvider implements GatewayAuthenticationProvid
     @Override
     public GatewayAuthenticationResult authenticate(GatewayRequestContext context) {
         try {
-            GoogleIdToken idToken = verifier.verify(context.credentials());
+            final String credentials = context.credentials();
+            if (credentials == null) {
+                return GatewayAuthenticationResult.authenticationFailed("Token not found.");
+            }
+            GoogleIdToken idToken = verifier.verify(credentials);
             if (idToken != null) {
                 final GoogleIdToken.Payload payload = idToken.getPayload();
                 Map<String, String> result = new HashMap<>();

--- a/langstream-api-gateway-auth/langstream-http-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/HttpAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-http-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/HttpAuthenticationProvider.java
@@ -64,7 +64,8 @@ public class HttpAuthenticationProvider implements GatewayAuthenticationProvider
         final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create(url));
 
         httpConfiguration.getHeaders().forEach(builder::header);
-        builder.header("Authorization", "Bearer " + context.credentials());
+        final String credentials = context.credentials();
+        builder.header("Authorization", "Bearer " + (credentials == null ? "" : credentials));
         final HttpRequest request = builder.GET().build();
 
         final HttpResponse<Void> response;

--- a/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProvider.java
+++ b/langstream-api-gateway-auth/langstream-jwt-api-gateway-auth/src/main/java/ai/langstream/apigateway/auth/impl/jwt/admin/JwtAuthenticationProvider.java
@@ -66,7 +66,8 @@ public class JwtAuthenticationProvider implements GatewayAuthenticationProvider 
     public GatewayAuthenticationResult authenticate(GatewayRequestContext context) {
         String role;
         try {
-            role = authenticationProviderToken.authenticate(context.credentials());
+            final String credentials = context.credentials();
+            role = authenticationProviderToken.authenticate(credentials == null ? "" : credentials);
         } catch (AuthenticationProviderToken.AuthenticationException ex) {
             return GatewayAuthenticationResult.authenticationFailed(ex.getMessage());
         }

--- a/langstream-api-gateway/pom.xml
+++ b/langstream-api-gateway/pom.xml
@@ -71,6 +71,16 @@
 			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>${springdoc-openapi-starter-webmvc.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+			<version>${springdoc-openapi-starter-webmvc.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
 		</dependency>

--- a/langstream-api-gateway/pom.xml
+++ b/langstream-api-gateway/pom.xml
@@ -62,6 +62,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>langstream-pulsar-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -96,11 +95,14 @@ public class ConsumeGateway implements Closeable {
     public void setup(
             String topic,
             List<Function<Record, Boolean>> filters,
-            AuthenticatedGatewayRequestContext requestContext) throws Exception {
-        this.logRef = "%s/%s/%s".formatted(
-                requestContext.tenant(),
-                requestContext.applicationId(),
-                requestContext.gateway().getId());
+            AuthenticatedGatewayRequestContext requestContext)
+            throws Exception {
+        this.logRef =
+                "%s/%s/%s"
+                        .formatted(
+                                requestContext.tenant(),
+                                requestContext.applicationId(),
+                                requestContext.gateway().getId());
         this.requestContext = requestContext;
         this.filters = filters == null ? List.of() : filters;
 
@@ -136,7 +138,8 @@ public class ConsumeGateway implements Closeable {
         if (readerFuture != null) {
             throw new IllegalStateException("Already started");
         }
-        readerFuture = CompletableFuture.runAsync(
+        readerFuture =
+                CompletableFuture.runAsync(
                         () -> {
                             try {
                                 log.debug("[{}] Started reader", logRef);

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
@@ -1,0 +1,215 @@
+package ai.langstream.apigateway.gateways;
+
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
+import ai.langstream.api.runner.topics.TopicOffsetPosition;
+import ai.langstream.api.runner.topics.TopicReadResult;
+import ai.langstream.api.runner.topics.TopicReader;
+import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
+import ai.langstream.apigateway.websocket.api.ConsumePushMessage;
+import ai.langstream.apigateway.websocket.api.ProduceResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Closeable;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ConsumeGateway implements Closeable {
+
+    protected static final ObjectMapper mapper = new ObjectMapper();
+
+    @Getter
+    public static class ProduceException extends Exception {
+
+        private final ProduceResponse.Status status;
+
+        public ProduceException(String message, ProduceResponse.Status status) {
+            super(message);
+            this.status = status;
+        }
+    }
+
+    public static class ProduceGatewayRequestValidator implements GatewayRequestHandler.GatewayRequestValidator {
+        @Override
+        public List<String> getAllRequiredParameters(Gateway gateway) {
+            return gateway.getParameters();
+        }
+
+        @Override
+        public void validateOptions(Map<String, String> options) {
+            for (Map.Entry<String, String> option : options.entrySet()) {
+                switch (option.getKey()) {
+                    default -> throw new IllegalArgumentException("Unknown option " + option.getKey());
+                }
+            }
+        }
+    }
+
+
+    private final TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry;
+    private TopicReader reader;
+    private AuthenticatedGatewayRequestContext requestContext;
+    private List<Function<Record, Boolean>> filters;
+
+    public ConsumeGateway(TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry) {
+        this.topicConnectionsRuntimeRegistry = topicConnectionsRuntimeRegistry;
+    }
+
+    @SneakyThrows
+    public void setup(String topic, List<Function<Record, Boolean>> filters, AuthenticatedGatewayRequestContext requestContext) {
+        this.requestContext = requestContext;
+        this.filters = filters == null ? List.of() : filters;
+
+        final StreamingCluster streamingCluster = requestContext.application().getInstance().streamingCluster();
+        final TopicConnectionsRuntime topicConnectionsRuntime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(streamingCluster)
+                        .asTopicConnectionsRuntime();
+
+        topicConnectionsRuntime.init(streamingCluster);
+
+        final String positionParameter = requestContext.options().getOrDefault("position", "latest");
+        TopicOffsetPosition position =
+                switch (positionParameter) {
+                    case "latest" -> TopicOffsetPosition.LATEST;
+                    case "earliest" -> TopicOffsetPosition.EARLIEST;
+                    default -> TopicOffsetPosition.absolute(
+                            Base64.getDecoder().decode(positionParameter));
+                };
+        reader =
+                topicConnectionsRuntime.createReader(
+                        streamingCluster, Map.of("topic", topic), position);
+        reader.start();
+    }
+
+
+    public CompletableFuture<Void> startReading(Executor executor, Supplier<Boolean> stop, Consumer<String> onMessage) {
+        if (requestContext == null || reader == null) {
+            throw new IllegalStateException("Not initialized");
+        }
+        return CompletableFuture.runAsync(
+                        () -> {
+
+                            try {
+                                final String tenant = requestContext.tenant();
+
+                                final String gatewayId = requestContext.gateway().getId();
+                                final String applicationId = requestContext.applicationId();
+                                log.info(
+                                        "Started reader for gateway {}/{}/{}",
+                                        tenant,
+                                        applicationId,
+                                        gatewayId);
+                                readMessages(stop, onMessage);
+                            } catch (InterruptedException | CancellationException ex) {
+                                // ignore
+                            } catch (Throwable ex) {
+                                log.error(ex.getMessage(), ex);
+                            } finally {
+                                closeReader();
+                            }
+                        },
+                        executor);
+    }
+
+
+    protected void readMessages(Supplier<Boolean> stop, Consumer<String> onMessage)
+            throws Exception {
+        while (true) {
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+            if (stop.get()) {
+                return;
+            }
+            final TopicReadResult readResult = reader.read();
+            final List<Record> records = readResult.records();
+            for (Record record : records) {
+                log.debug("Received record {}", record);
+                boolean skip = false;
+                if (filters != null) {
+                    for (Function<Record, Boolean> filter : filters) {
+                        if (!filter.apply(record)) {
+                            skip = true;
+                            log.debug("Skipping record {}", requestContext, record);
+                            break;
+                        }
+                    }
+                }
+                if (!skip) {
+                    final Map<String, String> messageHeaders = computeMessageHeaders(record);
+                    final String offset = computeOffset(readResult);
+
+                    final ConsumePushMessage message =
+                            new ConsumePushMessage(
+                                    new ConsumePushMessage.Record(
+                                            record.key(), record.value(), messageHeaders),
+                                    offset);
+                    final String jsonMessage = mapper.writeValueAsString(message);
+                    onMessage.accept(jsonMessage);
+
+                }
+            }
+        }
+    }
+
+
+
+
+    private static Map<String, String> computeMessageHeaders(Record record) {
+        final Collection<Header> headers = record.headers();
+        final Map<String, String> messageHeaders;
+        if (headers == null) {
+            messageHeaders = Map.of();
+        } else {
+            messageHeaders = new HashMap<>();
+            headers.forEach(h -> messageHeaders.put(h.key(), h.valueAsString()));
+        }
+        return messageHeaders;
+    }
+
+    private static String computeOffset(TopicReadResult readResult) {
+        final byte[] offset = readResult.offset();
+        if (offset == null) {
+            return null;
+        }
+        return Base64.getEncoder().encodeToString(offset);
+    }
+
+
+
+
+    private void closeReader() {
+        if (reader != null) {
+            try {
+                reader.close();
+            } catch (Exception e) {
+                log.error("error closing reader", e);
+            }
+        }
+    }
+
+
+
+    @Override
+    public void close()  {
+        closeReader();
+    }
+
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandler.java
@@ -1,0 +1,280 @@
+package ai.langstream.apigateway.gateways;
+
+import ai.langstream.api.gateway.GatewayAuthenticationProvider;
+import ai.langstream.api.gateway.GatewayAuthenticationProviderRegistry;
+import ai.langstream.api.gateway.GatewayAuthenticationResult;
+import ai.langstream.api.gateway.GatewayRequestContext;
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.ApplicationSpecs;
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.model.Gateways;
+import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
+import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
+import ai.langstream.apigateway.websocket.AuthenticationInterceptor;
+import ai.langstream.apigateway.websocket.impl.AuthenticatedGatewayRequestContextImpl;
+import ai.langstream.apigateway.websocket.impl.GatewayRequestContextImpl;
+import ai.langstream.impl.common.ApplicationPlaceholderResolver;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class GatewayRequestHandler {
+
+    public static class AuthFailedException extends Exception {
+        public AuthFailedException(String message) {
+            super(message);
+        }
+    }
+
+    public interface GatewayRequestValidator {
+        List<String> getAllRequiredParameters(Gateway gateway);
+        void validateOptions(Map<String, String> options);
+    }
+
+
+    private final ApplicationStore applicationStore;
+    private final GatewayAuthenticationProvider authTestProvider;
+
+
+
+    public GatewayRequestHandler(
+            ApplicationStore applicationStore,
+            GatewayTestAuthenticationProperties testAuthenticationProperties) {
+        this.applicationStore = applicationStore;
+        if (testAuthenticationProperties.getType() != null) {
+            authTestProvider =
+                    GatewayAuthenticationProviderRegistry.loadProvider(
+                            testAuthenticationProperties.getType(),
+                            testAuthenticationProperties.getConfiguration());
+            log.info(
+                    "Loaded test authentication provider {}",
+                    authTestProvider.getClass().getName());
+        } else {
+            authTestProvider = null;
+            log.info("No test authentication provider configured");
+        }
+    }
+
+
+    public GatewayRequestContext validateRequest(
+            String tenant,
+            String applicationId,
+            String gatewayId,
+            Gateway.GatewayType expectedGatewayType,
+            Map<String, String> queryString,
+            Map<String, String> httpHeaders,
+            GatewayRequestValidator validator) {
+        Map<String, String> options = new HashMap<>();
+        Map<String, String> userParameters = new HashMap<>();
+
+        final String credentials = queryString.remove("credentials");
+        final String testCredentials = queryString.remove("test-credentials");
+
+        for (Map.Entry<String, String> entry : queryString.entrySet()) {
+            if (entry.getKey().startsWith("option:")) {
+                options.put(entry.getKey().substring("option:".length()), entry.getValue());
+            } else if (entry.getKey().startsWith("param:")) {
+                userParameters.put(entry.getKey().substring("param:".length()), entry.getValue());
+            } else {
+                throw new IllegalArgumentException(
+                        "invalid query parameter "
+                        + entry.getKey()
+                        + ". "
+                        + "To specify a gateway parameter, use the format param:<parameter_name>."
+                        + "To specify a option, use the format option:<option_name>.");
+            }
+        }
+
+        final Application application = getResolvedApplication(tenant, applicationId);
+        final Gateway gateway = extractGateway(gatewayId, application, expectedGatewayType);
+
+        final List<String> requiredParameters = validator.getAllRequiredParameters(gateway);
+        Set<String> allUserParameterKeys = new HashSet<>(userParameters.keySet());
+        if (requiredParameters != null) {
+            for (String requiredParameter : requiredParameters) {
+                final String value = userParameters.get(requiredParameter);
+                if (!StringUtils.hasText(value)) {
+                    throw new IllegalArgumentException(
+                            formatErrorMessage(
+                                    tenant,
+                                    applicationId,
+                                    gateway,
+                                    "missing required parameter "
+                                    + requiredParameter
+                                    + ". Required parameters: "
+                                    + requiredParameters));
+                }
+                allUserParameterKeys.remove(requiredParameter);
+            }
+        }
+        if (!allUserParameterKeys.isEmpty()) {
+            throw new IllegalArgumentException(
+                    formatErrorMessage(
+                            tenant,
+                            applicationId,
+                            gateway,
+                            "unknown parameters: " + allUserParameterKeys));
+        }
+        validator.validateOptions(options);
+
+        if (credentials != null && testCredentials != null) {
+            throw new IllegalArgumentException(
+                    formatErrorMessage(
+                            tenant,
+                            applicationId,
+                            gateway,
+                            "credentials and test-credentials cannot be used together"));
+        }
+        return GatewayRequestContextImpl.builder()
+                .tenant(tenant)
+                .applicationId(applicationId)
+                .application(application)
+                .credentials(credentials)
+                .testCredentials(testCredentials)
+                .httpHeaders(httpHeaders)
+                .options(options)
+                .userParameters(userParameters)
+                .gateway(gateway)
+                .build();
+    }
+
+    private static String formatErrorMessage(
+            String tenant, String applicationId, Gateway gateway, String error) {
+        return "Error for gateway %s (tenant: %s, appId: %s): %s"
+                .formatted(gateway.getId(), tenant, applicationId, error);
+    }
+
+    private Application getResolvedApplication(String tenant, String applicationId) {
+        final ApplicationSpecs applicationSpecs = applicationStore.getSpecs(tenant, applicationId);
+        if (applicationSpecs == null) {
+            throw new IllegalArgumentException("application " + applicationId + " not found");
+        }
+        final Application application = applicationSpecs.getApplication();
+        application.setSecrets(applicationStore.getSecrets(tenant, applicationId));
+        return ApplicationPlaceholderResolver.resolvePlaceholders(application);
+    }
+
+
+
+    private Gateway extractGateway(
+            String gatewayId, Application application, Gateway.GatewayType type) {
+        final Gateways gatewaysObj = application.getGateways();
+        if (gatewaysObj == null) {
+            throw new IllegalArgumentException("no gateways defined for the application");
+        }
+        final List<Gateway> gateways = gatewaysObj.gateways();
+        if (gateways == null) {
+            throw new IllegalArgumentException("no gateways defined for the application");
+        }
+
+        Gateway selectedGateway = null;
+
+        for (Gateway gateway : gateways) {
+            if (gateway.getId().equals(gatewayId) && type == gateway.getType()) {
+                selectedGateway = gateway;
+                break;
+            }
+        }
+        if (selectedGateway == null) {
+            throw new IllegalArgumentException(
+                    "gateway "
+                    + gatewayId
+                    + " of type "
+                    + type
+                    + " is not defined in the application");
+        }
+        return selectedGateway;
+    }
+
+
+    public AuthenticatedGatewayRequestContext authenticate(GatewayRequestContext gatewayRequestContext)
+            throws AuthFailedException {
+
+        final Gateway.Authentication authentication =
+                gatewayRequestContext.gateway().getAuthentication();
+
+        if (authentication == null) {
+            return getAuthenticatedGatewayRequestContext(gatewayRequestContext, Map.of(), new HashMap<>());
+        }
+
+        final GatewayAuthenticationResult result;
+        if (gatewayRequestContext.isTestMode()) {
+            if (!authentication.isAllowTestMode()) {
+                throw new AuthFailedException(
+                        "Gateway "
+                        + gatewayRequestContext.gateway().getId()
+                        + " of tenant "
+                        + gatewayRequestContext.tenant()
+                        + " does not allow test mode.");
+            }
+            if (authTestProvider == null) {
+                throw new AuthFailedException("No test auth provider specified");
+            }
+            result = authTestProvider.authenticate(gatewayRequestContext);
+        } else {
+            final String provider = authentication.getProvider();
+            final GatewayAuthenticationProvider authProvider =
+                    GatewayAuthenticationProviderRegistry.loadProvider(
+                            provider, authentication.getConfiguration());
+            result = authProvider.authenticate(gatewayRequestContext);
+        }
+        if (result == null) {
+            throw new AuthFailedException("Authentication provider returned null");
+        }
+        if (!result.authenticated()) {
+            throw new AuthFailedException(result.reason());
+        }
+        final Map<String, String> principalValues = getPrincipalValues(result, gatewayRequestContext);
+        return getAuthenticatedGatewayRequestContext(gatewayRequestContext, principalValues, new HashMap<>());
+    }
+
+    private Map<String, String> getPrincipalValues(
+            GatewayAuthenticationResult result, GatewayRequestContext context) {
+        if (!context.isTestMode()) {
+            final Map<String, String> values = result.principalValues();
+            if (values == null) {
+                return Map.of();
+            }
+            return values;
+        } else {
+            final Map<String, String> values = new HashMap<>();
+            final String principalSubject = DigestUtils.sha256Hex(context.credentials());
+            final int principalNumericId = principalSubject.hashCode();
+            final String principalEmail = "%s@locahost".formatted(principalSubject);
+
+            // google
+            values.putIfAbsent("subject", principalSubject);
+            values.putIfAbsent("email", principalEmail);
+            values.putIfAbsent("name", principalSubject);
+
+            // github
+            values.putIfAbsent("login", principalSubject);
+            values.putIfAbsent("id", principalNumericId + "");
+            return values;
+        }
+    }
+
+    private AuthenticatedGatewayRequestContext getAuthenticatedGatewayRequestContext(
+            GatewayRequestContext gatewayRequestContext,
+            Map<String, String> principalValues,
+            Map<String, Object> attributes) {
+
+        return AuthenticatedGatewayRequestContextImpl.builder()
+                .gatewayRequestContext(gatewayRequestContext)
+                .attributes(attributes)
+                .principalValues(principalValues)
+                .build();
+    }
+
+
+
+
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.gateway.GatewayAuthenticationProvider;
@@ -11,7 +26,6 @@ import ai.langstream.api.model.Gateways;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
-import ai.langstream.apigateway.websocket.AuthenticationInterceptor;
 import ai.langstream.apigateway.websocket.impl.AuthenticatedGatewayRequestContextImpl;
 import ai.langstream.apigateway.websocket.impl.GatewayRequestContextImpl;
 import ai.langstream.impl.common.ApplicationPlaceholderResolver;
@@ -20,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.util.StringUtils;
@@ -36,14 +49,12 @@ public class GatewayRequestHandler {
 
     public interface GatewayRequestValidator {
         List<String> getAllRequiredParameters(Gateway gateway);
+
         void validateOptions(Map<String, String> options);
     }
 
-
     private final ApplicationStore applicationStore;
     private final GatewayAuthenticationProvider authTestProvider;
-
-
 
     public GatewayRequestHandler(
             ApplicationStore applicationStore,
@@ -62,7 +73,6 @@ public class GatewayRequestHandler {
             log.info("No test authentication provider configured");
         }
     }
-
 
     public GatewayRequestContext validateRequest(
             String tenant,
@@ -86,10 +96,10 @@ public class GatewayRequestHandler {
             } else {
                 throw new IllegalArgumentException(
                         "invalid query parameter "
-                        + entry.getKey()
-                        + ". "
-                        + "To specify a gateway parameter, use the format param:<parameter_name>."
-                        + "To specify a option, use the format option:<option_name>.");
+                                + entry.getKey()
+                                + ". "
+                                + "To specify a gateway parameter, use the format param:<parameter_name>."
+                                + "To specify a option, use the format option:<option_name>.");
             }
         }
 
@@ -108,9 +118,9 @@ public class GatewayRequestHandler {
                                     applicationId,
                                     gateway,
                                     "missing required parameter "
-                                    + requiredParameter
-                                    + ". Required parameters: "
-                                    + requiredParameters));
+                                            + requiredParameter
+                                            + ". Required parameters: "
+                                            + requiredParameters));
                 }
                 allUserParameterKeys.remove(requiredParameter);
             }
@@ -162,8 +172,6 @@ public class GatewayRequestHandler {
         return ApplicationPlaceholderResolver.resolvePlaceholders(application);
     }
 
-
-
     private Gateway extractGateway(
             String gatewayId, Application application, Gateway.GatewayType type) {
         final Gateways gatewaysObj = application.getGateways();
@@ -186,23 +194,23 @@ public class GatewayRequestHandler {
         if (selectedGateway == null) {
             throw new IllegalArgumentException(
                     "gateway "
-                    + gatewayId
-                    + " of type "
-                    + type
-                    + " is not defined in the application");
+                            + gatewayId
+                            + " of type "
+                            + type
+                            + " is not defined in the application");
         }
         return selectedGateway;
     }
 
-
-    public AuthenticatedGatewayRequestContext authenticate(GatewayRequestContext gatewayRequestContext)
-            throws AuthFailedException {
+    public AuthenticatedGatewayRequestContext authenticate(
+            GatewayRequestContext gatewayRequestContext) throws AuthFailedException {
 
         final Gateway.Authentication authentication =
                 gatewayRequestContext.gateway().getAuthentication();
 
         if (authentication == null) {
-            return getAuthenticatedGatewayRequestContext(gatewayRequestContext, Map.of(), new HashMap<>());
+            return getAuthenticatedGatewayRequestContext(
+                    gatewayRequestContext, Map.of(), new HashMap<>());
         }
 
         final GatewayAuthenticationResult result;
@@ -210,10 +218,10 @@ public class GatewayRequestHandler {
             if (!authentication.isAllowTestMode()) {
                 throw new AuthFailedException(
                         "Gateway "
-                        + gatewayRequestContext.gateway().getId()
-                        + " of tenant "
-                        + gatewayRequestContext.tenant()
-                        + " does not allow test mode.");
+                                + gatewayRequestContext.gateway().getId()
+                                + " of tenant "
+                                + gatewayRequestContext.tenant()
+                                + " does not allow test mode.");
             }
             if (authTestProvider == null) {
                 throw new AuthFailedException("No test auth provider specified");
@@ -232,8 +240,10 @@ public class GatewayRequestHandler {
         if (!result.authenticated()) {
             throw new AuthFailedException(result.reason());
         }
-        final Map<String, String> principalValues = getPrincipalValues(result, gatewayRequestContext);
-        return getAuthenticatedGatewayRequestContext(gatewayRequestContext, principalValues, new HashMap<>());
+        final Map<String, String> principalValues =
+                getPrincipalValues(result, gatewayRequestContext);
+        return getAuthenticatedGatewayRequestContext(
+                gatewayRequestContext, principalValues, new HashMap<>());
     }
 
     private Map<String, String> getPrincipalValues(
@@ -273,8 +283,4 @@ public class GatewayRequestHandler {
                 .principalValues(principalValues)
                 .build();
     }
-
-
-
-
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandlerFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandlerFactory.java
@@ -1,11 +1,22 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.gateways;
 
 import ai.langstream.api.storage.ApplicationStore;
-import ai.langstream.api.storage.ApplicationStoreRegistry;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
-import ai.langstream.apigateway.config.StorageProperties;
-import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
-import java.util.Objects;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,9 +24,9 @@ import org.springframework.context.annotation.Configuration;
 public class GatewayRequestHandlerFactory {
 
     @Bean
-    public GatewayRequestHandler gatewayRequestHandler(ApplicationStore applicationStore,
-                                                       GatewayTestAuthenticationProperties testAuthenticationProperties) {
+    public GatewayRequestHandler gatewayRequestHandler(
+            ApplicationStore applicationStore,
+            GatewayTestAuthenticationProperties testAuthenticationProperties) {
         return new GatewayRequestHandler(applicationStore, testAuthenticationProperties);
     }
-
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandlerFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/GatewayRequestHandlerFactory.java
@@ -1,0 +1,21 @@
+package ai.langstream.apigateway.gateways;
+
+import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.api.storage.ApplicationStoreRegistry;
+import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
+import ai.langstream.apigateway.config.StorageProperties;
+import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
+import java.util.Objects;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GatewayRequestHandlerFactory {
+
+    @Bean
+    public GatewayRequestHandler gatewayRequestHandler(ApplicationStore applicationStore,
+                                                       GatewayTestAuthenticationProperties testAuthenticationProperties) {
+        return new GatewayRequestHandler(applicationStore, testAuthenticationProperties);
+    }
+
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -1,0 +1,202 @@
+package ai.langstream.apigateway.gateways;
+
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.SimpleRecord;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntime;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
+import ai.langstream.api.runner.topics.TopicProducer;
+import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
+import ai.langstream.apigateway.websocket.api.ProduceRequest;
+import ai.langstream.apigateway.websocket.api.ProduceResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ProduceGateway implements Closeable {
+
+    protected static final ObjectMapper mapper = new ObjectMapper();
+
+    @Getter
+    public static class ProduceException extends Exception {
+
+        private final ProduceResponse.Status status;
+
+        public ProduceException(String message, ProduceResponse.Status status) {
+            super(message);
+            this.status = status;
+        }
+    }
+
+    public static class ProduceGatewayRequestValidator implements GatewayRequestHandler.GatewayRequestValidator {
+        @Override
+        public List<String> getAllRequiredParameters(Gateway gateway) {
+            return gateway.getParameters();
+        }
+
+        @Override
+        public void validateOptions(Map<String, String> options) {
+            for (Map.Entry<String, String> option : options.entrySet()) {
+                switch (option.getKey()) {
+                    default -> throw new IllegalArgumentException("Unknown option " + option.getKey());
+                }
+            }
+        }
+    }
+
+
+    private final TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry;
+    private TopicProducer producer;
+    private List<Header> commonHeaders;
+
+    public ProduceGateway(TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry) {
+        this.topicConnectionsRuntimeRegistry = topicConnectionsRuntimeRegistry;
+    }
+
+    public void start(String topic, List<Header> commonHeaders, AuthenticatedGatewayRequestContext requestContext) {
+        this.commonHeaders = commonHeaders == null ? List.of() : commonHeaders;
+
+        setupProducer(
+                topic,
+                requestContext.application().getInstance().streamingCluster(),
+                requestContext.tenant(),
+                requestContext.applicationId(),
+                requestContext.gateway().getId());
+    }
+
+    protected void setupProducer(
+            String topic,
+            StreamingCluster streamingCluster,
+            final String tenant,
+            final String applicationId,
+            final String gatewayId) {
+        final TopicConnectionsRuntime topicConnectionsRuntime =
+                topicConnectionsRuntimeRegistry
+                        .getTopicConnectionsRuntime(streamingCluster)
+                        .asTopicConnectionsRuntime();
+
+        topicConnectionsRuntime.init(streamingCluster);
+
+        producer =
+                topicConnectionsRuntime.createProducer(
+                        null, streamingCluster, Map.of("topic", topic));
+        producer.start();
+        log.info(
+                "Started producer for gateway {}/{}/{} on topic {}",
+                tenant,
+                applicationId,
+                gatewayId,
+                topic);
+    }
+
+    public void produceMessage(String payload) throws ProduceException {
+        final ProduceRequest produceRequest;
+        try {
+            produceRequest = mapper.readValue(payload, ProduceRequest.class);
+        } catch (JsonProcessingException err) {
+            throw new ProduceException(err.getMessage(), ProduceResponse.Status.BAD_REQUEST);
+        }
+        produceMessage(produceRequest);
+    }
+
+
+    public void produceMessage(ProduceRequest produceRequest) throws ProduceException {
+        if (produceRequest.value() == null && produceRequest.key() == null) {
+            throw new ProduceException("Either key or value must be set.", ProduceResponse.Status.BAD_REQUEST);
+        }
+        if (producer == null) {
+            throw new ProduceException("Producer not initialized", ProduceResponse.Status.PRODUCER_ERROR);
+        }
+
+        final Collection<Header> headers = new ArrayList<>(commonHeaders);
+        if (produceRequest.headers() != null) {
+            final Set<String> configuredHeaders =
+                    headers.stream().map(Header::key).collect(Collectors.toSet());
+            for (Map.Entry<String, String> messageHeader : produceRequest.headers().entrySet()) {
+                if (configuredHeaders.contains(messageHeader.getKey())) {
+                    throw new ProduceException("Header "
+                                               + messageHeader.getKey()
+                                               + " is configured as parameter-level header.", ProduceResponse.Status.BAD_REQUEST);
+                }
+                headers.add(
+                        SimpleRecord.SimpleHeader.of(
+                                messageHeader.getKey(), messageHeader.getValue()));
+            }
+        }
+        try {
+            final SimpleRecord record =
+                    SimpleRecord.builder()
+                            .key(produceRequest.key())
+                            .value(produceRequest.value())
+                            .headers(headers)
+                            .build();
+            producer.write(record).get();
+            log.info("Produced record {}", record);
+        } catch (Throwable tt) {
+            throw new ProduceException(tt.getMessage(), ProduceResponse.Status.PRODUCER_ERROR);
+        }
+    }
+
+    @Override
+    public void close()  {
+
+        if (producer != null) {
+            try {
+                producer.close();
+            } catch (Exception e) {
+                log.error("error closing producer", e);
+            }
+        }
+
+    }
+
+    public static List<Header> getProducerCommonHeaders(Gateway.ProduceOptions produceOptions,
+                                                        AuthenticatedGatewayRequestContext context) {
+        if (produceOptions != null) {
+            return getProducerCommonHeaders(
+                            produceOptions.headers(),
+                            context.userParameters(),
+                            context.principalValues());
+        }
+        return null;
+    }
+    public static List<Header> getProducerCommonHeaders(
+            List<Gateway.KeyValueComparison> headerFilters,
+            Map<String, String> passedParameters,
+            Map<String, String> principalValues) {
+        final List<Header> headers = new ArrayList<>();
+        if (headerFilters == null) {
+            return headers;
+        }
+        for (Gateway.KeyValueComparison mapping : headerFilters) {
+            if (mapping.key() == null || mapping.key().isEmpty()) {
+                throw new IllegalArgumentException("Header key cannot be empty");
+            }
+            String value = mapping.value();
+            if (value == null && mapping.valueFromParameters() != null) {
+                value = passedParameters.get(mapping.valueFromParameters());
+            }
+            if (value == null && mapping.valueFromAuthentication() != null) {
+                value = principalValues.get(mapping.valueFromAuthentication());
+            }
+            if (value == null) {
+                throw new IllegalArgumentException("header " + mapping.key() + " cannot be empty");
+            }
+            headers.add(SimpleRecord.SimpleHeader.of(mapping.key(), value));
+        }
+        return headers;
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -89,10 +89,12 @@ public class ProduceGateway implements Closeable {
             String topic,
             List<Header> commonHeaders,
             AuthenticatedGatewayRequestContext requestContext) {
-        this.logRef = "%s/%s/%s".formatted(
-                requestContext.tenant(),
-                requestContext.applicationId(),
-                requestContext.gateway().getId());
+        this.logRef =
+                "%s/%s/%s"
+                        .formatted(
+                                requestContext.tenant(),
+                                requestContext.applicationId(),
+                                requestContext.gateway().getId());
         this.commonHeaders = commonHeaders == null ? List.of() : commonHeaders;
 
         setupProducer(
@@ -120,7 +122,7 @@ public class ProduceGateway implements Closeable {
                 topicConnectionsRuntime.createProducer(
                         null, streamingCluster, Map.of("topic", topic));
         producer.start();
-        log.debug("[{}] Started producer on topic {}",logRef, topic);
+        log.debug("[{}] Started producer on topic {}", logRef, topic);
     }
 
     public void produceMessage(String payload) throws ProduceException {
@@ -168,7 +170,7 @@ public class ProduceGateway implements Closeable {
                             .headers(headers)
                             .build();
             producer.write(record).get();
-            log.debug("[{}] Produced record {}",logRef, record);
+            log.debug("[{}] Produced record {}", logRef, record);
         } catch (Throwable tt) {
             log.error("[{}] Error producing message: {}", logRef, tt.getMessage(), tt);
             throw new ProduceException(tt.getMessage(), ProduceResponse.Status.PRODUCER_ERROR, tt);

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -87,11 +87,15 @@ public class GatewayResource {
                 new ProduceGateway(
                         topicConnectionsRuntimeRegistryProvider
                                 .getTopicConnectionsRuntimeRegistry());
-        final List<Header> commonHeaders =
-                ProduceGateway.getProducerCommonHeaders(
-                        context.gateway().getProduceOptions(), authContext);
-        produceGateway.start(context.gateway().getTopic(), commonHeaders, authContext);
-        produceGateway.produceMessage(produceRequest);
-        return ProduceResponse.OK;
+        try {
+            final List<Header> commonHeaders =
+                    ProduceGateway.getProducerCommonHeaders(
+                            context.gateway().getProduceOptions(), authContext);
+            produceGateway.start(context.gateway().getTopic(), commonHeaders, authContext);
+            produceGateway.produceMessage(produceRequest);
+            return ProduceResponse.OK;
+        } finally {
+            produceGateway.close();
+        }
     }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -21,11 +21,9 @@ import ai.langstream.api.runner.code.Header;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.gateways.ProduceGateway;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
-import ai.langstream.apigateway.util.HttpUtil;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import ai.langstream.apigateway.websocket.api.ProduceRequest;
 import ai.langstream.apigateway.websocket.api.ProduceResponse;
-
 import jakarta.validation.constraints.NotBlank;
 import java.util.HashMap;
 import java.util.List;
@@ -35,11 +33,8 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.server.ServerHttpRequest;
-import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,20 +50,29 @@ public class GatewayResource {
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
     private final GatewayRequestHandler gatewayRequestHandler;
 
-    @PostMapping(value = "/produce/{tenant}/{application}/{gateway}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(
+            value = "/produce/{tenant}/{application}/{gateway}",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
     ProduceResponse produce(
             WebRequest request,
             @NotBlank @PathVariable("tenant") String tenant,
             @NotBlank @PathVariable("application") String application,
             @NotBlank @PathVariable("gateway") String gateway,
-            @RequestBody ProduceRequest produceRequest) throws ProduceGateway.ProduceException {
+            @RequestBody ProduceRequest produceRequest)
+            throws ProduceGateway.ProduceException {
 
-        final Map<String, String> queryString = request.getParameterMap().keySet().stream()
-                .collect(Collectors.toMap(k -> k, k -> request.getParameter(k)));
+        final Map<String, String> queryString =
+                request.getParameterMap().keySet().stream()
+                        .collect(Collectors.toMap(k -> k, k -> request.getParameter(k)));
         final Map<String, String> headers = new HashMap<>();
-        request.getHeaderNames().forEachRemaining(name -> headers.put(name, request.getHeader(name)));
+        request.getHeaderNames()
+                .forEachRemaining(name -> headers.put(name, request.getHeader(name)));
         final GatewayRequestContext context =
-                gatewayRequestHandler.validateRequest(tenant, application, gateway, Gateway.GatewayType.produce,
+                gatewayRequestHandler.validateRequest(
+                        tenant,
+                        application,
+                        gateway,
+                        Gateway.GatewayType.produce,
                         queryString,
                         headers,
                         new ProduceGateway.ProduceGatewayRequestValidator());
@@ -80,12 +84,14 @@ public class GatewayResource {
         }
 
         final ProduceGateway produceGateway =
-                new ProduceGateway(topicConnectionsRuntimeRegistryProvider.getTopicConnectionsRuntimeRegistry());
+                new ProduceGateway(
+                        topicConnectionsRuntimeRegistryProvider
+                                .getTopicConnectionsRuntimeRegistry());
         final List<Header> commonHeaders =
-                ProduceGateway.getProducerCommonHeaders(context.gateway().getProduceOptions(), authContext);
+                ProduceGateway.getProducerCommonHeaders(
+                        context.gateway().getProduceOptions(), authContext);
         produceGateway.start(context.gateway().getTopic(), commonHeaders, authContext);
         produceGateway.produceMessage(produceRequest);
         return ProduceResponse.OK;
-
     }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.http;
+
+import ai.langstream.api.gateway.GatewayRequestContext;
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.runner.code.Header;
+import ai.langstream.apigateway.gateways.GatewayRequestHandler;
+import ai.langstream.apigateway.gateways.ProduceGateway;
+import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
+import ai.langstream.apigateway.util.HttpUtil;
+import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
+import ai.langstream.apigateway.websocket.api.ProduceRequest;
+import ai.langstream.apigateway.websocket.api.ProduceResponse;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/gateways")
+@Slf4j
+@AllArgsConstructor
+public class GatewayResource {
+
+    private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
+    private final GatewayRequestHandler gatewayRequestHandler;
+
+    @PostMapping(value = "/produce/{tenant}/{application}/{gateway}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    ProduceResponse produce(
+            WebRequest request,
+            @NotBlank @PathVariable("tenant") String tenant,
+            @NotBlank @PathVariable("application") String application,
+            @NotBlank @PathVariable("gateway") String gateway,
+            @RequestBody ProduceRequest produceRequest) throws ProduceGateway.ProduceException {
+
+        final Map<String, String> queryString = request.getParameterMap().keySet().stream()
+                .collect(Collectors.toMap(k -> k, k -> request.getParameter(k)));
+        final Map<String, String> headers = new HashMap<>();
+        request.getHeaderNames().forEachRemaining(name -> headers.put(name, request.getHeader(name)));
+        final GatewayRequestContext context =
+                gatewayRequestHandler.validateRequest(tenant, application, gateway, Gateway.GatewayType.produce,
+                        queryString,
+                        headers,
+                        new ProduceGateway.ProduceGatewayRequestValidator());
+        final AuthenticatedGatewayRequestContext authContext;
+        try {
+            authContext = gatewayRequestHandler.authenticate(context);
+        } catch (GatewayRequestHandler.AuthFailedException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, e.getMessage());
+        }
+
+        final ProduceGateway produceGateway =
+                new ProduceGateway(topicConnectionsRuntimeRegistryProvider.getTopicConnectionsRuntimeRegistry());
+        final List<Header> commonHeaders =
+                ProduceGateway.getProducerCommonHeaders(context.gateway().getProduceOptions(), authContext);
+        produceGateway.start(context.gateway().getTopic(), commonHeaders, authContext);
+        produceGateway.produceMessage(produceRequest);
+        return ProduceResponse.OK;
+
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/ResourceErrorsHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/ResourceErrorsHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.http;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
+
+@ControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Slf4j
+public class ResourceErrorsHandler {
+
+    @ExceptionHandler(Throwable.class)
+    ProblemDetail handleAll(Throwable exception) {
+        if (exception instanceof final ResponseStatusException rs) {
+            return ProblemDetail.forStatusAndDetail(rs.getStatusCode(), rs.getMessage());
+        }
+        if (exception instanceof IllegalArgumentException) {
+            log.error("Bad request", exception);
+            return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.getMessage());
+        }
+        log.error("Internal error", exception);
+        return ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/util/HttpUtil.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/util/HttpUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.util;
 
 import java.net.URLDecoder;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/util/HttpUtil.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/util/HttpUtil.java
@@ -1,0 +1,30 @@
+package ai.langstream.apigateway.util;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpUtil {
+
+    public static Map<String, String> parseQuerystring(String queryString) {
+        Map<String, String> map = new HashMap<>();
+        if (queryString == null || queryString.isBlank()) {
+            return map;
+        }
+        String[] params = queryString.split("&");
+        for (String param : params) {
+            String[] keyValuePair = param.split("=", 2);
+            String name = URLDecoder.decode(keyValuePair[0], StandardCharsets.UTF_8);
+            if ("".equals(name)) {
+                continue;
+            }
+            String value =
+                    keyValuePair.length > 1
+                            ? URLDecoder.decode(keyValuePair[1], StandardCharsets.UTF_8)
+                            : "";
+            map.put(name, value);
+        }
+        return map;
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
@@ -15,23 +15,13 @@
  */
 package ai.langstream.apigateway.websocket;
 
-import ai.langstream.api.gateway.GatewayAuthenticationProvider;
-import ai.langstream.api.gateway.GatewayAuthenticationProviderRegistry;
-import ai.langstream.api.gateway.GatewayAuthenticationResult;
 import ai.langstream.api.gateway.GatewayRequestContext;
-import ai.langstream.api.model.Gateway;
-import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.util.HttpUtil;
 import ai.langstream.apigateway.websocket.handlers.AbstractHandler;
-import ai.langstream.apigateway.websocket.impl.AuthenticatedGatewayRequestContextImpl;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -81,7 +71,8 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
 
             final AuthenticatedGatewayRequestContext authenticatedGatewayRequestContext;
             try {
-                authenticatedGatewayRequestContext = gatewayRequestHandler.authenticate(gatewayRequestContext);
+                authenticatedGatewayRequestContext =
+                        gatewayRequestHandler.authenticate(gatewayRequestContext);
             } catch (GatewayRequestHandler.AuthFailedException authFailedException) {
                 log.info("Authentication failed {}", authFailedException.getMessage());
                 String error = authFailedException.getMessage();
@@ -94,7 +85,8 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
             log.debug("Authentication OK");
 
             sessionAttributes.put("context", authenticatedGatewayRequestContext);
-            handler.onBeforeHandshakeCompleted(authenticatedGatewayRequestContext,
+            handler.onBeforeHandshakeCompleted(
+                    authenticatedGatewayRequestContext,
                     authenticatedGatewayRequestContext.attributes());
             return true;
         } catch (Throwable error) {
@@ -106,13 +98,10 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
         }
     }
 
-
-
     @Override
     public void afterHandshake(
             ServerHttpRequest request,
             ServerHttpResponse response,
             WebSocketHandler wsHandler,
             Exception exception) {}
-
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/AuthenticationInterceptor.java
@@ -21,12 +21,15 @@ import ai.langstream.api.gateway.GatewayAuthenticationResult;
 import ai.langstream.api.gateway.GatewayRequestContext;
 import ai.langstream.api.model.Gateway;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
+import ai.langstream.apigateway.gateways.GatewayRequestHandler;
+import ai.langstream.apigateway.util.HttpUtil;
 import ai.langstream.apigateway.websocket.handlers.AbstractHandler;
 import ai.langstream.apigateway.websocket.impl.AuthenticatedGatewayRequestContextImpl;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.http.HttpStatus;
@@ -40,38 +43,23 @@ import org.springframework.web.socket.handler.ExceptionWebSocketHandlerDecorator
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
 @Slf4j
+@AllArgsConstructor
 public class AuthenticationInterceptor implements HandshakeInterceptor {
 
-    private final GatewayAuthenticationProvider authTestProvider;
-
-    public AuthenticationInterceptor(
-            GatewayTestAuthenticationProperties testAuthenticationProperties) {
-        if (testAuthenticationProperties.getType() != null) {
-            authTestProvider =
-                    GatewayAuthenticationProviderRegistry.loadProvider(
-                            testAuthenticationProperties.getType(),
-                            testAuthenticationProperties.getConfiguration());
-            log.info(
-                    "Loaded test authentication provider {}",
-                    authTestProvider.getClass().getName());
-        } else {
-            authTestProvider = null;
-            log.info("No test authentication provider configured");
-        }
-    }
+    private final GatewayRequestHandler gatewayRequestHandler;
 
     @Override
     public boolean beforeHandshake(
             ServerHttpRequest request,
             ServerHttpResponse response,
             WebSocketHandler wsHandler,
-            Map<String, Object> attributes)
+            Map<String, Object> sessionAttributes)
             throws Exception {
         final ServletServerHttpRequest httpRequest = (ServletServerHttpRequest) request;
         final ServletServerHttpResponse httpResponse = (ServletServerHttpResponse) response;
         try {
             final String queryString = httpRequest.getServletRequest().getQueryString();
-            final Map<String, String> querystring = parseQuerystring(queryString);
+            final Map<String, String> querystring = HttpUtil.parseQuerystring(queryString);
 
             final WebSocketHandler delegate =
                     ((ExceptionWebSocketHandlerDecorator) wsHandler).getLastHandler();
@@ -82,28 +70,32 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
             final Map<String, String> vars =
                     antPathMatcher.extractUriTemplateVariables(handler.path(), path);
             final GatewayRequestContext gatewayRequestContext =
-                    handler.validateRequest(
-                            vars, querystring, request.getHeaders().toSingleValueMap());
+                    gatewayRequestHandler.validateRequest(
+                            handler.tenantFromPath(vars, querystring),
+                            handler.applicationIdFromPath(vars, querystring),
+                            handler.gatewayFromPath(vars, querystring),
+                            handler.gatewayType(),
+                            querystring,
+                            request.getHeaders().toSingleValueMap(),
+                            handler.validator());
 
-            final Map<String, String> principalValues;
+            final AuthenticatedGatewayRequestContext authenticatedGatewayRequestContext;
             try {
-                principalValues = authenticate(gatewayRequestContext);
-            } catch (AuthFailedException authFailedException) {
+                authenticatedGatewayRequestContext = gatewayRequestHandler.authenticate(gatewayRequestContext);
+            } catch (GatewayRequestHandler.AuthFailedException authFailedException) {
                 log.info("Authentication failed {}", authFailedException.getMessage());
                 String error = authFailedException.getMessage();
                 if (error == null || error.isEmpty()) {
                     error = "unknown";
                 }
-                httpResponse.getServletResponse().sendError(HttpStatus.FORBIDDEN.value(), error);
+                httpResponse.getServletResponse().sendError(HttpStatus.UNAUTHORIZED.value(), error);
                 return false;
             }
-            log.info("Authentication passed!");
+            log.debug("Authentication OK");
 
-            final AuthenticatedGatewayRequestContext authenticatedGatewayRequestContext =
-                    getAuthenticatedGatewayRequestContext(
-                            gatewayRequestContext, principalValues, attributes);
-            attributes.put("context", authenticatedGatewayRequestContext);
-            handler.onBeforeHandshakeCompleted(authenticatedGatewayRequestContext, attributes);
+            sessionAttributes.put("context", authenticatedGatewayRequestContext);
+            handler.onBeforeHandshakeCompleted(authenticatedGatewayRequestContext,
+                    authenticatedGatewayRequestContext.attributes());
             return true;
         } catch (Throwable error) {
             log.info("Internal error {}", error.getMessage(), error);
@@ -114,89 +106,7 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
         }
     }
 
-    private static class AuthFailedException extends Exception {
-        public AuthFailedException(String message) {
-            super(message);
-        }
-    }
 
-    private Map<String, String> authenticate(GatewayRequestContext gatewayRequestContext)
-            throws AuthFailedException {
-
-        final Gateway.Authentication authentication =
-                gatewayRequestContext.gateway().getAuthentication();
-
-        if (authentication == null) {
-            return Map.of();
-        }
-
-        final GatewayAuthenticationResult result;
-        if (gatewayRequestContext.isTestMode()) {
-            if (!authentication.isAllowTestMode()) {
-                throw new AuthFailedException(
-                        "Gateway "
-                                + gatewayRequestContext.gateway().getId()
-                                + " of tenant "
-                                + gatewayRequestContext.tenant()
-                                + " does not allow test mode.");
-            }
-            if (authTestProvider == null) {
-                throw new AuthFailedException("No test auth provider specified");
-            }
-            result = authTestProvider.authenticate(gatewayRequestContext);
-        } else {
-            final String provider = authentication.getProvider();
-            final GatewayAuthenticationProvider authProvider =
-                    GatewayAuthenticationProviderRegistry.loadProvider(
-                            provider, authentication.getConfiguration());
-            result = authProvider.authenticate(gatewayRequestContext);
-        }
-        if (result == null) {
-            throw new AuthFailedException("Authentication provider returned null");
-        }
-        if (!result.authenticated()) {
-            throw new AuthFailedException(result.reason());
-        }
-        return getPrincipalValues(result, gatewayRequestContext);
-    }
-
-    private Map<String, String> getPrincipalValues(
-            GatewayAuthenticationResult result, GatewayRequestContext context) {
-        if (!context.isTestMode()) {
-            final Map<String, String> values = result.principalValues();
-            if (values == null) {
-                return Map.of();
-            }
-            return values;
-        } else {
-            final Map<String, String> values = new HashMap<>();
-            final String principalSubject = DigestUtils.sha256Hex(context.credentials());
-            final int principalNumericId = principalSubject.hashCode();
-            final String principalEmail = "%s@locahost".formatted(principalSubject);
-
-            // google
-            values.putIfAbsent("subject", principalSubject);
-            values.putIfAbsent("email", principalEmail);
-            values.putIfAbsent("name", principalSubject);
-
-            // github
-            values.putIfAbsent("login", principalSubject);
-            values.putIfAbsent("id", principalNumericId + "");
-            return values;
-        }
-    }
-
-    private AuthenticatedGatewayRequestContext getAuthenticatedGatewayRequestContext(
-            GatewayRequestContext gatewayRequestContext,
-            Map<String, String> principalValues,
-            Map<String, Object> attributes) {
-
-        return AuthenticatedGatewayRequestContextImpl.builder()
-                .gatewayRequestContext(gatewayRequestContext)
-                .attributes(attributes)
-                .principalValues(principalValues)
-                .build();
-    }
 
     @Override
     public void afterHandshake(
@@ -205,24 +115,4 @@ public class AuthenticationInterceptor implements HandshakeInterceptor {
             WebSocketHandler wsHandler,
             Exception exception) {}
 
-    private static Map<String, String> parseQuerystring(String queryString) {
-        Map<String, String> map = new HashMap<>();
-        if (queryString == null || queryString.isBlank()) {
-            return map;
-        }
-        String[] params = queryString.split("&");
-        for (String param : params) {
-            String[] keyValuePair = param.split("=", 2);
-            String name = URLDecoder.decode(keyValuePair[0], StandardCharsets.UTF_8);
-            if ("".equals(name)) {
-                continue;
-            }
-            String value =
-                    keyValuePair.length > 1
-                            ? URLDecoder.decode(keyValuePair[1], StandardCharsets.UTF_8)
-                            : "";
-            map.put(name, value);
-        }
-        return map;
-    }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
@@ -18,6 +18,7 @@ package ai.langstream.apigateway.websocket;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
+import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
 import ai.langstream.apigateway.websocket.handlers.ChatHandler;
 import ai.langstream.apigateway.websocket.handlers.ConsumeHandler;
@@ -47,7 +48,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     private final ApplicationStore applicationStore;
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
-    private final GatewayTestAuthenticationProperties adminAuthenticationProperties;
+    private final GatewayRequestHandler gatewayRequestHandler;
     private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool();
 
     @Override
@@ -72,7 +73,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
                 .setAllowedOrigins("*")
                 .addInterceptors(
                         new HttpSessionHandshakeInterceptor(),
-                        new AuthenticationInterceptor(adminAuthenticationProperties));
+                        new AuthenticationInterceptor(gatewayRequestHandler));
     }
 
     @Bean

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
@@ -17,7 +17,6 @@ package ai.langstream.apigateway.websocket;
 
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.storage.ApplicationStore;
-import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
 import ai.langstream.apigateway.websocket.handlers.ChatHandler;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import lombok.SneakyThrows;
@@ -228,15 +227,15 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
         final ConsumeGateway consumeGateway =
                 (ConsumeGateway) context.attributes().get(ATTRIBUTE_CONSUME_GATEWAY);
         consumeGateway.startReadingAsync(
-                        executor,
-                        () -> !webSocketSession.isOpen(),
-                        message -> {
-                            try {
-                                webSocketSession.sendMessage(new TextMessage(message));
-                            } catch (IOException ex) {
-                                throw new RuntimeException(ex);
-                            }
-                        });
+                executor,
+                () -> !webSocketSession.isOpen(),
+                message -> {
+                    try {
+                        webSocketSession.sendMessage(new TextMessage(message));
+                    } catch (IOException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                });
     }
 
     protected static List<Function<Record, Boolean>> createMessageFilters(
@@ -291,11 +290,11 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
             throw ex;
         }
         context.attributes().put(ATTRIBUTE_CONSUME_GATEWAY, consumeGateway);
-
     }
 
     protected void setupProducer(
-            String topic, List<Header> commonHeaders, AuthenticatedGatewayRequestContext context) throws Exception {
+            String topic, List<Header> commonHeaders, AuthenticatedGatewayRequestContext context)
+            throws Exception {
         final ProduceGateway produceGateway = new ProduceGateway(topicConnectionsRuntimeRegistry);
 
         try {
@@ -325,10 +324,10 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
     protected void closeConsumeGateway(WebSocketSession webSocketSession) {
         closeConsumeGateway(getContext(webSocketSession));
     }
+
     protected void closeConsumeGateway(AuthenticatedGatewayRequestContext context) {
         final ConsumeGateway consumeGateway =
-                (ConsumeGateway)
-                        context.attributes().get(ATTRIBUTE_CONSUME_GATEWAY);
+                (ConsumeGateway) context.attributes().get(ATTRIBUTE_CONSUME_GATEWAY);
         if (consumeGateway == null) {
             return;
         }
@@ -341,8 +340,7 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
 
     protected void closeProduceGateway(AuthenticatedGatewayRequestContext context) {
         final ProduceGateway produceGateway =
-                (ProduceGateway)
-                        context.attributes().get(ATTRIBUTE_PRODUCE_GATEWAY);
+                (ProduceGateway) context.attributes().get(ATTRIBUTE_PRODUCE_GATEWAY);
         if (produceGateway == null) {
             return;
         }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
@@ -22,6 +22,8 @@ import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.apigateway.gateways.GatewayRequestHandler;
+import ai.langstream.apigateway.gateways.ProduceGateway;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,39 +55,59 @@ public class ChatHandler extends AbstractHandler {
     }
 
     @Override
-    Gateway.GatewayType gatewayType() {
+    public Gateway.GatewayType gatewayType() {
         return Gateway.GatewayType.chat;
     }
 
     @Override
-    String tenantFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
+    public  String tenantFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
         return parsedPath.get("tenant");
     }
 
     @Override
-    String applicationIdFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
+    public String applicationIdFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
         return parsedPath.get("application");
     }
 
     @Override
-    String gatewayFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
+    public String gatewayFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
         return parsedPath.get("gateway");
     }
 
     @Override
-    protected List<String> getAllRequiredParameters(Gateway gateway) {
-        List<String> parameters = gateway.getParameters();
-        if (parameters == null) {
-            parameters = new ArrayList<>();
-        }
-        if (gateway.getChatOptions() != null && gateway.getChatOptions().getHeaders() != null) {
-            for (Gateway.KeyValueComparison header : gateway.getChatOptions().getHeaders()) {
-                if (header.valueFromParameters() != null) {
-                    parameters.add(header.valueFromParameters());
+    public GatewayRequestHandler.GatewayRequestValidator validator() {
+        return new GatewayRequestHandler.GatewayRequestValidator() {
+            @Override
+            public List<String> getAllRequiredParameters(Gateway gateway) {
+                List<String> parameters = gateway.getParameters();
+                if (parameters == null) {
+                    parameters = new ArrayList<>();
+                }
+                if (gateway.getChatOptions() != null && gateway.getChatOptions().getHeaders() != null) {
+                    for (Gateway.KeyValueComparison header : gateway.getChatOptions().getHeaders()) {
+                        if (header.valueFromParameters() != null) {
+                            parameters.add(header.valueFromParameters());
+                        }
+                    }
+                }
+                return parameters;
+            }
+
+            @Override
+            public void validateOptions(Map<String, String> options) {
+                for (Map.Entry<String, String> option : options.entrySet()) {
+                    switch (option.getKey()) {
+                        case "position":
+                            if (!StringUtils.hasText(option.getValue())) {
+                                throw new IllegalArgumentException("'position' cannot be blank");
+                            }
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Unknown option " + option.getKey());
+                    }
                 }
             }
-        }
-        return parameters;
+        };
     }
 
     @Override
@@ -110,16 +132,10 @@ public class ChatHandler extends AbstractHandler {
             }
         }
         final List<Header> commonHeaders =
-                getProducerCommonHeaders(
-                        headerConfig, context.userParameters(), context.principalValues());
-        setupProducer(
-                context.attributes(),
-                chatOptions.getQuestionsTopic(),
-                context.application().getInstance().streamingCluster(),
-                commonHeaders,
-                context.tenant(),
-                context.applicationId(),
-                context.gateway().getId());
+                ProduceGateway.getProducerCommonHeaders(headerConfig, context.userParameters(),
+                        context.principalValues());
+
+        setupProducer(chatOptions.getQuestionsTopic(), commonHeaders, context);
     }
 
     private void setupReader(AuthenticatedGatewayRequestContext context) throws Exception {
@@ -136,18 +152,15 @@ public class ChatHandler extends AbstractHandler {
                 createMessageFilters(
                         headerFilters, context.userParameters(), context.principalValues());
 
-        setupReader(
-                context.attributes(),
-                chatOptions.getAnswersTopic(),
-                context.application().getInstance().streamingCluster(),
+        setupReader(chatOptions.getAnswersTopic(),
                 messageFilters,
-                context.options());
+                context);
     }
 
     @Override
     public void onOpen(
             WebSocketSession webSocketSession, AuthenticatedGatewayRequestContext context) {
-        startReadingMessages(webSocketSession, context, executor);
+        startReadingMessages(webSocketSession, executor);
     }
 
     @Override
@@ -165,18 +178,4 @@ public class ChatHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context,
             CloseStatus status) {}
 
-    @Override
-    void validateOptions(Map<String, String> options) {
-        for (Map.Entry<String, String> option : options.entrySet()) {
-            switch (option.getKey()) {
-                case "position":
-                    if (!StringUtils.hasText(option.getValue())) {
-                        throw new IllegalArgumentException("'position' cannot be blank");
-                    }
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown option " + option.getKey());
-            }
-        }
-    }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
@@ -118,13 +118,24 @@ public class ChatHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context, Map<String, Object> attributes)
             throws Exception {
 
-        setupReader(context);
-        setupProducer(context);
+        try {
+            setupReader(context);
+        } catch (Exception ex) {
+            log.error("Error setting up reader", ex);
+            throw ex;
+        }
+        try {
+            setupProducer(context);
+        } catch (Exception ex) {
+            log.error("Error setting up producer", ex);
+            closeConsumeGateway(context);
+            throw ex;
+        }
 
         sendClientConnectedEvent(context);
     }
 
-    private void setupProducer(AuthenticatedGatewayRequestContext context) {
+    private void setupProducer(AuthenticatedGatewayRequestContext context) throws Exception {
         final Gateway.ChatOptions chatOptions = context.gateway().getChatOptions();
 
         List<Gateway.KeyValueComparison> headerConfig = new ArrayList<>();
@@ -177,5 +188,8 @@ public class ChatHandler extends AbstractHandler {
     public void onClose(
             WebSocketSession webSocketSession,
             AuthenticatedGatewayRequestContext context,
-            CloseStatus status) {}
+            CloseStatus status) {
+        closeConsumeGateway(webSocketSession);
+        closeProduceGateway(webSocketSession);
+    }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
@@ -60,12 +60,13 @@ public class ChatHandler extends AbstractHandler {
     }
 
     @Override
-    public  String tenantFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
+    public String tenantFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
         return parsedPath.get("tenant");
     }
 
     @Override
-    public String applicationIdFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
+    public String applicationIdFromPath(
+            Map<String, String> parsedPath, Map<String, String> queryString) {
         return parsedPath.get("application");
     }
 
@@ -83,8 +84,10 @@ public class ChatHandler extends AbstractHandler {
                 if (parameters == null) {
                     parameters = new ArrayList<>();
                 }
-                if (gateway.getChatOptions() != null && gateway.getChatOptions().getHeaders() != null) {
-                    for (Gateway.KeyValueComparison header : gateway.getChatOptions().getHeaders()) {
+                if (gateway.getChatOptions() != null
+                        && gateway.getChatOptions().getHeaders() != null) {
+                    for (Gateway.KeyValueComparison header :
+                            gateway.getChatOptions().getHeaders()) {
                         if (header.valueFromParameters() != null) {
                             parameters.add(header.valueFromParameters());
                         }
@@ -132,8 +135,8 @@ public class ChatHandler extends AbstractHandler {
             }
         }
         final List<Header> commonHeaders =
-                ProduceGateway.getProducerCommonHeaders(headerConfig, context.userParameters(),
-                        context.principalValues());
+                ProduceGateway.getProducerCommonHeaders(
+                        headerConfig, context.userParameters(), context.principalValues());
 
         setupProducer(chatOptions.getQuestionsTopic(), commonHeaders, context);
     }
@@ -152,9 +155,7 @@ public class ChatHandler extends AbstractHandler {
                 createMessageFilters(
                         headerFilters, context.userParameters(), context.principalValues());
 
-        setupReader(chatOptions.getAnswersTopic(),
-                messageFilters,
-                context);
+        setupReader(chatOptions.getAnswersTopic(), messageFilters, context);
     }
 
     @Override
@@ -177,5 +178,4 @@ public class ChatHandler extends AbstractHandler {
             WebSocketSession webSocketSession,
             AuthenticatedGatewayRequestContext context,
             CloseStatus status) {}
-
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
@@ -62,7 +62,8 @@ public class ConsumeHandler extends AbstractHandler {
     }
 
     @Override
-    public String applicationIdFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
+    public String applicationIdFromPath(
+            Map<String, String> parsedPath, Map<String, String> queryString) {
         return parsedPath.get("application");
     }
 
@@ -113,9 +114,7 @@ public class ConsumeHandler extends AbstractHandler {
         } else {
             messageFilters = null;
         }
-        setupReader(context.gateway().getTopic(),
-                messageFilters,
-                context);
+        setupReader(context.gateway().getTopic(), messageFilters, context);
         sendClientConnectedEvent(context);
     }
 
@@ -137,5 +136,4 @@ public class ConsumeHandler extends AbstractHandler {
             CloseStatus closeStatus) {
         stopReadingMessages(webSocketSession);
     }
-
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
@@ -99,8 +99,7 @@ public class ConsumeHandler extends AbstractHandler {
 
     @Override
     public void onBeforeHandshakeCompleted(
-            AuthenticatedGatewayRequestContext context, Map<String, Object> attributes)
-            throws Exception {
+            AuthenticatedGatewayRequestContext context, Map<String, Object> attributes) {
 
         final Gateway.ConsumeOptions consumeOptions = context.gateway().getConsumeOptions();
 
@@ -114,7 +113,12 @@ public class ConsumeHandler extends AbstractHandler {
         } else {
             messageFilters = null;
         }
-        setupReader(context.gateway().getTopic(), messageFilters, context);
+        try {
+            setupReader(context.gateway().getTopic(), messageFilters, context);
+        } catch (Exception ex) {
+            log.error("Error setting up reader", ex);
+            throw new RuntimeException(ex);
+        }
         sendClientConnectedEvent(context);
     }
 
@@ -134,6 +138,6 @@ public class ConsumeHandler extends AbstractHandler {
             WebSocketSession webSocketSession,
             AuthenticatedGatewayRequestContext context,
             CloseStatus closeStatus) {
-        stopReadingMessages(webSocketSession);
+        closeConsumeGateway(webSocketSession);
     }
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
@@ -24,7 +24,6 @@ import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.gateways.ProduceGateway;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +56,8 @@ public class ProduceHandler extends AbstractHandler {
     }
 
     @Override
-    public String applicationIdFromPath(Map<String, String> parsedPath, Map<String, String> queryString) {
+    public String applicationIdFromPath(
+            Map<String, String> parsedPath, Map<String, String> queryString) {
         return parsedPath.get("application");
     }
 
@@ -76,7 +76,8 @@ public class ProduceHandler extends AbstractHandler {
             AuthenticatedGatewayRequestContext context, Map<String, Object> attributes)
             throws Exception {
         final List<Header> commonHeaders =
-                ProduceGateway.getProducerCommonHeaders(context.gateway().getProduceOptions(), context);
+                ProduceGateway.getProducerCommonHeaders(
+                        context.gateway().getProduceOptions(), context);
         setupProducer(context.gateway().getTopic(), commonHeaders, context);
 
         sendClientConnectedEvent(context);

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/impl/AuthenticatedGatewayRequestContextImpl.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/impl/AuthenticatedGatewayRequestContextImpl.java
@@ -25,6 +25,7 @@ import lombok.Builder;
 @Builder
 public class AuthenticatedGatewayRequestContextImpl implements AuthenticatedGatewayRequestContext {
 
+    private final String sessionId;
     private final GatewayRequestContext gatewayRequestContext;
     private final Map<String, Object> attributes;
     private final Map<String, String> principalValues;

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -249,7 +249,7 @@ abstract class GatewayResourceTest {
                 "http://localhost:%d/api/gateways/produce/tenant1/application1/produce"
                         .formatted(port);
 
-        produceAndExpectOk(url, "{\"value\": \"my-value\"}");
+        produceAndExpectOk(url, "{\"key\": \"my-key\", \"value\": \"my-value\"}");
         produceAndExpectOk(url, "{\"key\": \"my-key\"}");
         produceAndExpectOk(url, "{\"key\": \"my-key\", \"headers\": {\"h1\": \"v1\"}}");
     }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -1,12 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.http;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import ai.langstream.api.events.EventRecord;
-import ai.langstream.api.events.EventSources;
-import ai.langstream.api.events.GatewayEventData;
+
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.ApplicationSpecs;
 import ai.langstream.api.model.Gateway;
@@ -19,36 +32,23 @@ import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
-import ai.langstream.apigateway.websocket.api.ConsumePushMessage;
-import ai.langstream.apigateway.websocket.api.ProduceRequest;
-import ai.langstream.apigateway.websocket.api.ProduceResponse;
-import ai.langstream.apigateway.websocket.handlers.TestWebSocketClient;
 import ai.langstream.impl.deploy.ApplicationDeployer;
 import ai.langstream.impl.parser.ModelBuilder;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import jakarta.websocket.CloseReason;
-import jakarta.websocket.DeploymentException;
-import jakarta.websocket.Session;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
@@ -57,18 +57,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
-
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {
-                "spring.main.allow-bean-definition-overriding=true",
+            "spring.main.allow-bean-definition-overriding=true",
         })
 @WireMockTest
 @Slf4j
@@ -90,19 +87,19 @@ abstract class GatewayResourceTest {
     protected static ApplicationStore getMockedStore(String instanceYaml) {
         ApplicationStore mock = Mockito.mock(ApplicationStore.class);
         doAnswer(
-                invocationOnMock -> {
-                    final StoredApplication storedApplication = new StoredApplication();
-                    final Application application = buildApp(instanceYaml);
-                    storedApplication.setInstance(application);
-                    return storedApplication;
-                })
+                        invocationOnMock -> {
+                            final StoredApplication storedApplication = new StoredApplication();
+                            final Application application = buildApp(instanceYaml);
+                            storedApplication.setInstance(application);
+                            return storedApplication;
+                        })
                 .when(mock)
                 .get(anyString(), anyString(), anyBoolean());
         doAnswer(
-                invocationOnMock ->
-                        ApplicationSpecs.builder()
-                                .application(buildApp(instanceYaml))
-                                .build())
+                        invocationOnMock ->
+                                ApplicationSpecs.builder()
+                                        .application(buildApp(instanceYaml))
+                                        .build())
                 .when(mock)
                 .getSpecs(anyString(), anyString());
 
@@ -123,8 +120,7 @@ abstract class GatewayResourceTest {
         return props;
     }
 
-    @Autowired
-    private TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeProvider;
+    @Autowired private TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeProvider;
 
     @NotNull
     private static Application buildApp(String instanceYaml) throws Exception {
@@ -158,8 +154,7 @@ abstract class GatewayResourceTest {
         return application;
     }
 
-    @LocalServerPort
-    int port;
+    @LocalServerPort int port;
 
     @Autowired ApplicationStore store;
 
@@ -170,7 +165,6 @@ abstract class GatewayResourceTest {
     private static String genTopic() {
         return "topic" + topicCounter.incrementAndGet();
     }
-
 
     @BeforeAll
     public static void beforeAll(WireMockRuntimeInfo wmRuntimeInfo) {
@@ -190,7 +184,6 @@ abstract class GatewayResourceTest {
         Awaitility.reset();
     }
 
-
     @SneakyThrows
     void produceAndExpectOk(String url, String content) {
         final HttpRequest request =
@@ -198,11 +191,11 @@ abstract class GatewayResourceTest {
                         .header("Content-Type", "application/json")
                         .POST(HttpRequest.BodyPublishers.ofString(content))
                         .build();
-        final HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        final HttpResponse<String> response =
+                CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(200, response.statusCode());
         assertEquals("""
                 {"status":"OK","reason":null}""", response.body());
-
     }
 
     @SneakyThrows
@@ -212,13 +205,13 @@ abstract class GatewayResourceTest {
                         .header("Content-Type", "application/json")
                         .POST(HttpRequest.BodyPublishers.ofString(content))
                         .build();
-        final HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        final HttpResponse<String> response =
+                CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(400, response.statusCode());
         log.info("Response body: {}", response.body());
         final Map map = new ObjectMapper().readValue(response.body(), Map.class);
-        String detail = (String)map.get("detail");
+        String detail = (String) map.get("detail");
         assertTrue(detail.contains(errorMessage));
-
     }
 
     @SneakyThrows
@@ -228,10 +221,10 @@ abstract class GatewayResourceTest {
                         .header("Content-Type", "application/json")
                         .POST(HttpRequest.BodyPublishers.ofString(content))
                         .build();
-        final HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        final HttpResponse<String> response =
+                CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(401, response.statusCode());
         log.info("Response body: {}", response.body());
-
     }
 
     @Test
@@ -253,13 +246,13 @@ abstract class GatewayResourceTest {
                                         .build()));
 
         final String url =
-                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce".formatted(port);
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce"
+                        .formatted(port);
 
         produceAndExpectOk(url, "{\"value\": \"my-value\"}");
         produceAndExpectOk(url, "{\"key\": \"my-key\"}");
         produceAndExpectOk(url, "{\"key\": \"my-key\", \"headers\": {\"h1\": \"v1\"}}");
     }
-
 
     @Test
     void testParametersRequired() throws Exception {
@@ -281,15 +274,17 @@ abstract class GatewayResourceTest {
 
         final String content = "{\"value\": \"my-value\"}";
         produceAndExpectBadRequest(baseUrl, content, "missing required parameter session-id");
-        produceAndExpectBadRequest(baseUrl+ "?param:otherparam=1", content, "missing required parameter session-id");
-        produceAndExpectBadRequest(baseUrl+ "?param:session-id=", content, "missing required parameter session-id");
-        produceAndExpectBadRequest(baseUrl+ "?param:session-id=ok&param:another-non-declared=y", content, "unknown parameters: [another-non-declared]");
-        produceAndExpectOk(baseUrl+ "?param:session-id=1", content);
-        produceAndExpectOk(baseUrl+ "?param:session-id=string-value", content);
-
+        produceAndExpectBadRequest(
+                baseUrl + "?param:otherparam=1", content, "missing required parameter session-id");
+        produceAndExpectBadRequest(
+                baseUrl + "?param:session-id=", content, "missing required parameter session-id");
+        produceAndExpectBadRequest(
+                baseUrl + "?param:session-id=ok&param:another-non-declared=y",
+                content,
+                "unknown parameters: [another-non-declared]");
+        produceAndExpectOk(baseUrl + "?param:session-id=1", content);
+        produceAndExpectOk(baseUrl + "?param:session-id=string-value", content);
     }
-
-
 
     @Test
     void testAuthentication() throws Exception {
@@ -332,12 +327,14 @@ abstract class GatewayResourceTest {
                                         .build()));
 
         final String baseUrl =
-                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce".formatted(port);
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce"
+                        .formatted(port);
 
         produceAndExpectUnauthorized(baseUrl, "{\"value\": \"my-value\"}");
         produceAndExpectUnauthorized(baseUrl + "?credentials=", "{\"value\": \"my-value\"}");
         produceAndExpectUnauthorized(baseUrl + "?credentials=error", "{\"value\": \"my-value\"}");
-        produceAndExpectOk(baseUrl + "?credentials=test-user-password", "{\"value\": \"my-value\"}");
+        produceAndExpectOk(
+                baseUrl + "?credentials=test-user-password", "{\"value\": \"my-value\"}");
     }
 
     @Test
@@ -378,16 +375,18 @@ abstract class GatewayResourceTest {
                                         .build()));
 
         final String baseUrl =
-                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce".formatted(port);
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce"
+                        .formatted(port);
 
-
-        produceAndExpectUnauthorized(baseUrl + "?test-credentials=test", "{\"value\": \"my-value\"}");
-        produceAndExpectOk(baseUrl + "?test-credentials=test-user-password", "{\"value\": \"my-value\"}");
-        produceAndExpectUnauthorized("http://localhost:%d/api/gateways/produce/tenant1/application1/produce-no-test?test-credentials=test-user-password".formatted(port), "{\"value\": \"my-value\"}");
-
+        produceAndExpectUnauthorized(
+                baseUrl + "?test-credentials=test", "{\"value\": \"my-value\"}");
+        produceAndExpectOk(
+                baseUrl + "?test-credentials=test-user-password", "{\"value\": \"my-value\"}");
+        produceAndExpectUnauthorized(
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce-no-test?test-credentials=test-user-password"
+                        .formatted(port),
+                "{\"value\": \"my-value\"}");
     }
-
-
 
     protected abstract StreamingCluster getStreamingCluster();
 
@@ -409,5 +408,4 @@ abstract class GatewayResourceTest {
                         deployer.createImplementation(
                                 "app", store.get("t", "app", false).getInstance()));
     }
-
 }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -1,0 +1,413 @@
+package ai.langstream.apigateway.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import ai.langstream.api.events.EventRecord;
+import ai.langstream.api.events.EventSources;
+import ai.langstream.api.events.GatewayEventData;
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.ApplicationSpecs;
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.model.Gateways;
+import ai.langstream.api.model.StoredApplication;
+import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
+import ai.langstream.api.runtime.ClusterRuntimeRegistry;
+import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
+import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
+import ai.langstream.apigateway.websocket.api.ConsumePushMessage;
+import ai.langstream.apigateway.websocket.api.ProduceRequest;
+import ai.langstream.apigateway.websocket.api.ProduceResponse;
+import ai.langstream.apigateway.websocket.handlers.TestWebSocketClient;
+import ai.langstream.impl.deploy.ApplicationDeployer;
+import ai.langstream.impl.parser.ModelBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.DeploymentException;
+import jakarta.websocket.Session;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.main.allow-bean-definition-overriding=true",
+        })
+@WireMockTest
+@Slf4j
+abstract class GatewayResourceTest {
+
+    public static final Path agentsDirectory;
+    protected static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    static {
+        agentsDirectory = Path.of(System.getProperty("user.dir"), "target", "agents");
+        log.info("Agents directory is {}", agentsDirectory);
+    }
+
+    protected static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static List<String> topics;
+    static Gateways testGateways;
+
+    protected static ApplicationStore getMockedStore(String instanceYaml) {
+        ApplicationStore mock = Mockito.mock(ApplicationStore.class);
+        doAnswer(
+                invocationOnMock -> {
+                    final StoredApplication storedApplication = new StoredApplication();
+                    final Application application = buildApp(instanceYaml);
+                    storedApplication.setInstance(application);
+                    return storedApplication;
+                })
+                .when(mock)
+                .get(anyString(), anyString(), anyBoolean());
+        doAnswer(
+                invocationOnMock ->
+                        ApplicationSpecs.builder()
+                                .application(buildApp(instanceYaml))
+                                .build())
+                .when(mock)
+                .getSpecs(anyString(), anyString());
+
+        return mock;
+    }
+
+    protected static GatewayTestAuthenticationProperties getGatewayTestAuthenticationProperties() {
+        final GatewayTestAuthenticationProperties props = new GatewayTestAuthenticationProperties();
+        props.setType("http");
+        props.setConfiguration(
+                Map.of(
+                        "base-url",
+                        wireMockBaseUrl,
+                        "path-template",
+                        "/auth/{tenant}",
+                        "headers",
+                        Map.of("h1", "v1")));
+        return props;
+    }
+
+    @Autowired
+    private TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeProvider;
+
+    @NotNull
+    private static Application buildApp(String instanceYaml) throws Exception {
+        final Map<String, Object> module =
+                Map.of(
+                        "module",
+                        "mod1",
+                        "id",
+                        "p",
+                        "topics",
+                        topics.stream()
+                                .map(
+                                        t ->
+                                                Map.of(
+                                                        "name",
+                                                        t,
+                                                        "creation-mode",
+                                                        "create-if-not-exists"))
+                                .collect(Collectors.toList()));
+
+        final Application application =
+                ModelBuilder.buildApplicationInstance(
+                                Map.of(
+                                        "module.yaml",
+                                        new ObjectMapper(new YAMLFactory())
+                                                .writeValueAsString(module)),
+                                instanceYaml,
+                                null)
+                        .getApplication();
+        application.setGateways(testGateways);
+        return application;
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Autowired ApplicationStore store;
+
+    static WireMock wireMock;
+    static String wireMockBaseUrl;
+    static AtomicInteger topicCounter = new AtomicInteger();
+
+    private static String genTopic() {
+        return "topic" + topicCounter.incrementAndGet();
+    }
+
+
+    @BeforeAll
+    public static void beforeAll(WireMockRuntimeInfo wmRuntimeInfo) {
+        wireMock = wmRuntimeInfo.getWireMock();
+        wireMockBaseUrl = wmRuntimeInfo.getHttpBaseUrl();
+    }
+
+    @BeforeEach
+    public void beforeEach(WireMockRuntimeInfo wmRuntimeInfo) {
+        testGateways = null;
+        topics = null;
+        Awaitility.setDefaultTimeout(30, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        Awaitility.reset();
+    }
+
+
+    @SneakyThrows
+    void produceAndExpectOk(String url, String content) {
+        final HttpRequest request =
+                HttpRequest.newBuilder(URI.create(url))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(content))
+                        .build();
+        final HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        assertEquals("""
+                {"status":"OK","reason":null}""", response.body());
+
+    }
+
+    @SneakyThrows
+    void produceAndExpectBadRequest(String url, String content, String errorMessage) {
+        final HttpRequest request =
+                HttpRequest.newBuilder(URI.create(url))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(content))
+                        .build();
+        final HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode());
+        log.info("Response body: {}", response.body());
+        final Map map = new ObjectMapper().readValue(response.body(), Map.class);
+        String detail = (String)map.get("detail");
+        assertTrue(detail.contains(errorMessage));
+
+    }
+
+    @SneakyThrows
+    void produceAndExpectUnauthorized(String url, String content) {
+        final HttpRequest request =
+                HttpRequest.newBuilder(URI.create(url))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(content))
+                        .build();
+        final HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(401, response.statusCode());
+        log.info("Response body: {}", response.body());
+
+    }
+
+    @Test
+    void testSimpleProduce() throws Exception {
+        final String topic = genTopic();
+        prepareTopicsForTest(topic);
+        testGateways =
+                new Gateways(
+                        List.of(
+                                Gateway.builder()
+                                        .id("produce")
+                                        .type(Gateway.GatewayType.produce)
+                                        .topic(topic)
+                                        .build(),
+                                Gateway.builder()
+                                        .id("consume")
+                                        .type(Gateway.GatewayType.consume)
+                                        .topic(topic)
+                                        .build()));
+
+        final String url =
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce".formatted(port);
+
+        produceAndExpectOk(url, "{\"value\": \"my-value\"}");
+        produceAndExpectOk(url, "{\"key\": \"my-key\"}");
+        produceAndExpectOk(url, "{\"key\": \"my-key\", \"headers\": {\"h1\": \"v1\"}}");
+    }
+
+
+    @Test
+    void testParametersRequired() throws Exception {
+        final String topic = genTopic();
+        prepareTopicsForTest(topic);
+
+        testGateways =
+                new Gateways(
+                        List.of(
+                                Gateway.builder()
+                                        .id("gw")
+                                        .type(Gateway.GatewayType.produce)
+                                        .topic(topic)
+                                        .parameters(List.of("session-id"))
+                                        .build()));
+
+        final String baseUrl =
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/gw".formatted(port);
+
+        final String content = "{\"value\": \"my-value\"}";
+        produceAndExpectBadRequest(baseUrl, content, "missing required parameter session-id");
+        produceAndExpectBadRequest(baseUrl+ "?param:otherparam=1", content, "missing required parameter session-id");
+        produceAndExpectBadRequest(baseUrl+ "?param:session-id=", content, "missing required parameter session-id");
+        produceAndExpectBadRequest(baseUrl+ "?param:session-id=ok&param:another-non-declared=y", content, "unknown parameters: [another-non-declared]");
+        produceAndExpectOk(baseUrl+ "?param:session-id=1", content);
+        produceAndExpectOk(baseUrl+ "?param:session-id=string-value", content);
+
+    }
+
+
+
+    @Test
+    void testAuthentication() throws Exception {
+        final String topic = genTopic();
+        prepareTopicsForTest(topic);
+
+        testGateways =
+                new Gateways(
+                        List.of(
+                                Gateway.builder()
+                                        .id("produce")
+                                        .type(Gateway.GatewayType.produce)
+                                        .topic(topic)
+                                        .authentication(
+                                                new Gateway.Authentication(
+                                                        "test-auth", Map.of(), true))
+                                        .produceOptions(
+                                                new Gateway.ProduceOptions(
+                                                        List.of(
+                                                                Gateway.KeyValueComparison
+                                                                        .valueFromAuthentication(
+                                                                                "header1",
+                                                                                "login"))))
+                                        .build(),
+                                Gateway.builder()
+                                        .id("consume")
+                                        .type(Gateway.GatewayType.consume)
+                                        .topic(topic)
+                                        .authentication(
+                                                new Gateway.Authentication(
+                                                        "test-auth", Map.of(), true))
+                                        .consumeOptions(
+                                                new Gateway.ConsumeOptions(
+                                                        new Gateway.ConsumeOptionsFilters(
+                                                                List.of(
+                                                                        Gateway.KeyValueComparison
+                                                                                .valueFromAuthentication(
+                                                                                        "header1",
+                                                                                        "login")))))
+                                        .build()));
+
+        final String baseUrl =
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce".formatted(port);
+
+        produceAndExpectUnauthorized(baseUrl, "{\"value\": \"my-value\"}");
+        produceAndExpectUnauthorized(baseUrl + "?credentials=", "{\"value\": \"my-value\"}");
+        produceAndExpectUnauthorized(baseUrl + "?credentials=error", "{\"value\": \"my-value\"}");
+        produceAndExpectOk(baseUrl + "?credentials=test-user-password", "{\"value\": \"my-value\"}");
+    }
+
+    @Test
+    void testTestCredentials() throws Exception {
+        wireMock.register(
+                WireMock.get("/auth/tenant1")
+                        .withHeader("Authorization", WireMock.equalTo("Bearer test-user-password"))
+                        .withHeader("h1", WireMock.equalTo("v1"))
+                        .willReturn(WireMock.ok("")));
+        final String topic = genTopic();
+        prepareTopicsForTest(topic);
+
+        testGateways =
+                new Gateways(
+                        List.of(
+                                Gateway.builder()
+                                        .id("produce")
+                                        .type(Gateway.GatewayType.produce)
+                                        .topic(topic)
+                                        .authentication(
+                                                new Gateway.Authentication(
+                                                        "test-auth", Map.of(), true))
+                                        .produceOptions(
+                                                new Gateway.ProduceOptions(
+                                                        List.of(
+                                                                Gateway.KeyValueComparison
+                                                                        .valueFromAuthentication(
+                                                                                "header1",
+                                                                                "login"))))
+                                        .build(),
+                                Gateway.builder()
+                                        .id("produce-no-test")
+                                        .type(Gateway.GatewayType.produce)
+                                        .topic(topic)
+                                        .authentication(
+                                                new Gateway.Authentication(
+                                                        "test-auth", Map.of(), false))
+                                        .build()));
+
+        final String baseUrl =
+                "http://localhost:%d/api/gateways/produce/tenant1/application1/produce".formatted(port);
+
+
+        produceAndExpectUnauthorized(baseUrl + "?test-credentials=test", "{\"value\": \"my-value\"}");
+        produceAndExpectOk(baseUrl + "?test-credentials=test-user-password", "{\"value\": \"my-value\"}");
+        produceAndExpectUnauthorized("http://localhost:%d/api/gateways/produce/tenant1/application1/produce-no-test?test-credentials=test-user-password".formatted(port), "{\"value\": \"my-value\"}");
+
+    }
+
+
+
+    protected abstract StreamingCluster getStreamingCluster();
+
+    private void prepareTopicsForTest(String... topic) throws Exception {
+        topics = List.of(topic);
+        TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry =
+                topicConnectionsRuntimeProvider.getTopicConnectionsRuntimeRegistry();
+        final ApplicationDeployer deployer =
+                ApplicationDeployer.builder()
+                        .pluginsRegistry(new PluginsRegistry())
+                        .registry(new ClusterRuntimeRegistry())
+                        .topicConnectionsRuntimeRegistry(topicConnectionsRuntimeRegistry)
+                        .build();
+        final StreamingCluster streamingCluster = getStreamingCluster();
+        topicConnectionsRuntimeRegistry
+                .getTopicConnectionsRuntime(streamingCluster)
+                .asTopicConnectionsRuntime()
+                .deploy(
+                        deployer.createImplementation(
+                                "app", store.get("t", "app", false).getInstance()));
+    }
+
+}

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/KafkaGatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/KafkaGatewayResourceTest.java
@@ -1,54 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.http;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import ai.langstream.api.model.Application;
-import ai.langstream.api.model.ApplicationSpecs;
-import ai.langstream.api.model.Gateway;
-import ai.langstream.api.model.Gateways;
-import ai.langstream.api.model.StoredApplication;
 import ai.langstream.api.model.StreamingCluster;
-import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
-import ai.langstream.api.runtime.ClusterRuntimeRegistry;
-import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
-import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
-import ai.langstream.impl.deploy.ApplicationDeployer;
-import ai.langstream.impl.parser.ModelBuilder;
 import ai.langstream.kafka.extensions.KafkaContainerExtension;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
-import org.awaitility.Awaitility;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
-
 
 class KafkaGatewayResourceTest extends GatewayResourceTest {
 

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/KafkaGatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/KafkaGatewayResourceTest.java
@@ -1,0 +1,98 @@
+package ai.langstream.apigateway.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.ApplicationSpecs;
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.model.Gateways;
+import ai.langstream.api.model.StoredApplication;
+import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
+import ai.langstream.api.runtime.ClusterRuntimeRegistry;
+import ai.langstream.api.runtime.PluginsRegistry;
+import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
+import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
+import ai.langstream.impl.deploy.ApplicationDeployer;
+import ai.langstream.impl.parser.ModelBuilder;
+import ai.langstream.kafka.extensions.KafkaContainerExtension;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+
+class KafkaGatewayResourceTest extends GatewayResourceTest {
+
+    @RegisterExtension
+    static KafkaContainerExtension kafkaContainer = new KafkaContainerExtension();
+
+    @Override
+    protected StreamingCluster getStreamingCluster() {
+        return new StreamingCluster(
+                "kafka",
+                Map.of(
+                        "admin",
+                        Map.of(
+                                "bootstrap.servers",
+                                kafkaContainer.getBootstrapServers(),
+                                "default.api.timeout.ms",
+                                5000)));
+    }
+
+    @TestConfiguration
+    public static class WebSocketTestConfig {
+
+        @Bean
+        @Primary
+        public ApplicationStore store() {
+            String instanceYaml =
+                    """
+                    instance:
+                      streamingCluster:
+                        type: "kafka"
+                        configuration:
+                          admin:
+                            bootstrap.servers: "%s"
+                      computeCluster:
+                         type: "none"
+                    """
+                            .formatted(kafkaContainer.getBootstrapServers());
+            return getMockedStore(instanceYaml);
+        }
+
+        @Bean
+        @Primary
+        public GatewayTestAuthenticationProperties gatewayTestAuthenticationProperties() {
+            return getGatewayTestAuthenticationProperties();
+        }
+    }
+}

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/PulsarGatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/PulsarGatewayResourceTest.java
@@ -1,19 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.apigateway.http;
 
 import ai.langstream.api.model.StreamingCluster;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
 import ai.langstream.apigateway.websocket.handlers.PulsarContainerExtension;
-import ai.langstream.kafka.extensions.KafkaContainerExtension;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
-
 
 class PulsarGatewayResourceTest extends GatewayResourceTest {
 

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/PulsarGatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/PulsarGatewayResourceTest.java
@@ -1,0 +1,71 @@
+package ai.langstream.apigateway.http;
+
+import ai.langstream.api.model.StreamingCluster;
+import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
+import ai.langstream.apigateway.websocket.handlers.PulsarContainerExtension;
+import ai.langstream.kafka.extensions.KafkaContainerExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+
+class PulsarGatewayResourceTest extends GatewayResourceTest {
+
+    @RegisterExtension
+    static PulsarContainerExtension pulsarContainer = new PulsarContainerExtension();
+
+    @Override
+    protected StreamingCluster getStreamingCluster() {
+        return new StreamingCluster(
+                "pulsar",
+                Map.of(
+                        "admin",
+                        Map.of("serviceUrl", pulsarContainer.getHttpServiceUrl()),
+                        "service",
+                        Map.of("serviceUrl", pulsarContainer.getBrokerUrl()),
+                        "default-tenant",
+                        "public",
+                        "default-namespace",
+                        "default"));
+    }
+
+    @TestConfiguration
+    public static class WebSocketTestConfig {
+
+        @Bean
+        @Primary
+        public ApplicationStore store() {
+            String instanceYaml =
+                    """
+                     instance:
+                       streamingCluster:
+                         type: "pulsar"
+                         configuration:
+                           admin:
+                             serviceUrl: "%s"
+                           service:
+                             serviceUrl: "%s"
+                           default-tenant: "public"
+                           default-namespace: "default"
+                       computeCluster:
+                         type: "none"
+                     """
+                            .formatted(
+                                    pulsarContainer.getHttpServiceUrl(),
+                                    pulsarContainer.getBrokerUrl());
+            return getMockedStore(instanceYaml);
+        }
+
+        @Bean
+        @Primary
+        public GatewayTestAuthenticationProperties gatewayTestAuthenticationProperties() {
+            return getGatewayTestAuthenticationProperties();
+        }
+    }
+}

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/TestGatewayAuthenticationProvider.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/TestGatewayAuthenticationProvider.java
@@ -35,7 +35,8 @@ public class TestGatewayAuthenticationProvider implements GatewayAuthenticationP
     @Override
     public GatewayAuthenticationResult authenticate(GatewayRequestContext context) {
         log.info("Authenticating {}", context.credentials());
-        if (context.credentials() != null && context.credentials().startsWith("test-user-password")) {
+        if (context.credentials() != null
+                && context.credentials().startsWith("test-user-password")) {
             return GatewayAuthenticationResult.authenticationSuccessful(
                     Map.of("login", context.credentials()));
         } else {

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/TestGatewayAuthenticationProvider.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/TestGatewayAuthenticationProvider.java
@@ -35,7 +35,7 @@ public class TestGatewayAuthenticationProvider implements GatewayAuthenticationP
     @Override
     public GatewayAuthenticationResult authenticate(GatewayRequestContext context) {
         log.info("Authenticating {}", context.credentials());
-        if (context.credentials().startsWith("test-user-password")) {
+        if (context.credentials() != null && context.credentials().startsWith("test-user-password")) {
             return GatewayAuthenticationResult.authenticationSuccessful(
                     Map.of("login", context.credentials()));
         } else {

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
@@ -292,21 +292,25 @@ abstract class ProduceConsumeHandlerTest {
                                         .parameters(List.of("session-id"))
                                         .build()));
         connectAndExpectHttpError(
-                URI.create("ws://localhost:%d/v1/%s/tenant1/application1/gw".formatted(port, type)), 500);
+                URI.create("ws://localhost:%d/v1/%s/tenant1/application1/gw".formatted(port, type)),
+                500);
         connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/%s/tenant1/application1/gw?param:otherparam=1"
-                                .formatted(port, type)), 500);
+                                .formatted(port, type)),
+                500);
         connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/%s/tenant1/application1/gw?param:session-id="
-                                .formatted(port, type)), 500);
+                                .formatted(port, type)),
+                500);
 
         connectAndExpectHttpError(
                 URI.create(
                         ("ws://localhost:%d/v1/%s/tenant1/application1/gw?param:session-id=ok&param:another-non"
                                         + "-declared=y")
-                                .formatted(port, type)), 500);
+                                .formatted(port, type)),
+                500);
 
         connectAndExpectRunning(
                 URI.create(
@@ -465,15 +469,18 @@ abstract class ProduceConsumeHandlerTest {
         connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                .formatted(port)), 401);
+                                .formatted(port)),
+                401);
         connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce?credentials="
-                                .formatted(port)), 401);
+                                .formatted(port)),
+                401);
         connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce?credentials=error"
-                                .formatted(port)), 401);
+                                .formatted(port)),
+                401);
         connectAndExpectRunning(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce?credentials=test-user-password"
@@ -605,13 +612,15 @@ abstract class ProduceConsumeHandlerTest {
                 URI.create(
                         ("ws://localhost:%d/v1/consume/tenant1/application1/consume-no-test?test-credentials=test"
                                         + "-user-password")
-                                .formatted(port)), 401);
+                                .formatted(port)),
+                401);
 
         connectAndExpectHttpError(
                 URI.create(
                         ("ws://localhost:%d/v1/produce/tenant1/application1/produce?test-credentials=test-user"
                                         + "-password-but-wrong")
-                                .formatted(port)), 401);
+                                .formatted(port)),
+                401);
     }
 
     private record MsgRecord(Object key, Object value, Map<String, String> headers) {}
@@ -1084,15 +1093,14 @@ abstract class ProduceConsumeHandlerTest {
         return "topic" + topicCounter.incrementAndGet();
     }
 
-
     private void connectAndExpectClose(URI connectTo, CloseReason expectedCloseReason) {
         connectAndExpectClose(connectTo, expectedCloseReason, -1);
-
     }
+
     private void connectAndExpectHttpError(URI connectTo, int code) {
         connectAndExpectClose(connectTo, null, code);
-
     }
+
     @SneakyThrows
     private void connectAndExpectClose(URI connectTo, CloseReason expectedCloseReason, int code) {
         CountDownLatch countDownLatch = new CountDownLatch(1);

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
@@ -291,34 +291,22 @@ abstract class ProduceConsumeHandlerTest {
                                         .topic(topic)
                                         .parameters(List.of("session-id"))
                                         .build()));
-        connectAndExpectClose(
-                URI.create("ws://localhost:%d/v1/%s/tenant1/application1/gw".formatted(port, type)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "missing required parameter session-id"));
-        connectAndExpectClose(
+        connectAndExpectHttpError(
+                URI.create("ws://localhost:%d/v1/%s/tenant1/application1/gw".formatted(port, type)), 500);
+        connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/%s/tenant1/application1/gw?param:otherparam=1"
-                                .formatted(port, type)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "missing required parameter session-id"));
-        connectAndExpectClose(
+                                .formatted(port, type)), 500);
+        connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/%s/tenant1/application1/gw?param:session-id="
-                                .formatted(port, type)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "missing required parameter session-id"));
+                                .formatted(port, type)), 500);
 
-        connectAndExpectClose(
+        connectAndExpectHttpError(
                 URI.create(
                         ("ws://localhost:%d/v1/%s/tenant1/application1/gw?param:session-id=ok&param:another-non"
                                         + "-declared=y")
-                                .formatted(port, type)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "unknown parameters: [another-non-declared]"));
+                                .formatted(port, type)), 500);
 
         connectAndExpectRunning(
                 URI.create(
@@ -474,27 +462,18 @@ abstract class ProduceConsumeHandlerTest {
                                                                                         "login")))))
                                         .build()));
 
-        connectAndExpectClose(
+        connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce"
-                                .formatted(port)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "missing required parameter session-id"));
-        connectAndExpectClose(
+                                .formatted(port)), 401);
+        connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce?credentials="
-                                .formatted(port)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "missing required parameter session-id"));
-        connectAndExpectClose(
+                                .formatted(port)), 401);
+        connectAndExpectHttpError(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce?credentials=error"
-                                .formatted(port)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "missing required parameter session-id"));
+                                .formatted(port)), 401);
         connectAndExpectRunning(
                 URI.create(
                         "ws://localhost:%d/v1/produce/tenant1/application1/produce?credentials=test-user-password"
@@ -622,21 +601,17 @@ abstract class ProduceConsumeHandlerTest {
                                                                 "9d75ff199d33e051209b59702de27d1e470eafb58ac6d8865788bf23b48e6818"))),
                                         user1Messages));
 
-        connectAndExpectClose(
+        connectAndExpectHttpError(
                 URI.create(
-                        ("ws://localhost:%d/v1/consume/tenant1/application1/consume-no-admin?test-credentials=test"
+                        ("ws://localhost:%d/v1/consume/tenant1/application1/consume-no-test?test-credentials=test"
                                         + "-user-password")
-                                .formatted(port)),
-                new CloseReason(
-                        CloseReason.CloseCodes.VIOLATED_POLICY,
-                        "Gateway consume-no-test of tenant tenant1 does not allow test mode."));
+                                .formatted(port)), 401);
 
-        connectAndExpectClose(
+        connectAndExpectHttpError(
                 URI.create(
                         ("ws://localhost:%d/v1/produce/tenant1/application1/produce?test-credentials=test-user"
                                         + "-password-but-wrong")
-                                .formatted(port)),
-                new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "Invalid credentials"));
+                                .formatted(port)), 401);
     }
 
     private record MsgRecord(Object key, Object value, Map<String, String> headers) {}
@@ -1109,8 +1084,17 @@ abstract class ProduceConsumeHandlerTest {
         return "topic" + topicCounter.incrementAndGet();
     }
 
-    @SneakyThrows
+
     private void connectAndExpectClose(URI connectTo, CloseReason expectedCloseReason) {
+        connectAndExpectClose(connectTo, expectedCloseReason, -1);
+
+    }
+    private void connectAndExpectHttpError(URI connectTo, int code) {
+        connectAndExpectClose(connectTo, null, code);
+
+    }
+    @SneakyThrows
+    private void connectAndExpectClose(URI connectTo, CloseReason expectedCloseReason, int code) {
         CountDownLatch countDownLatch = new CountDownLatch(1);
 
         AtomicReference<CloseReason> closeReason = new AtomicReference<>();
@@ -1137,11 +1121,20 @@ abstract class ProduceConsumeHandlerTest {
                         .connect(connectTo)) {
             Thread.sleep(5000);
             countDownLatch.await();
+            if (expectedCloseReason == null) {
+                throw new RuntimeException("close reason not expected");
+            }
             assertEquals(
                     expectedCloseReason.getReasonPhrase(), closeReason.get().getReasonPhrase());
             assertEquals(expectedCloseReason.getCloseCode(), closeReason.get().getCloseCode());
         } catch (DeploymentException e) {
-            // ok
+            if (code > 0) {
+                if (e.getMessage().contains("[" + code + "]")) {
+                    return;
+                }
+                throw new RuntimeException("expected http error code " + code, e);
+            }
+            throw new RuntimeException(e);
         }
     }
 

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/BaseGatewayCmd.java
@@ -34,8 +34,10 @@ import picocli.CommandLine;
 public abstract class BaseGatewayCmd extends BaseCmd {
 
     protected static final ObjectMapper messageMapper = new ObjectMapper();
+
     protected enum Protocols {
-        ws, http;
+        ws,
+        http;
     }
 
     @CommandLine.ParentCommand private RootGatewayCmd cmd;
@@ -110,7 +112,6 @@ public abstract class BaseGatewayCmd extends BaseCmd {
                     applicationId,
                     gatewayId,
                     computeQueryString(systemParams, params, options));
-
         }
 
         return String.format(
@@ -130,7 +131,6 @@ public abstract class BaseGatewayCmd extends BaseCmd {
     private String getApiGatewayUrl() {
         return getCurrentProfile().getApiGatewayUrl();
     }
-
 
     private String getApiGatewayUrlHttp() {
         return getApiGatewayUrl().replace("wss://", "https://").replace("ws://", "http://");

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ChatGatewayCmd.java
@@ -238,7 +238,8 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
                             finalParams,
                             consumeGatewayOptions,
                             credentials,
-                            testCredentials);
+                            testCredentials,
+                            Protocols.ws);
             return new ChatGatewayConnection(url, connectTimeout);
         }
 
@@ -250,7 +251,8 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
                         params,
                         consumeGatewayOptions,
                         credentials,
-                        testCredentials);
+                        testCredentials,
+                        Protocols.ws);
         final String producePath =
                 validateGatewayAndGetUrl(
                         applicationId,
@@ -259,7 +261,8 @@ public class ChatGatewayCmd extends BaseGatewayCmd {
                         params,
                         Map.of(),
                         credentials,
-                        testCredentials);
+                        testCredentials,
+                        Protocols.ws);
         return new ProduceConsumeGatewaysConnection(consumePath, producePath, connectTimeout);
     }
 

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ConsumeGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ConsumeGatewayCmd.java
@@ -83,7 +83,8 @@ public class ConsumeGatewayCmd extends BaseGatewayCmd {
                         params,
                         options,
                         credentials,
-                        testCredentials);
+                        testCredentials,
+                        Protocols.ws);
 
         final Duration connectTimeout =
                 connectTimeoutSeconds > 0 ? Duration.ofSeconds(connectTimeoutSeconds) : null;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/gateway/ProduceGatewayCmd.java
@@ -87,7 +87,8 @@ public class ProduceGatewayCmd extends BaseGatewayCmd {
 
     @CommandLine.Option(
             names = {"--protocol"},
-            description = "Protocol to use: http or ws", defaultValue = "ws")
+            description = "Protocol to use: http or ws",
+            defaultValue = "ws")
     private Protocols protocol = Protocols.ws;
 
     @Override
@@ -106,8 +107,7 @@ public class ProduceGatewayCmd extends BaseGatewayCmd {
         final Duration connectTimeout =
                 connectTimeoutSeconds > 0 ? Duration.ofSeconds(connectTimeoutSeconds) : null;
 
-        final ProduceRequest produceRequest =
-                new ProduceRequest(messageKey, messageValue, headers);
+        final ProduceRequest produceRequest = new ProduceRequest(messageKey, messageValue, headers);
         final String json = messageMapper.writeValueAsString(produceRequest);
 
         if (protocol == Protocols.http) {
@@ -117,7 +117,8 @@ public class ProduceGatewayCmd extends BaseGatewayCmd {
         }
     }
 
-    private void produceWebSocket(String producePath, Duration connectTimeout, String json) throws Exception {
+    private void produceWebSocket(String producePath, Duration connectTimeout, String json)
+            throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         try (final WebSocketClient client =
                 new WebSocketClient(
@@ -156,17 +157,21 @@ public class ProduceGatewayCmd extends BaseGatewayCmd {
         }
     }
 
-    private void produceHttp(String producePath, Duration connectTimeout, String json) throws Exception {
-        final HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(producePath))
-                .header("Content-Type", "application/json")
-                .version(HttpClient.Version.HTTP_1_1)
-                .POST(HttpRequest.BodyPublishers.ofString(json));
+    private void produceHttp(String producePath, Duration connectTimeout, String json)
+            throws Exception {
+        final HttpRequest.Builder builder =
+                HttpRequest.newBuilder(URI.create(producePath))
+                        .header("Content-Type", "application/json")
+                        .version(HttpClient.Version.HTTP_1_1)
+                        .POST(HttpRequest.BodyPublishers.ofString(json));
         if (connectTimeout != null) {
             builder.timeout(connectTimeout);
         }
         final HttpRequest request = builder.build();
         final HttpResponse<String> response =
-                getClient().getHttpClientFacade().http(request, HttpResponse.BodyHandlers.ofString());
+                getClient()
+                        .getHttpClientFacade()
+                        .http(request, HttpResponse.BodyHandlers.ofString());
         log(response.body());
     }
 }

--- a/langstream-kafka-runtime/pom.xml
+++ b/langstream-kafka-runtime/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>langstream-kafka-runtime</artifactId>
   <packaging>jar</packaging>
-  <name>LangStream - Kafka Implementation</name>
+  <name>LangStream - Kafka runtime</name>
   <properties>
     <build.dir>${project.build.directory}</build.dir>
   </properties>

--- a/langstream-pulsar-runtime/pom.xml
+++ b/langstream-pulsar-runtime/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>langstream-pulsar-runtime</artifactId>
   <packaging>jar</packaging>
-  <name>LangStream - Pulsar Implementation</name>
+  <name>LangStream - Pulsar runtime</name>
   <properties>
     <build.dir>${project.build.directory}</build.dir>
   </properties>

--- a/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
+++ b/langstream-pulsar-runtime/src/main/java/ai/langstream/pulsar/runner/PulsarTopicConnectionsRuntimeProvider.java
@@ -667,11 +667,12 @@ public class PulsarTopicConnectionsRuntimeProvider implements TopicConnectionsRu
                 totalIn.addAndGet(1);
                 if (schema == null) {
                     try {
-                        if (r.value() == null) {
-                            throw new IllegalStateException(
-                                    "Cannot infer schema because value is null");
+                        final Schema<?> valueSchema;
+                        if (r.value() != null) {
+                            valueSchema = getSchema(r.value().getClass());
+                        } else {
+                            valueSchema = Schema.BYTES;
                         }
-                        Schema<?> valueSchema = getSchema(r.value().getClass());
                         if (r.key() != null) {
                             Schema<?> keySchema = getSchema(r.key().getClass());
                             schema =


### PR DESCRIPTION
Changes:
* It is now possible produce a message for a "produce" gateway by using HTTP. There's no need to change anything in the application config.
* The endpoint is http://api-gateway-xxxx:8091/api/gateways/produce/{tenant}/{application}/{gateway}
The body must be a json {value: xx, key:xx, headers: {xx}}