### PR TITLE
Service gateway: direct interaction with agent

### DIFF
--- a/examples/applications/python/langserve-service/gateways.yaml
+++ b/examples/applications/python/langserve-service/gateways.yaml
@@ -16,8 +16,9 @@
 #
 
 gateways:
+  - id: chatbot
+    type: service
+    service-options:
+      agent-id: langserve-service
 
-#  - id: chatbot
-#    type: service
-#    agent: service1
 

--- a/examples/applications/python/langserve-service/pipeline.yaml
+++ b/examples/applications/python/langserve-service/pipeline.yaml
@@ -18,7 +18,7 @@ module: default
 name: "Basic LangServe application"
 pipeline:
   - name: "Start LangServe"
-    id: agent1
+    id: langserve-service
     type: "python-service"
     configuration:
       className: example.ChatBotService

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -19,6 +19,7 @@ import ai.langstream.api.gateway.GatewayRequestContext;
 import ai.langstream.api.model.Gateway;
 import ai.langstream.api.runner.code.Header;
 import ai.langstream.api.runner.code.Record;
+import ai.langstream.api.storage.ApplicationStore;
 import ai.langstream.apigateway.api.ProduceRequest;
 import ai.langstream.apigateway.api.ProduceResponse;
 import ai.langstream.apigateway.gateways.ConsumeGateway;
@@ -27,12 +28,19 @@ import ai.langstream.apigateway.gateways.ProduceGateway;
 import ai.langstream.apigateway.gateways.TopicProducerCache;
 import ai.langstream.apigateway.runner.TopicConnectionsRuntimeProviderBean;
 import ai.langstream.apigateway.websocket.AuthenticatedGatewayRequestContext;
-import jakarta.servlet.http.HttpServletResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotBlank;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,15 +49,21 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequestMapping("/api/gateways")
@@ -57,9 +71,18 @@ import org.springframework.web.server.ResponseStatusException;
 @AllArgsConstructor
 public class GatewayResource {
 
+    protected static final String GATEWAY_SERVICE_PATH =
+            "/service/{tenant}/{application}/{gateway}/**";
+    protected static final ObjectMapper MAPPER = new ObjectMapper();
     private final TopicConnectionsRuntimeProviderBean topicConnectionsRuntimeRegistryProvider;
     private final TopicProducerCache topicProducerCache;
+    private final ApplicationStore applicationStore;
     private final GatewayRequestHandler gatewayRequestHandler;
+    private final ExecutorService httpClientThreadPool =
+            Executors.newCachedThreadPool(
+                    new BasicThreadFactory.Builder().namingPattern("http-client-%d").build());
+    private final HttpClient httpClient =
+            HttpClient.newBuilder().executor(httpClientThreadPool).build();
     private final ExecutorService consumeThreadPool =
             Executors.newCachedThreadPool(
                     new BasicThreadFactory.Builder().namingPattern("http-consume-%d").build());
@@ -114,18 +137,57 @@ public class GatewayResource {
         return headers;
     }
 
-    @PostMapping(
-            value = "/service/{tenant}/{application}/{gateway}",
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    void service(
+    @PostMapping(value = GATEWAY_SERVICE_PATH)
+    CompletableFuture<ResponseEntity> service(
             WebRequest request,
-            HttpServletResponse response,
+            HttpServletRequest servletRequest,
             @NotBlank @PathVariable("tenant") String tenant,
             @NotBlank @PathVariable("application") String application,
-            @NotBlank @PathVariable("gateway") String gateway,
-            @RequestBody ProduceRequest produceRequest)
-            throws ProduceGateway.ProduceException {
+            @NotBlank @PathVariable("gateway") String gateway)
+            throws Exception {
+        return handleServiceCall(request, servletRequest, tenant, application, gateway);
+    }
 
+    @GetMapping(value = GATEWAY_SERVICE_PATH)
+    CompletableFuture<ResponseEntity> serviceGet(
+            WebRequest request,
+            HttpServletRequest servletRequest,
+            @NotBlank @PathVariable("tenant") String tenant,
+            @NotBlank @PathVariable("application") String application,
+            @NotBlank @PathVariable("gateway") String gateway)
+            throws Exception {
+        return handleServiceCall(request, servletRequest, tenant, application, gateway);
+    }
+
+    @PutMapping(value = GATEWAY_SERVICE_PATH)
+    CompletableFuture<ResponseEntity> servicePut(
+            WebRequest request,
+            HttpServletRequest servletRequest,
+            @NotBlank @PathVariable("tenant") String tenant,
+            @NotBlank @PathVariable("application") String application,
+            @NotBlank @PathVariable("gateway") String gateway)
+            throws Exception {
+        return handleServiceCall(request, servletRequest, tenant, application, gateway);
+    }
+
+    @DeleteMapping(value = GATEWAY_SERVICE_PATH)
+    CompletableFuture<ResponseEntity> serviceDelete(
+            WebRequest request,
+            HttpServletRequest servletRequest,
+            @NotBlank @PathVariable("tenant") String tenant,
+            @NotBlank @PathVariable("application") String application,
+            @NotBlank @PathVariable("gateway") String gateway)
+            throws Exception {
+        return handleServiceCall(request, servletRequest, tenant, application, gateway);
+    }
+
+    private CompletableFuture<ResponseEntity> handleServiceCall(
+            WebRequest request,
+            HttpServletRequest servletRequest,
+            String tenant,
+            String application,
+            String gateway)
+            throws IOException {
         final Map<String, String> queryString = computeQueryString(request);
         final Map<String, String> headers = computeHeaders(request);
         final GatewayRequestContext context =
@@ -136,14 +198,42 @@ public class GatewayResource {
                         Gateway.GatewayType.service,
                         queryString,
                         headers,
-                        new ProduceGateway.ProduceGatewayRequestValidator());
+                        new GatewayRequestHandler.GatewayRequestValidator() {
+                            @Override
+                            public List<String> getAllRequiredParameters(Gateway gateway) {
+                                return List.of();
+                            }
+
+                            @Override
+                            public void validateOptions(Map<String, String> options) {}
+                        });
         final AuthenticatedGatewayRequestContext authContext;
         try {
             authContext = gatewayRequestHandler.authenticate(context);
         } catch (GatewayRequestHandler.AuthFailedException e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, e.getMessage());
         }
+        if (context.gateway().getServiceOptions().getAgentId() != null) {
+            final String uri =
+                    applicationStore.getExecutorServiceURI(
+                            context.tenant(),
+                            context.applicationId(),
+                            context.gateway().getServiceOptions().getAgentId());
+            return forwardTo(uri, servletRequest.getMethod(), servletRequest);
+        } else {
+            if (!servletRequest.getMethod().equalsIgnoreCase("post")) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST, "Only POST method is supported");
+            }
+            final ProduceRequest produceRequest =
+                    MAPPER.readValue(servletRequest.getInputStream(), ProduceRequest.class);
+            return handleServiceWithTopics(produceRequest, authContext);
+        }
+    }
 
