### PR TITLE
[tests] Use a fixed version of RedPanda that is known to work

### DIFF
--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/kafka/LocalRedPandaClusterProvider.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/kafka/LocalRedPandaClusterProvider.java
@@ -74,7 +74,7 @@ public class LocalRedPandaClusterProvider implements StreamingClusterProvider {
         // ref https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml
         log.info("running helm command to install redpanda");
         BaseEndToEndTest.runProcess(
-                ("helm upgrade --install redpanda redpanda/redpanda --namespace %s --set resources.cpu.cores=0.3"
+                ("helm upgrade --install redpanda redpanda/redpanda --version 5.6.29 --namespace %s --set resources.cpu.cores=0.3"
                                         .formatted(NAMESPACE)
                                 + " --set resources.memory.container.max=1512Mi --set statefulset.replicas=1 --set console"
                                 + ".enabled=false --set tls.enabled=false --set external.domain=redpanda-external.%s.svc"


### PR DESCRIPTION
CI is failing due to a problem in the RedPanda helm chart

```
15:25:19.268 [ForkJoinPool.commonPool-worker-1] INFO  a.l.t.u.k.LocalRedPandaClusterProvider -- running helm command to install redpanda
[455](https://github.com/LangStream/langstream/actions/runs/6669026801/job/18125905752?pr=661#step:9:456)
Error: template: redpanda/templates/post-upgrade.yaml:78:40: executing “redpanda/templates/post-upgrade.yaml” at <eq (floor $value) $value>: error calling eq: incompatible types for comparison
```

This patch is trying to rollback to an older version that was known to work
