### PR TITLE
API gateway: cache topic producer for the same gateway

### DIFF
--- a/langstream-api-gateway/pom.xml
+++ b/langstream-api-gateway/pom.xml
@@ -142,6 +142,10 @@
 			<artifactId>langstream-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>ai.langstream</groupId>

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/LangStreamApiGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/LangStreamApiGateway.java
@@ -17,6 +17,7 @@ package ai.langstream.apigateway;
 
 import ai.langstream.apigateway.config.GatewayTestAuthenticationProperties;
 import ai.langstream.apigateway.config.StorageProperties;
+import ai.langstream.apigateway.config.TopicProperties;
 import ai.langstream.apigateway.runner.CodeConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +30,8 @@ import org.springframework.core.env.Environment;
 @EnableConfigurationProperties({
     StorageProperties.class,
     GatewayTestAuthenticationProperties.class,
-    CodeConfiguration.class
+    CodeConfiguration.class,
+    TopicProperties.class
 })
 public class LangStreamApiGateway {
 

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/MetricsNames.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/MetricsNames.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway;
+
+public class MetricsNames {
+    public static final String TOPIC_PRODUCER_CACHE = "topic_producer_cache";
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/config/TopicProperties.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/config/TopicProperties.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "application.topics")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopicProperties {
+
+    @JsonProperty("producers-cache-enabled")
+    private boolean producersCacheEnabled;
+
+    @JsonProperty("producers-cache-size")
+    private int producersCacheSize;
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
@@ -153,8 +153,7 @@ public class ConsumeGateway implements AutoCloseable {
                         executor);
     }
 
-    private void readMessages(Supplier<Boolean> stop, Consumer<String> onMessage)
-            throws Exception {
+    private void readMessages(Supplier<Boolean> stop, Consumer<String> onMessage) throws Exception {
         while (true) {
             if (interrupted) {
                 return;

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
@@ -153,7 +153,7 @@ public class ConsumeGateway implements AutoCloseable {
                         executor);
     }
 
-    protected void readMessages(Supplier<Boolean> stop, Consumer<String> onMessage)
+    private void readMessages(Supplier<Boolean> stop, Consumer<String> onMessage)
             throws Exception {
         while (true) {
             if (interrupted) {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/LRUTopicProducerCache.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/LRUTopicProducerCache.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.gateways;
+
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.topics.TopicProducer;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalNotification;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LRUTopicProducerCache implements TopicProducerCache {
+
+    private static class SharedTopicProducer implements TopicProducer {
+        private TopicProducer producer;
+        private volatile int referenceCount;
+        private volatile boolean cached = true;
+
+        public SharedTopicProducer(TopicProducer producer) {
+            this.producer = producer;
+        }
+
+        public boolean acquire() {
+            synchronized (this) {
+                if (producer == null) {
+                    return false;
+                }
+                referenceCount++;
+                return true;
+            }
+        }
+
+        public void removedFromCache() {
+            synchronized (this) {
+                cached = false;
+                if (referenceCount == 0) {
+                    producer.close();
+                    producer = null;
+                }
+            }
+        }
+
+        @Override
+        public void start() {
+            producer.start();
+        }
+
+        @Override
+        public void close() {
+            synchronized (this) {
+                referenceCount--;
+                if (referenceCount == 0 && !cached) {
+                    producer.close();
+                    producer = null;
+                }
+            }
+        }
+
+        @Override
+        public CompletableFuture<?> write(Record record) {
+            return producer.write(record);
+        }
+
+        @Override
+        public Object getNativeProducer() {
+            return producer.getNativeProducer();
+        }
+
+        @Override
+        public Object getInfo() {
+            return producer.getInfo();
+        }
+
+        @Override
+        public long getTotalIn() {
+            return 0;
+        }
+    }
+
+    @Getter private final Cache<Key, SharedTopicProducer> cache;
+
+    public LRUTopicProducerCache(int size) {
+        this.cache =
+                CacheBuilder.newBuilder()
+                        .maximumSize(size)
+                        .expireAfterWrite(10, TimeUnit.MINUTES)
+                        .expireAfterAccess(10, TimeUnit.MINUTES)
+                        .removalListener(
+                                (RemovalNotification<Key, SharedTopicProducer> notification) -> {
+                                    SharedTopicProducer resource = notification.getValue();
+                                    resource.removedFromCache();
+                                })
+                        .recordStats()
+                        .build();
+    }
+
+    @Override
+    public TopicProducer getOrCreate(
+            TopicProducerCache.Key key, Supplier<TopicProducer> topicProducerSupplier) {
+        try {
+            final SharedTopicProducer sharedTopicProducer =
+                    cache.get(
+                            key,
+                            () -> {
+                                final SharedTopicProducer result =
+                                        new SharedTopicProducer(topicProducerSupplier.get());
+                                log.debug("Created new topic producer {}", key);
+                                return result;
+                            });
+            if (!sharedTopicProducer.acquire()) {
+                log.warn("Not able to acquire topic producer {}, retry", key);
+                return getOrCreate(key, topicProducerSupplier);
+            }
+            return sharedTopicProducer;
+        } catch (ExecutionException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -41,8 +41,8 @@ import org.apache.commons.lang3.tuple.Pair;
 @Slf4j
 public class ProduceGateway implements AutoCloseable {
 
-    protected static final ObjectMapper mapper = new ObjectMapper()
-            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    protected static final ObjectMapper mapper =
+            new ObjectMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
 
     @Getter
     public static class ProduceException extends Exception {
@@ -103,18 +103,18 @@ public class ProduceGateway implements AutoCloseable {
                                 requestContext.gateway().getId());
         this.commonHeaders = commonHeaders == null ? List.of() : commonHeaders;
 
-        final StreamingCluster streamingCluster = requestContext
-                .application()
-                .getInstance()
-                .streamingCluster();
+        final StreamingCluster streamingCluster =
+                requestContext.application().getInstance().streamingCluster();
         final String configString;
         try {
             configString =
-                    mapper.writeValueAsString(Pair.of(streamingCluster.type(), streamingCluster.configuration()));
+                    mapper.writeValueAsString(
+                            Pair.of(streamingCluster.type(), streamingCluster.configuration()));
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
-        // we need to cache the producer per topic and per config, since an application update could change the configuration
+        // we need to cache the producer per topic and per config, since an application update could
+        // change the configuration
         final TopicProducerCache.Key key =
                 new TopicProducerCache.Key(
                         requestContext.tenant(),
@@ -123,12 +123,7 @@ public class ProduceGateway implements AutoCloseable {
                         topic,
                         configString);
         producer =
-                topicProducerCache.getOrCreate(
-                        key,
-                        () ->
-                                setupProducer(
-                                        topic,
-                                        streamingCluster));
+                topicProducerCache.getOrCreate(key, () -> setupProducer(topic, streamingCluster));
     }
 
     protected TopicProducer setupProducer(String topic, StreamingCluster streamingCluster) {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCache.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCache.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.gateways;
+
+import ai.langstream.api.runner.topics.TopicProducer;
+import java.util.function.Supplier;
+
+public interface TopicProducerCache {
+    record Key(String tenant, String application, String gatewayId) {}
+
+    TopicProducer getOrCreate(Key key, Supplier<TopicProducer> topicProducerSupplier);
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCache.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCache.java
@@ -19,7 +19,12 @@ import ai.langstream.api.runner.topics.TopicProducer;
 import java.util.function.Supplier;
 
 public interface TopicProducerCache {
-    record Key(String tenant, String application, String gatewayId, String topic, String configString) {}
+    record Key(
+            String tenant,
+            String application,
+            String gatewayId,
+            String topic,
+            String configString) {}
 
     TopicProducer getOrCreate(Key key, Supplier<TopicProducer> topicProducerSupplier);
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCache.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCache.java
@@ -19,7 +19,7 @@ import ai.langstream.api.runner.topics.TopicProducer;
 import java.util.function.Supplier;
 
 public interface TopicProducerCache {
-    record Key(String tenant, String application, String gatewayId) {}
+    record Key(String tenant, String application, String gatewayId, String topic, String configString) {}
 
     TopicProducer getOrCreate(Key key, Supplier<TopicProducer> topicProducerSupplier);
 }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/TopicProducerCacheFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.gateways;
+
+import ai.langstream.apigateway.MetricsNames;
+import ai.langstream.apigateway.config.TopicProperties;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TopicProducerCacheFactory {
+
+    @Bean
+    public TopicProducerCache topicProducerCache(TopicProperties topicProperties) {
+        if (topicProperties.isProducersCacheEnabled()) {
+            final LRUTopicProducerCache cache =
+                    new LRUTopicProducerCache(topicProperties.getProducersCacheSize());
+            GuavaCacheMetrics.monitor(
+                    Metrics.globalRegistry, cache.getCache(), MetricsNames.TOPIC_PRODUCER_CACHE);
+            return cache;
+        } else {
+            return (key, topicProducerSupplier) -> topicProducerSupplier.get();
+        }
+    }
+}

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -60,9 +60,9 @@ public class GatewayResource {
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
     private final TopicProducerCache topicProducerCache;
     private final GatewayRequestHandler gatewayRequestHandler;
-    private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool(
-            new BasicThreadFactory.Builder().namingPattern("http-consume-%d").build()
-    );
+    private final ExecutorService consumeThreadPool =
+            Executors.newCachedThreadPool(
+                    new BasicThreadFactory.Builder().namingPattern("http-consume-%d").build());
 
     @PostMapping(
             value = "/produce/{tenant}/{application}/{gateway}",

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -59,7 +60,9 @@ public class GatewayResource {
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
     private final TopicProducerCache topicProducerCache;
     private final GatewayRequestHandler gatewayRequestHandler;
-    private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool();
+    private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool(
+            new BasicThreadFactory.Builder().namingPattern("http-consume-%d").build()
+    );
 
     @PostMapping(
             value = "/produce/{tenant}/{application}/{gateway}",

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -24,6 +24,7 @@ import ai.langstream.apigateway.api.ProduceResponse;
 import ai.langstream.apigateway.gateways.ConsumeGateway;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.gateways.ProduceGateway;
+import ai.langstream.apigateway.gateways.TopicProducerCache;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import jakarta.servlet.http.HttpServletResponse;
@@ -56,6 +57,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class GatewayResource {
 
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
+    private final TopicProducerCache topicProducerCache;
     private final GatewayRequestHandler gatewayRequestHandler;
     private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool();
 
@@ -89,9 +91,10 @@ public class GatewayResource {
         }
 
         try (final ProduceGateway produceGateway =
-                new ProduceGateway(
-                        topicConnectionsRuntimeRegistryProvider
-                                .getTopicConnectionsRuntimeRegistry()); ) {
+                     new ProduceGateway(
+                             topicConnectionsRuntimeRegistryProvider
+                                     .getTopicConnectionsRuntimeRegistry(),
+                             topicProducerCache)) {
             final List<Header> commonHeaders =
                     ProduceGateway.getProducerCommonHeaders(
                             context.gateway().getProduceOptions(), authContext);
@@ -139,13 +142,14 @@ public class GatewayResource {
         }
 
         try (final ConsumeGateway consumeGateway =
-                        new ConsumeGateway(
-                                topicConnectionsRuntimeRegistryProvider
-                                        .getTopicConnectionsRuntimeRegistry());
-                final ProduceGateway produceGateway =
-                        new ProduceGateway(
-                                topicConnectionsRuntimeRegistryProvider
-                                        .getTopicConnectionsRuntimeRegistry()); ) {
+                     new ConsumeGateway(
+                             topicConnectionsRuntimeRegistryProvider
+                                     .getTopicConnectionsRuntimeRegistry());
+             final ProduceGateway produceGateway =
+                     new ProduceGateway(
+                             topicConnectionsRuntimeRegistryProvider
+                                     .getTopicConnectionsRuntimeRegistry(),
+                             topicProducerCache);) {
 
             final Gateway.ServiceOptions serviceOptions = authContext.gateway().getServiceOptions();
             try {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -91,10 +91,10 @@ public class GatewayResource {
         }
 
         try (final ProduceGateway produceGateway =
-                     new ProduceGateway(
-                             topicConnectionsRuntimeRegistryProvider
-                                     .getTopicConnectionsRuntimeRegistry(),
-                             topicProducerCache)) {
+                new ProduceGateway(
+                        topicConnectionsRuntimeRegistryProvider
+                                .getTopicConnectionsRuntimeRegistry(),
+                        topicProducerCache)) {
             final List<Header> commonHeaders =
                     ProduceGateway.getProducerCommonHeaders(
                             context.gateway().getProduceOptions(), authContext);
@@ -142,14 +142,14 @@ public class GatewayResource {
         }
 
         try (final ConsumeGateway consumeGateway =
-                     new ConsumeGateway(
-                             topicConnectionsRuntimeRegistryProvider
-                                     .getTopicConnectionsRuntimeRegistry());
-             final ProduceGateway produceGateway =
-                     new ProduceGateway(
-                             topicConnectionsRuntimeRegistryProvider
-                                     .getTopicConnectionsRuntimeRegistry(),
-                             topicProducerCache);) {
+                        new ConsumeGateway(
+                                topicConnectionsRuntimeRegistryProvider
+                                        .getTopicConnectionsRuntimeRegistry());
+                final ProduceGateway produceGateway =
+                        new ProduceGateway(
+                                topicConnectionsRuntimeRegistryProvider
+                                        .getTopicConnectionsRuntimeRegistry(),
+                                topicProducerCache); ) {
 
             final Gateway.ServiceOptions serviceOptions = authContext.gateway().getServiceOptions();
             try {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
@@ -18,6 +18,7 @@ package ai.langstream.apigateway.websocket;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
+import ai.langstream.apigateway.gateways.TopicProducerCache;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
 import ai.langstream.apigateway.websocket.handlers.ChatHandler;
 import ai.langstream.apigateway.websocket.handlers.ConsumeHandler;
@@ -48,6 +49,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final ApplicationStore applicationStore;
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
     private final GatewayRequestHandler gatewayRequestHandler;
+    private final TopicProducerCache topicProducerCache;
     private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool();
 
     @Override
@@ -58,16 +60,21 @@ public class WebSocketConfig implements WebSocketConfigurer {
                         new ConsumeHandler(
                                 applicationStore,
                                 consumeThreadPool,
-                                topicConnectionsRuntimeRegistry),
+                                topicConnectionsRuntimeRegistry,
+                                topicProducerCache),
                         CONSUME_PATH)
                 .addHandler(
-                        new ProduceHandler(applicationStore, topicConnectionsRuntimeRegistry),
+                        new ProduceHandler(
+                                applicationStore,
+                                topicConnectionsRuntimeRegistry,
+                                topicProducerCache),
                         PRODUCE_PATH)
                 .addHandler(
                         new ChatHandler(
                                 applicationStore,
                                 consumeThreadPool,
-                                topicConnectionsRuntimeRegistry),
+                                topicConnectionsRuntimeRegistry,
+                                topicProducerCache),
                         CHAT_PATH)
                 .setAllowedOrigins("*")
                 .addInterceptors(

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
@@ -51,9 +51,9 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
     private final GatewayRequestHandler gatewayRequestHandler;
     private final TopicProducerCache topicProducerCache;
-    private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool(
-            new BasicThreadFactory.Builder().namingPattern("ws-consume-%d").build()
-    );
+    private final ExecutorService consumeThreadPool =
+            Executors.newCachedThreadPool(
+                    new BasicThreadFactory.Builder().namingPattern("ws-consume-%d").build());
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/WebSocketConfig.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
@@ -50,7 +51,9 @@ public class WebSocketConfig implements WebSocketConfigurer {
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
     private final GatewayRequestHandler gatewayRequestHandler;
     private final TopicProducerCache topicProducerCache;
-    private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool();
+    private final ExecutorService consumeThreadPool = Executors.newCachedThreadPool(
+            new BasicThreadFactory.Builder().namingPattern("ws-consume-%d").build()
+    );
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/AbstractHandler.java
@@ -31,6 +31,7 @@ import ai.langstream.apigateway.api.ProduceResponse;
 import ai.langstream.apigateway.gateways.ConsumeGateway;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.gateways.ProduceGateway;
+import ai.langstream.apigateway.gateways.TopicProducerCache;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -52,12 +53,15 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
     protected static final String ATTRIBUTE_CONSUME_GATEWAY = "__consume_gateway";
     protected final TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry;
     protected final ApplicationStore applicationStore;
+    private final TopicProducerCache topicProducerCache;
 
     public AbstractHandler(
             ApplicationStore applicationStore,
-            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry) {
+            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry,
+            TopicProducerCache topicProducerCache) {
         this.topicConnectionsRuntimeRegistry = topicConnectionsRuntimeRegistry;
         this.applicationStore = applicationStore;
+        this.topicProducerCache = topicProducerCache;
     }
 
     public abstract String path();
@@ -256,7 +260,8 @@ public abstract class AbstractHandler extends TextWebSocketHandler {
     protected void setupProducer(
             String topic, List<Header> commonHeaders, AuthenticatedGatewayRequestContext context)
             throws Exception {
-        final ProduceGateway produceGateway = new ProduceGateway(topicConnectionsRuntimeRegistry);
+        final ProduceGateway produceGateway =
+                new ProduceGateway(topicConnectionsRuntimeRegistry, topicProducerCache);
 
         try {
             produceGateway.start(topic, commonHeaders, context);

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ChatHandler.java
@@ -25,6 +25,7 @@ import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.gateways.ConsumeGateway;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.gateways.ProduceGateway;
+import ai.langstream.apigateway.gateways.TopicProducerCache;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,8 +46,9 @@ public class ChatHandler extends AbstractHandler {
     public ChatHandler(
             ApplicationStore applicationStore,
             ExecutorService executor,
-            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry) {
-        super(applicationStore, topicConnectionsRuntimeRegistry);
+            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry,
+            TopicProducerCache topicProducerCache) {
+        super(applicationStore, topicConnectionsRuntimeRegistry, topicProducerCache);
         this.executor = executor;
     }
 

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ConsumeHandler.java
@@ -23,6 +23,7 @@ import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.gateways.ConsumeGateway;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
+import ai.langstream.apigateway.gateways.TopicProducerCache;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import java.util.List;
 import java.util.Map;
@@ -42,8 +43,9 @@ public class ConsumeHandler extends AbstractHandler {
     public ConsumeHandler(
             ApplicationStore applicationStore,
             ExecutorService executor,
-            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry) {
-        super(applicationStore, topicConnectionsRuntimeRegistry);
+            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry,
+            TopicProducerCache topicProducerCache) {
+        super(applicationStore, topicConnectionsRuntimeRegistry, topicProducerCache);
         this.executor = executor;
     }
 

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/websocket/handlers/ProduceHandler.java
@@ -23,6 +23,7 @@ import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.gateways.GatewayRequestHandler;
 import ai.langstream.apigateway.gateways.ProduceGateway;
+import ai.langstream.apigateway.gateways.TopicProducerCache;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +37,9 @@ public class ProduceHandler extends AbstractHandler {
 
     public ProduceHandler(
             ApplicationStore applicationStore,
-            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry) {
-        super(applicationStore, topicConnectionsRuntimeRegistry);
+            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry,
+            TopicProducerCache topicProducerCache) {
+        super(applicationStore, topicConnectionsRuntimeRegistry, topicProducerCache);
     }
 
     @Override

--- a/langstream-api-gateway/src/main/resources/application.properties
+++ b/langstream-api-gateway/src/main/resources/application.properties
@@ -30,3 +30,6 @@ application.storage.apps.type=kubernetes
 application.storage.apps.configuration.namespaceprefix=langstream-
 
 application.gateways.code.path=/app/agents
+
+application.topics.producers-cache-enabled=true
+application.topics.producers-cache-size=100

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/gateways/LRUTopicProducerCacheTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/gateways/LRUTopicProducerCacheTest.java
@@ -74,24 +74,24 @@ class LRUTopicProducerCacheTest {
                 };
         final TopicProducer first =
                 cache.getOrCreate(
-                        new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                        newKey("tenant", "application", "gatewayId"),
                         topicProducerSupplier);
         cache.getOrCreate(
-                new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                newKey("tenant", "application", "gatewayId"),
                 topicProducerSupplier);
         cache.getOrCreate(
-                new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                newKey("tenant", "application", "gatewayId"),
                 topicProducerSupplier);
 
         final TopicProducer second =
                 cache.getOrCreate(
-                        new TopicProducerCache.Key("tenant", "application", "gatewayId2"),
+                        newKey("tenant", "application", "gatewayId2"),
                         topicProducerSupplier);
 
         assertEquals(2, initCounter.get());
         assertEquals(0, closeCounter.get());
         cache.getOrCreate(
-                new TopicProducerCache.Key("tenant", "application", "gatewayId3"),
+                newKey("tenant", "application", "gatewayId3"),
                 topicProducerSupplier);
         assertEquals(3, initCounter.get());
         assertEquals(0, closeCounter.get());
@@ -104,7 +104,7 @@ class LRUTopicProducerCacheTest {
 
         assertEquals(2, cache.getCache().size());
         cache.getOrCreate(
-                new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                newKey("tenant", "application", "gatewayId"),
                 topicProducerSupplier);
         assertEquals(4, initCounter.get());
         assertEquals(2, cache.getCache().size());
@@ -138,21 +138,21 @@ class LRUTopicProducerCacheTest {
                                 for (int j = 0; j < 100; j++) {
                                     final TopicProducer prod0 =
                                             cache.getOrCreate(
-                                                    new TopicProducerCache.Key(
+                                                    newKey(
                                                             "tenant", "application", "gatewayId"),
                                                     topicProducerSupplier);
                                     prod0.write(SimpleRecord.of("key", "value"));
                                     prod0.close();
                                     final TopicProducer prod1 =
                                             cache.getOrCreate(
-                                                    new TopicProducerCache.Key(
+                                                    newKey(
                                                             "tenant", "application", "gatewayId1"),
                                                     topicProducerSupplier);
                                     prod1.write(SimpleRecord.of("key", "value"));
                                     prod1.close();
                                     final TopicProducer prod2 =
                                             cache.getOrCreate(
-                                                    new TopicProducerCache.Key(
+                                                    newKey(
                                                             "tenant", "application", "gatewayId2"),
                                                     topicProducerSupplier);
                                     prod2.write(SimpleRecord.of("key", "value"));
@@ -163,5 +163,9 @@ class LRUTopicProducerCacheTest {
         }
         futures.forEach(CompletableFuture::join);
         assertEquals(initCounter.get() - 2, closeCounter.get());
+    }
+
+    private static TopicProducerCache.Key newKey(String tenant, String application, String gateway) {
+        return new TopicProducerCache.Key(tenant, application, gateway, null, null);
     }
 }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/gateways/LRUTopicProducerCacheTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/gateways/LRUTopicProducerCacheTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.gateways;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.runner.code.SimpleRecord;
+import ai.langstream.api.runner.topics.TopicProducer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class LRUTopicProducerCacheTest {
+
+    private static class NoopTopicProducer implements TopicProducer {
+        private volatile boolean closed;
+
+        @Override
+        public CompletableFuture<?> write(Record record) {
+            synchronized (this) {
+                if (closed) {
+                    throw new RuntimeException("Closed");
+                }
+                return CompletableFuture.completedFuture(null);
+            }
+        }
+
+        @Override
+        public long getTotalIn() {
+            return 0;
+        }
+
+        @Override
+        public void close() {
+            synchronized (this) {
+                closed = true;
+            }
+        }
+    }
+
+    @Test
+    void testGetOrCreate() {
+        final LRUTopicProducerCache cache = new LRUTopicProducerCache(2);
+        AtomicInteger initCounter = new AtomicInteger();
+        AtomicInteger closeCounter = new AtomicInteger();
+        final Supplier<TopicProducer> topicProducerSupplier =
+                () -> {
+                    initCounter.incrementAndGet();
+                    return new NoopTopicProducer() {
+                        @Override
+                        public void close() {
+                            closeCounter.incrementAndGet();
+                        }
+                    };
+                };
+        final TopicProducer first =
+                cache.getOrCreate(
+                        new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                        topicProducerSupplier);
+        cache.getOrCreate(
+                new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                topicProducerSupplier);
+        cache.getOrCreate(
+                new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                topicProducerSupplier);
+
+        final TopicProducer second =
+                cache.getOrCreate(
+                        new TopicProducerCache.Key("tenant", "application", "gatewayId2"),
+                        topicProducerSupplier);
+
+        assertEquals(2, initCounter.get());
+        assertEquals(0, closeCounter.get());
+        cache.getOrCreate(
+                new TopicProducerCache.Key("tenant", "application", "gatewayId3"),
+                topicProducerSupplier);
+        assertEquals(3, initCounter.get());
+        assertEquals(0, closeCounter.get());
+        first.close();
+        assertEquals(0, closeCounter.get());
+        first.close();
+        assertEquals(0, closeCounter.get());
+        first.close();
+        assertEquals(1, closeCounter.get());
+
+        assertEquals(2, cache.getCache().size());
+        cache.getOrCreate(
+                new TopicProducerCache.Key("tenant", "application", "gatewayId"),
+                topicProducerSupplier);
+        assertEquals(4, initCounter.get());
+        assertEquals(2, cache.getCache().size());
+        assertEquals(1, closeCounter.get());
+        second.close();
+        assertEquals(2, closeCounter.get());
+    }
+
+    @Test
+    void testConcurrency() {
+        final LRUTopicProducerCache cache = new LRUTopicProducerCache(2);
+        AtomicInteger initCounter = new AtomicInteger();
+        AtomicInteger closeCounter = new AtomicInteger();
+        final Supplier<TopicProducer> topicProducerSupplier =
+                () -> {
+                    initCounter.incrementAndGet();
+                    return new NoopTopicProducer() {
+                        @Override
+                        public void close() {
+                            closeCounter.incrementAndGet();
+                        }
+                    };
+                };
+        final int nThreads = 50;
+        final ExecutorService pool = Executors.newFixedThreadPool(nThreads);
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < nThreads; i++) {
+            futures.add(
+                    CompletableFuture.runAsync(
+                            () -> {
+                                for (int j = 0; j < 100; j++) {
+                                    final TopicProducer prod0 =
+                                            cache.getOrCreate(
+                                                    new TopicProducerCache.Key(
+                                                            "tenant", "application", "gatewayId"),
+                                                    topicProducerSupplier);
+                                    prod0.write(SimpleRecord.of("key", "value"));
+                                    prod0.close();
+                                    final TopicProducer prod1 =
+                                            cache.getOrCreate(
+                                                    new TopicProducerCache.Key(
+                                                            "tenant", "application", "gatewayId1"),
+                                                    topicProducerSupplier);
+                                    prod1.write(SimpleRecord.of("key", "value"));
+                                    prod1.close();
+                                    final TopicProducer prod2 =
+                                            cache.getOrCreate(
+                                                    new TopicProducerCache.Key(
+                                                            "tenant", "application", "gatewayId2"),
+                                                    topicProducerSupplier);
+                                    prod2.write(SimpleRecord.of("key", "value"));
+                                    prod2.close();
+                                }
+                            },
+                            pool));
+        }
+        futures.forEach(CompletableFuture::join);
+        assertEquals(initCounter.get() - 2, closeCounter.get());
+    }
+}

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/gateways/LRUTopicProducerCacheTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/gateways/LRUTopicProducerCacheTest.java
@@ -74,25 +74,17 @@ class LRUTopicProducerCacheTest {
                 };
         final TopicProducer first =
                 cache.getOrCreate(
-                        newKey("tenant", "application", "gatewayId"),
-                        topicProducerSupplier);
-        cache.getOrCreate(
-                newKey("tenant", "application", "gatewayId"),
-                topicProducerSupplier);
-        cache.getOrCreate(
-                newKey("tenant", "application", "gatewayId"),
-                topicProducerSupplier);
+                        newKey("tenant", "application", "gatewayId"), topicProducerSupplier);
+        cache.getOrCreate(newKey("tenant", "application", "gatewayId"), topicProducerSupplier);
+        cache.getOrCreate(newKey("tenant", "application", "gatewayId"), topicProducerSupplier);
 
         final TopicProducer second =
                 cache.getOrCreate(
-                        newKey("tenant", "application", "gatewayId2"),
-                        topicProducerSupplier);
+                        newKey("tenant", "application", "gatewayId2"), topicProducerSupplier);
 
         assertEquals(2, initCounter.get());
         assertEquals(0, closeCounter.get());
-        cache.getOrCreate(
-                newKey("tenant", "application", "gatewayId3"),
-                topicProducerSupplier);
+        cache.getOrCreate(newKey("tenant", "application", "gatewayId3"), topicProducerSupplier);
         assertEquals(3, initCounter.get());
         assertEquals(0, closeCounter.get());
         first.close();
@@ -103,9 +95,7 @@ class LRUTopicProducerCacheTest {
         assertEquals(1, closeCounter.get());
 
         assertEquals(2, cache.getCache().size());
-        cache.getOrCreate(
-                newKey("tenant", "application", "gatewayId"),
-                topicProducerSupplier);
+        cache.getOrCreate(newKey("tenant", "application", "gatewayId"), topicProducerSupplier);
         assertEquals(4, initCounter.get());
         assertEquals(2, cache.getCache().size());
         assertEquals(1, closeCounter.get());
@@ -138,22 +128,19 @@ class LRUTopicProducerCacheTest {
                                 for (int j = 0; j < 100; j++) {
                                     final TopicProducer prod0 =
                                             cache.getOrCreate(
-                                                    newKey(
-                                                            "tenant", "application", "gatewayId"),
+                                                    newKey("tenant", "application", "gatewayId"),
                                                     topicProducerSupplier);
                                     prod0.write(SimpleRecord.of("key", "value"));
                                     prod0.close();
                                     final TopicProducer prod1 =
                                             cache.getOrCreate(
-                                                    newKey(
-                                                            "tenant", "application", "gatewayId1"),
+                                                    newKey("tenant", "application", "gatewayId1"),
                                                     topicProducerSupplier);
                                     prod1.write(SimpleRecord.of("key", "value"));
                                     prod1.close();
                                     final TopicProducer prod2 =
                                             cache.getOrCreate(
-                                                    newKey(
-                                                            "tenant", "application", "gatewayId2"),
+                                                    newKey("tenant", "application", "gatewayId2"),
                                                     topicProducerSupplier);
                                     prod2.write(SimpleRecord.of("key", "value"));
                                     prod2.close();
@@ -165,7 +152,8 @@ class LRUTopicProducerCacheTest {
         assertEquals(initCounter.get() - 2, closeCounter.get());
     }
 
-    private static TopicProducerCache.Key newKey(String tenant, String application, String gateway) {
+    private static TopicProducerCache.Key newKey(
+            String tenant, String application, String gateway) {
         return new TopicProducerCache.Key(tenant, application, gateway, null, null);
     }
 }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.micrometer.core.instrument.Metrics;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -58,6 +59,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,6 +69,7 @@ import org.springframework.boot.test.autoconfigure.actuate.observability.AutoCon
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(
@@ -78,6 +81,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @Slf4j
 @AutoConfigureObservability
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 abstract class GatewayResourceTest {
 
     public static final Path agentsDirectory;
@@ -192,6 +196,11 @@ abstract class GatewayResourceTest {
     @AfterAll
     public static void afterAll() {
         Awaitility.reset();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        Metrics.globalRegistry.clear();
     }
 
     @SneakyThrows

--- a/langstream-api-gateway/src/test/resources/application.properties
+++ b/langstream-api-gateway/src/test/resources/application.properties
@@ -1,1 +1,6 @@
 application.gateways.code.path=target/agents
+management.endpoints.web.base-path=/management
+management.endpoints.web.exposure.include=configprops,env,health,info,logfile,loggers,threaddump,prometheus
+management.endpoint.health.probes.enabled=true
+application.topics.producers-cache-enabled=true
+application.topics.producers-cache-size=2


### PR DESCRIPTION
Changes:
* We use Guava cache to keep producer by gateway. The cache is LRU and every access refresh the ttl. 
* The max size is configurable (max 100 across all tenants). The cache can be disabled