### PR TITLE
[python] use vfork to start the python interpreter (needed for openjdk)

### DIFF
--- a/langstream-runtime/langstream-runtime-impl/src/main/assemble/entrypoint.sh
+++ b/langstream-runtime/langstream-runtime-impl/src/main/assemble/entrypoint.sh
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-exec java ${JAVA_OPTS} -cp "/app/lib/*" "ai.langstream.runtime.Main" "$@"
+exec java ${JAVA_OPTS} -Djdk.lang.Process.launchMechanism=vfork -cp "/app/lib/*" "ai.langstream.runtime.Main" "$@"


### PR DESCRIPTION
After the upgrade to OpenJDK in kubernetes I see this error.

The fix is to apply this system property -Djdk.lang.Process.launchMechanism=vfork

Please note that we were already using that flag in the langstream docker tester docker image (for docker run)

```

java.io.IOException: Cannot run program "python3": error=0, Failed to exec spawn helper: pid: 31, exit value: 1                                  │
│ runtime     at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)                                                                        │
│ runtime     at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)                                                                        │
│ runtime     at ai.langstream.agents.grpc.PythonGrpcServer.start(PythonGrpcServer.java:87)                                                                │
│ runtime     at ai.langstream.agents.grpc.PythonGrpcAgentProcessor.start(PythonGrpcAgentProcessor.java:36)                                                │
│ runtime     at ai.langstream.api.runner.code.AgentCodeAndLoader.executeWithContextClassloader(AgentCodeAndLoader.java:46)                                │
│ runtime     at ai.langstream.api.runner.code.AgentCodeAndLoader$3.start(AgentCodeAndLoader.java:254)                                                     │
│ runtime     at ai.langstream.runtime.agent.AgentRunner.runMainLoop(AgentRunner.java:619)                                                                 │
│ runtime     at ai.langstream.runtime.agent.AgentRunner.runJavaAgent(AgentRunner.java:396)                                                                │
│ runtime     at ai.langstream.runtime.agent.AgentRunner.run(AgentRunner.java:186)                                                                         │
│ runtime     at ai.langstream.runtime.agent.AgentRunnerStarter.start(AgentRunnerStarter.java:120)                                                         │
│ runtime     at ai.langstream.runtime.agent.AgentRunnerStarter.main(AgentRunnerStarter.java:55)                                                           │
│ runtime     at ai.langstream.runtime.Main.main(Main.java:42)                                                                                             │
│ runtime Caused by: java.io.IOException: error=0, Failed to exec spawn helper: pid: 31, exit value: 1                                                     │
│ runtime     at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)                                                                                │
│ runtime     at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:314)                                                                              │
│ runtime     at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:244)      
```                 