### PR TITLE
CLI: add .env configuration file

### DIFF
--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,19 +1,3 @@
-#
-# Copyright DataStax, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/conf/cli.yaml
+++ b/conf/cli.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ---
 webServiceUrl: "http://localhost:8090"
 apiGatewayUrl: "ws://localhost:8091"

--- a/langstream-cli/pom.xml
+++ b/langstream-cli/pom.xml
@@ -175,6 +175,7 @@
             <platform>windows</platform>
             <platform>unix</platform>
           </platforms>
+          <environmentSetupFileName>langstream.env</environmentSetupFileName>
           <programs>
             <program>
               <mainClass>ai.langstream.cli.LangStreamCLI</mainClass>

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -143,8 +143,9 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
 
     @CommandLine.Option(
             names = {"--langstream-runtime-version"},
-            description = "Version of the LangStream runtime to use")
-    private String dockerImageVersion = VersionProvider.getMavenVersion();
+            description = "Version of the LangStream runtime to use",
+            defaultValue = "${env:LANGSTREAM_RUNTIME_DOCKER_IMAGE_VERSION}")
+    private String dockerImageVersion;
 
     @CommandLine.Option(
             names = {"--langstream-runtime-docker-image"},

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -148,7 +148,8 @@ public class LocalRunApplicationCmd extends BaseDockerCmd {
 
     @CommandLine.Option(
             names = {"--langstream-runtime-docker-image"},
-            description = "Docker image of the LangStream runtime to use")
+            description = "Docker image of the LangStream runtime to use",
+            defaultValue = "${env:LANGSTREAM_RUNTIME_DOCKER_IMAGE}")
     private String dockerImageName;
 
     @CommandLine.Option(

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/docker/LocalRunApplicationCmd.java
@@ -23,7 +23,6 @@ import ai.langstream.admin.client.http.NoRetryPolicy;
 import ai.langstream.cli.LangStreamCLI;
 import ai.langstream.cli.NamedProfile;
 import ai.langstream.cli.api.model.Gateways;
-import ai.langstream.cli.commands.VersionProvider;
 import ai.langstream.cli.commands.applications.MermaidAppDiagramGenerator;
 import ai.langstream.cli.commands.applications.UIAppCmd;
 import ai.langstream.cli.util.DockerImageUtils;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/python/LoadPythonDependenciesCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/python/LoadPythonDependenciesCmd.java
@@ -15,7 +15,6 @@
  */
 package ai.langstream.cli.commands.python;
 
-import ai.langstream.cli.commands.VersionProvider;
 import ai.langstream.cli.util.DockerImageUtils;
 import java.io.File;
 import java.nio.file.Files;

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/python/LoadPythonDependenciesCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/python/LoadPythonDependenciesCmd.java
@@ -56,12 +56,14 @@ public class LoadPythonDependenciesCmd extends BasePythonCmd {
 
     @CommandLine.Option(
             names = {"--langstream-runtime-version"},
-            description = "Version of the LangStream runtime to use")
-    private String dockerImageVersion = VersionProvider.getMavenVersion();
+            description = "Version of the LangStream runtime to use",
+            defaultValue = "${env:LANGSTREAM_RUNTIME_DOCKER_IMAGE_VERSION}")
+    private String dockerImageVersion;
 
     @CommandLine.Option(
             names = {"--langstream-runtime-docker-image"},
-            description = "Docker image of the LangStream runtime to use")
+            description = "Docker image of the LangStream runtime to use",
+            defaultValue = "${env:LANGSTREAM_RUNTIME_DOCKER_IMAGE}")
     private String dockerImageName;
 
     @Override

--- a/langstream-cli/src/main/java/ai/langstream/cli/util/DockerImageUtils.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/util/DockerImageUtils.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.cli.util;
 
+import ai.langstream.cli.commands.VersionProvider;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -22,9 +23,12 @@ public class DockerImageUtils {
 
     public static DockerImage computeDockerImage(
             String dockerImageVersion, String dockerImageName) {
-        if (dockerImageVersion != null && dockerImageVersion.endsWith("-SNAPSHOT")) {
-            // built-from-sources, not a release
-            dockerImageVersion = "latest-dev";
+        if (dockerImageVersion == null) {
+            dockerImageVersion = VersionProvider.getMavenVersion();
+            if (dockerImageVersion != null && dockerImageVersion.endsWith("-SNAPSHOT")) {
+                // built-from-sources, not a release
+                dockerImageVersion = "latest-dev";
+            }
         }
 
         if (dockerImageName == null) {


### PR DESCRIPTION
Changes:
* Added possibility add an ENV file that is loaded before the actual java command. the file must be in the bin directory and must be named `langstream.env`
* Docker image by default is retrieved from LANGSTREAM_RUNTIME_DOCKER_IMAGE env