+    private CompletableFuture<ResponseEntity> handleServiceWithTopics(
+            ProduceRequest produceRequest, AuthenticatedGatewayRequestContext authContext) {
+        final CompletableFuture<ResponseEntity> completableFuture = new CompletableFuture<>();
         try (final ConsumeGateway consumeGateway =
                         new ConsumeGateway(
                                 topicConnectionsRuntimeRegistryProvider
@@ -168,13 +258,7 @@ public class GatewayResource {
                         () -> stop.get(),
                         record -> {
                             stop.set(true);
-                            try {
-                                response.getWriter().print(record);
-                                response.getWriter().flush();
-                                response.getWriter().close();
-                            } catch (IOException ioException) {
-                                throw new RuntimeException(ioException);
-                            }
+                            completableFuture.complete(ResponseEntity.ok(record));
                         });
             } catch (Exception ex) {
                 log.error("Error while setting up consume gateway", ex);
@@ -184,7 +268,10 @@ public class GatewayResource {
                     ProduceGateway.getProducerCommonHeaders(serviceOptions, authContext);
             produceGateway.start(serviceOptions.getOutputTopic(), commonHeaders, authContext);
             produceGateway.produceMessage(produceRequest);
+        } catch (Throwable t) {
+            completableFuture.completeExceptionally(t);
         }
+        return completableFuture;
     }
 
     private Map<String, String> computeQueryString(WebRequest request) {
@@ -192,5 +279,82 @@ public class GatewayResource {
                 request.getParameterMap().keySet().stream()
                         .collect(Collectors.toMap(k -> k, k -> request.getParameter(k)));
         return queryString;
+    }
+
+    private CompletableFuture<ResponseEntity> forwardTo(
+            String agentURI, String method, HttpServletRequest request) {
+        try {
+            String requestUrl = request.getRequestURI();
+            final String[] parts = requestUrl.split("/", 8);
+            final List<String> partsList =
+                    Arrays.stream(parts).filter(s -> !s.isBlank()).collect(Collectors.toList());
+
+            // /api/gateways/service/tenant/application/gateway/<part>
+            if (partsList.size() > 6) {
+                requestUrl = "/" + partsList.get(6);
+            } else {
+                requestUrl = "/";
+            }
+            final URI uri =
+                    UriComponentsBuilder.fromUri(URI.create(agentURI))
+                            .path(requestUrl)
+                            .query(request.getQueryString())
+                            .build(true)
+                            .toUri();
+            log.debug("Forwarding service request to {}, method {}", uri, method);
+
+            final HttpRequest.Builder requestBuilder =
+                    HttpRequest.newBuilder(uri)
+                            .version(HttpClient.Version.HTTP_1_1)
+                            .method(
+                                    method,
+                                    HttpRequest.BodyPublishers.ofInputStream(
+                                            () -> {
+                                                try {
+                                                    return request.getInputStream();
+                                                } catch (IOException e) {
+                                                    throw new RuntimeException(e);
+                                                }
+                                            }));
+
+            request.getHeaderNames()
+                    .asIterator()
+                    .forEachRemaining(
+                            h -> {
+                                switch (h) {
+                                        // from jdk.internal.net.http.common.Utils
+                                    case "connection":
+                                    case "content-length":
+                                    case "expect":
+                                    case "host":
+                                    case "upgrade":
+                                        return;
+                                    default:
+                                        requestBuilder.header(h, request.getHeader(h));
+                                        break;
+                                }
+                            });
+
+            final HttpRequest httpRequest = requestBuilder.build();
+            return httpClient
+                    .sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream())
+                    .thenApply(
+                            remoteResponse -> {
+                                final ResponseEntity.BodyBuilder responseBuilder =
+                                        ResponseEntity.status(remoteResponse.statusCode());
+                                remoteResponse
+                                        .headers()
+                                        .map()
+                                        .forEach(
+                                                (k, v) -> {
+                                                    responseBuilder.header(k, v.get(0));
+                                                });
+
+                                return responseBuilder.body(
+                                        new InputStreamResource(remoteResponse.body()));
+                            });
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
     }
 }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -98,6 +98,12 @@ abstract class GatewayResourceTest {
     static Gateways testGateways;
 
     protected static ApplicationStore getMockedStore(String instanceYaml) {
+        wireMock.register(
+                WireMock.get("/agent-endpoint/custom-path")
+                        .willReturn(WireMock.ok("agent response")));
+
+        wireMock.register(
+                WireMock.get("/agent-endpoint").willReturn(WireMock.ok("agent response ROOT")));
         ApplicationStore mock = Mockito.mock(ApplicationStore.class);
         doAnswer(
                         invocationOnMock -> {
@@ -500,7 +506,8 @@ abstract class GatewayResourceTest {
                                         .id("svc")
                                         .type(Gateway.GatewayType.service)
                                         .serviceOptions(
-                                                new Gateway.ServiceOptions(topic, topic, List.of()))
+                                                new Gateway.ServiceOptions(
+                                                        null, topic, topic, List.of()))
                                         .build()));
 
         final String url =

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/ServiceAgentGatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/ServiceAgentGatewayResourceTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.apigateway.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+
+import ai.langstream.api.model.Application;
+import ai.langstream.api.model.ApplicationSpecs;
+import ai.langstream.api.model.Gateway;
+import ai.langstream.api.model.Gateways;
+import ai.langstream.api.model.StoredApplication;
+import ai.langstream.api.storage.ApplicationStore;
+import ai.langstream.impl.parser.ModelBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.main.allow-bean-definition-overriding=true",
+        })
+@WireMockTest
+@Slf4j
+@AutoConfigureObservability
+@AutoConfigureMockMvc
+class ServiceAgentGatewayResourceTest {
+
+    public static final Path agentsDirectory;
+    protected static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    static {
+        agentsDirectory = Path.of(System.getProperty("user.dir"), "target", "agents");
+        log.info("Agents directory is {}", agentsDirectory);
+    }
+
+    static List<String> topics;
+    static Gateways testGateways;
+
+    @TestConfiguration
+    public static class WebSocketTestConfig {
+
+        @Bean
+        @Primary
+        public ApplicationStore store() {
+            String instanceYaml =
+                    """
+                    instance:
+                      streamingCluster:
+                        type: "noop"
+                      computeCluster:
+                         type: "none"
+                    """;
+            return getMockedStore(instanceYaml);
+        }
+    }
+
+    protected static ApplicationStore getMockedStore(String instanceYaml) {
+        ApplicationStore mock = Mockito.mock(ApplicationStore.class);
+        doAnswer(
+                        invocationOnMock -> {
+                            final StoredApplication storedApplication = new StoredApplication();
+                            final Application application = buildApp(instanceYaml);
+                            storedApplication.setInstance(application);
+                            return storedApplication;
+                        })
+                .when(mock)
+                .get(anyString(), anyString(), anyBoolean());
+        doAnswer(
+                        invocationOnMock ->
+                                ApplicationSpecs.builder()
+                                        .application(buildApp(instanceYaml))
+                                        .build())
+                .when(mock)
+                .getSpecs(anyString(), anyString());
+
+        doAnswer(invocationOnMock -> "http://localhost:" + wireMockPort)
+                .when(mock)
+                .getExecutorServiceURI(anyString(), anyString(), anyString());
+
+        return mock;
+    }
+
+    @NotNull
+    private static Application buildApp(String instanceYaml) throws Exception {
+        final Map<String, Object> module = Map.of("module", "mod1", "id", "p");
+
+        final Application application =
+                ModelBuilder.buildApplicationInstance(
+                                Map.of(
+                                        "module.yaml",
+                                        new ObjectMapper(new YAMLFactory())
+                                                .writeValueAsString(module)),
+                                instanceYaml,
+                                null)
+                        .getApplication();
+        application.setGateways(testGateways);
+        return application;
+    }
+
+    @LocalServerPort int port;
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ApplicationStore store;
+
+    static WireMock wireMock;
+    static String wireMockBaseUrl;
+    static int wireMockPort;
+
+    @BeforeAll
+    public static void beforeAll(WireMockRuntimeInfo wmRuntimeInfo) {
+        wireMock = wmRuntimeInfo.getWireMock();
+        wireMockBaseUrl = wmRuntimeInfo.getHttpBaseUrl();
+        wireMockPort = wmRuntimeInfo.getHttpPort();
+    }
+
+    @BeforeEach
+    public void beforeEach(WireMockRuntimeInfo wmRuntimeInfo) {
+        testGateways = null;
+        topics = null;
+        Awaitility.setDefaultTimeout(30, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        Awaitility.reset();
+    }
+
+    @Test
+    void testServiceAgent() throws Exception {
+        wireMock.register(
+                WireMock.post("/agent-endpoint/custom-path")
+                        .willReturn(WireMock.ok("agent response")));
+        wireMock.register(
+                WireMock.post("/agent-endpoint/custom-path-json?q=v")
+                        .withHeader("X-Custom-Header", equalTo("XXX"))
+                        .withHeader("Content-Type", equalTo("application/json"))
+                        .willReturn(WireMock.ok("agent response")));
+
+        wireMock.register(
+                WireMock.post("/")
+                        .withRequestBody(equalTo("hello"))
+                        .willReturn(WireMock.ok("agent response ROOT")));
+        wireMock.register(WireMock.get("/").willReturn(WireMock.ok("agent response ROOT")));
+
+        wireMock.register(WireMock.put("/").willReturn(WireMock.ok("agent response ROOT")));
+        wireMock.register(WireMock.delete("/").willReturn(WireMock.ok("agent response ROOT")));
+
+        testGateways =
+                new Gateways(
+                        List.of(
+                                Gateway.builder()
+                                        .id("svc")
+                                        .type(Gateway.GatewayType.service)
+                                        .serviceOptions(
+                                                new Gateway.ServiceOptions(
+                                                        "my-agent", null, null, List.of()))
+                                        .build()));
+
+        String url =
+                "http://localhost:%d/api/gateways/service/tenant1/application1/svc".formatted(port);
+        HttpRequest request =
+                HttpRequest.newBuilder(URI.create(url))
+                        .header("Content-Type", "text/plain")
+                        .POST(HttpRequest.BodyPublishers.ofString("hello"))
+                        .build();
+        HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        assertEquals("agent response ROOT", response.body());
+
+        for (String method : List.of("GET", "PUT", "DELETE")) {
+            request =
+                    HttpRequest.newBuilder(URI.create(url))
+                            .header("Content-Type", "text/plain")
+                            .method(method, HttpRequest.BodyPublishers.ofString("hello"))
+                            .build();
+            response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, response.statusCode());
+            assertEquals("agent response ROOT", response.body());
+        }
+
+        url =
+                "http://localhost:%d/api/gateways/service/tenant1/application1/svc/not-found"
+                        .formatted(port);
+        request =
+                HttpRequest.newBuilder(URI.create(url))
+                        .header("Content-Type", "text/plain")
+                        .POST(HttpRequest.BodyPublishers.ofString("hello"))
+                        .build();
+        response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        log.info("Response {}", response.body());
+        assertEquals(404, response.statusCode());
+
+        url =
+                "http://localhost:%d/api/gateways/service/tenant1/application1/svc/agent-endpoint/custom-path"
+                        .formatted(port);
+        request =
+                HttpRequest.newBuilder(URI.create(url))
+                        .header("Content-Type", "text/plain")
+                        .POST(HttpRequest.BodyPublishers.ofString("hello"))
+                        .build();
+        response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        assertEquals("agent response", response.body());
+
+        url =
+                "http://localhost:%d/api/gateways/service/tenant1/application1/svc/agent-endpoint/custom-path-json?q=v"
+                        .formatted(port);
+        request =
+                HttpRequest.newBuilder(URI.create(url))
+                        .header("Content-Type", "application/json")
+                        .header("X-Custom-Header", "XXX")
+                        .POST(HttpRequest.BodyPublishers.ofString("hello"))
+                        .build();
+        response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        assertEquals("agent response", response.body());
+    }
+}

--- a/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
+++ b/langstream-api/src/main/java/ai/langstream/api/model/Gateway.java
@@ -148,6 +148,9 @@ public final class Gateway {
     @AllArgsConstructor
     public static class ServiceOptions {
 
+        @JsonProperty("agent-id")
+        private String agentId;
+
         @JsonProperty("input-topic")
         private String inputTopic;
 

--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -55,6 +55,8 @@ public interface ApplicationStore extends GenericStore {
 
     Map<String, Integer> getResourceUsage(String tenant);
 
+    String getExecutorServiceURI(String tenant, String applicationId, String executorId);
+
     @Data
     @NoArgsConstructor
     @AllArgsConstructor

--- a/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/parser/ModelBuilder.java
@@ -601,15 +601,22 @@ public class ModelBuilder {
                 throw new IllegalArgumentException(
                         "Gateway of type 'service' must have service-options");
             }
+            if (serviceOptions.getAgentId() == null) {
+                if (serviceOptions.getInputTopic() == null) {
+                    throw new IllegalArgumentException(
+                            "Gateway of type 'service' must have service-options.input-topic");
+                }
 
-            if (serviceOptions.getInputTopic() == null) {
-                throw new IllegalArgumentException(
-                        "Gateway of type 'service' must have service-options.input-topic");
-            }
-
-            if (serviceOptions.getOutputTopic() == null) {
-                throw new IllegalArgumentException(
-                        "Gateway of type 'service' must have service-options.output-topic");
+                if (serviceOptions.getOutputTopic() == null) {
+                    throw new IllegalArgumentException(
+                            "Gateway of type 'service' must have service-options.output-topic");
+                }
+            } else {
+                if (serviceOptions.getInputTopic() != null
+                        || serviceOptions.getOutputTopic() != null) {
+                    throw new IllegalArgumentException(
+                            "Gateway of type 'service' with service-options.agent-id must not include service-options.input-topic and service-options.output-topic");
+                }
             }
         }
     }

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
@@ -275,6 +275,12 @@ public class InMemoryApplicationStore implements ApplicationStore {
     }
 
     @Override
+    public String getExecutorServiceURI(String tenant, String applicationId, String executorId) {
+        notSupported();
+        return null;
+    }
+
+    @Override
     public String storeType() {
         return "memory";
     }

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
@@ -248,5 +248,11 @@ class ApplicationServiceResourceLimitTest {
         public void initialize(Map<String, Object> configuration) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public String getExecutorServiceURI(
+                String tenant, String applicationId, String executorId) {
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
Changes:
* Added support for gateway 'service' that instead of specifying output and input topic, you can specify an agent-id. The agent must be of type the new type 'service'
* The requests are forwarded including query string and headers. POST, PUT, DELETE, GET methods are all supported