### PR TITLE
[examples] correct misspelling in README.md

### DIFF
--- a/examples/applications/slack/README.md
+++ b/examples/applications/slack/README.md
@@ -17,5 +17,3 @@ Since the application opens a gateway, we can use the gateway API to send and co
 langstream gateway produce slack produce-input -p sessionId=$(uuidgen) -v "hello"
 ```
 
-This is currently working because the slack message and token are hardcoded and need to be referenced by variables.
-

--- a/examples/applications/slack/README.md
+++ b/examples/applications/slack/README.md
@@ -1,4 +1,4 @@
-# Slack channel witer
+# Slack channel writer
 
 This sample application shows how to write to a slack channel
 


### PR DESCRIPTION
correct misspelling in README.md