### PR TITLE
[docker] Do not close classloaders, to prevent spammy ClassNotFoundExceptions

### DIFF
--- a/langstream-core/src/main/java/ai/langstream/impl/nar/NarFileHandler.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/nar/NarFileHandler.java
@@ -51,7 +51,7 @@ public class NarFileHandler
             Boolean.parseBoolean(System.getProperty("langstream.nar.closeClassloaders", "true"));
 
     static {
-        log.info("langstream.nar.close-classloaders = {}", CLOSE_CLASSLOADERS);
+        log.info("langstream.nar.closeClassloaders = {}", CLOSE_CLASSLOADERS);
     }
 
     private final Path packagesDirectory;

--- a/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
+++ b/langstream-runtime/langstream-runtime-tester/src/main/assemble/entrypoint.sh
@@ -33,4 +33,4 @@ if [ "$START_HERDDB" = "true" ]; then
   /herddb/herddb/bin/service server start
 fi
 
-exec java ${JAVA_OPTS} -Dlogging.config=/app/logback.xml -Djdk.lang.Process.launchMechanism=vfork -cp "/app/lib/*" "ai.langstream.runtime.tester.Main"
+exec java ${JAVA_OPTS} -Dlangstream.nar.closeClassloaders=false -Dlogging.config=/app/logback.xml -Djdk.lang.Process.launchMechanism=vfork -cp "/app/lib/*" "ai.langstream.runtime.tester.Main"


### PR DESCRIPTION
When the docker container is existing, usually due to an error in the configuration, we close the classloaders and this triggers a lot of spammy ClassNotFound errors that are misleading, because users think that there is a bug somewhere in LangStream.

The trick here is not not close them: the JMV is existing, there is no risk of leaking resources.
Also the tmp directory of the container is ephemeral: we are not leaving dangling temporary files