### PR TITLE
Fix WebCrawler state-storage default value

### DIFF
--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -25,9 +25,11 @@ import ai.langstream.api.runtime.ComponentType;
 import ai.langstream.api.runtime.ComputeClusterRuntime;
 import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.runtime.StreamingClusterRuntime;
+import ai.langstream.api.util.ConfigurationUtils;
 import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.lang.module.Configuration;
 import java.util.List;
 import java.util.Set;
 import lombok.Data;
@@ -54,8 +56,8 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
             ExecutionPlan physicalApplicationInstance,
             ComputeClusterRuntime clusterRuntime,
             StreamingClusterRuntime streamingClusterRuntime) {
-        final String stateStorage =
-                (String) agentConfiguration.getConfiguration().get("state-storage");
+        final String stateStorage = ConfigurationUtils.getString("state-storage", "s3",
+                agentConfiguration.getConfiguration());
         if (stateStorage.equals("s3")) {
             return null;
         }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -29,7 +29,6 @@ import ai.langstream.api.util.ConfigurationUtils;
 import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.lang.module.Configuration;
 import java.util.List;
 import java.util.Set;
 import lombok.Data;
@@ -56,8 +55,9 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
             ExecutionPlan physicalApplicationInstance,
             ComputeClusterRuntime clusterRuntime,
             StreamingClusterRuntime streamingClusterRuntime) {
-        final String stateStorage = ConfigurationUtils.getString("state-storage", "s3",
-                agentConfiguration.getConfiguration());
+        final String stateStorage =
+                ConfigurationUtils.getString(
+                        "state-storage", "s3", agentConfiguration.getConfiguration());
         if (stateStorage.equals("s3")) {
             return null;
         }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProviderTest.java
@@ -1,0 +1,46 @@
+package ai.langstream.runtime.impl.k8s.agents;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+class WebCrawlerSourceAgentProviderTest {
+    @Test
+    @SneakyThrows
+    public void testStateStorage() {
+        validate(
+                """
+                topics: []
+                pipeline:
+                  - name: "webcrawler-source"
+                    type: "webcrawler-source"
+                    configuration: {}
+                """,
+                null);
+
+        validate(
+                """
+                topics: []
+                pipeline:
+                  - name: "webcrawler-source"
+                    type: "webcrawler-source"
+                    configuration:
+                        state-storage: s3
+                """,
+                null);
+
+        validate(
+                """
+                topics: []
+                pipeline:
+                  - name: "webcrawler-source"
+                    type: "webcrawler-source"
+                    configuration:
+                        state-storage: disk
+                """,
+                null);
+    }
+
+    private void validate(String pipeline, String expectErrMessage) throws Exception {
+        AgentValidationTestUtil.validate(pipeline, expectErrMessage);
+    }
+}

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.runtime.impl.k8s.agents;
 
 import lombok.SneakyThrows;


### PR DESCRIPTION
Error (only on main branch)

```
Cannot invoke \"String.equals(Object)\" because \"stateStorage\" is null
```