### PR TITLE
[agents] Add support for exporting custom metrics to Prometheus

### DIFF
--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
@@ -24,6 +24,7 @@ import ai.langstream.ai.agents.services.ServiceProviderRegistry;
 import ai.langstream.api.runner.code.AbstractAgentCode;
 import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.RecordSink;
 import ai.langstream.api.runner.topics.TopicProducer;
@@ -133,10 +134,12 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
     public void init(Map<String, Object> configuration) {
         configuration = new HashMap<>(configuration);
 
+        MetricsReporter reporter = agentContext.getMetricsReporter().withPrefix(agentId());
+
         // remove this from the config in order to avoid passing it TransformStepConfig
         Map<String, Object> datasourceConfiguration =
                 (Map<String, Object>) configuration.remove("datasource");
-        serviceProvider = ServiceProviderRegistry.getServiceProvider(configuration);
+        serviceProvider = ServiceProviderRegistry.getServiceProvider(configuration, reporter);
 
         configuration.remove("vertex");
         config = MAPPER.convertValue(configuration, TransformStepConfig.class);

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
@@ -58,6 +58,7 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
     private QueryStepDataSource dataSource;
     private ServiceProvider serviceProvider;
     private AgentContext agentContext;
+    private Map<String, Object> configuration;
 
     private TopicProducerStreamingAnswersConsumerFactory streamingAnswersConsumerFactory;
 
@@ -132,9 +133,12 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
     @Override
     @SneakyThrows
     public void init(Map<String, Object> configuration) {
-        configuration = new HashMap<>(configuration);
+        this.configuration = new HashMap<>(configuration);
+    }
 
-        MetricsReporter reporter = agentContext.getMetricsReporter().withPrefix(agentId());
+    @Override
+    public void start() throws Exception {
+        MetricsReporter reporter = agentContext.getMetricsReporter().withAgentName(agentId());
 
         // remove this from the config in order to avoid passing it TransformStepConfig
         Map<String, Object> datasourceConfiguration =
@@ -159,10 +163,6 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
                         dataSource,
                         streamingAnswersConsumerFactory,
                         stepsConfig.get(0));
-    }
-
-    @Override
-    public void start() throws Exception {
         streamingAnswersConsumerFactory.setAgentContext(agentContext);
         step.getTransformStep().start();
     }

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/ServiceProviderRegistry.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/ServiceProviderRegistry.java
@@ -15,6 +15,7 @@
  */
 package ai.langstream.ai.agents.services;
 
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
 import com.datastax.oss.streaming.ai.services.ServiceProvider;
@@ -45,7 +46,8 @@ public class ServiceProviderRegistry {
         public void close() {}
     }
 
-    public static ServiceProvider getServiceProvider(Map<String, Object> agentConfiguration) {
+    public static ServiceProvider getServiceProvider(
+            Map<String, Object> agentConfiguration, MetricsReporter metricsReporter) {
         if (agentConfiguration == null || agentConfiguration.isEmpty()) {
             return null;
         }
@@ -58,7 +60,7 @@ public class ServiceProviderRegistry {
         Optional<ServiceLoader.Provider<ServiceProviderProvider>> provider =
                 loader.stream().filter(p -> p.get().supports(agentConfiguration)).findFirst();
         if (provider.isPresent()) {
-            return provider.get().get().createImplementation(agentConfiguration);
+            return provider.get().get().createImplementation(agentConfiguration, metricsReporter);
         } else {
             return NoServiceProvider.INSTANCE;
         }

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/BedrockServiceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/BedrockServiceProvider.java
@@ -20,6 +20,7 @@ import ai.langstream.ai.agents.services.ServiceProviderProvider;
 import ai.langstream.ai.agents.services.impl.bedrock.BaseInvokeModelRequest;
 import ai.langstream.ai.agents.services.impl.bedrock.BedrockClient;
 import ai.langstream.ai.agents.services.impl.bedrock.TitanEmbeddingsModel;
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.datastax.oss.streaming.ai.completions.ChatChoice;
 import com.datastax.oss.streaming.ai.completions.ChatCompletions;
 import com.datastax.oss.streaming.ai.completions.ChatMessage;
@@ -50,7 +51,8 @@ public class BedrockServiceProvider implements ServiceProviderProvider {
     }
 
     @Override
-    public ServiceProvider createImplementation(Map<String, Object> agentConfiguration) {
+    public ServiceProvider createImplementation(
+            Map<String, Object> agentConfiguration, MetricsReporter metricsReporter) {
         Map<String, Object> config = (Map<String, Object>) agentConfiguration.get("bedrock");
         String accessKey = (String) config.get("access-key");
         String secretKey = (String) config.get("secret-key");

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/HuggingFaceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/HuggingFaceProvider.java
@@ -16,6 +16,7 @@
 package ai.langstream.ai.agents.services.impl;
 
 import ai.langstream.ai.agents.services.ServiceProviderProvider;
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.datastax.oss.streaming.ai.completions.ChatChoice;
 import com.datastax.oss.streaming.ai.completions.ChatCompletions;
 import com.datastax.oss.streaming.ai.completions.ChatMessage;
@@ -54,7 +55,8 @@ public class HuggingFaceProvider implements ServiceProviderProvider {
     }
 
     @Override
-    public ServiceProvider createImplementation(Map<String, Object> agentConfiguration) {
+    public ServiceProvider createImplementation(
+            Map<String, Object> agentConfiguration, MetricsReporter metricsReporter) {
         return new HuggingFaceServiceProvider(
                 (Map<String, Object>) agentConfiguration.get("huggingface"));
     }

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAIServiceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/OpenAIServiceProvider.java
@@ -16,6 +16,7 @@
 package ai.langstream.ai.agents.services.impl;
 
 import ai.langstream.ai.agents.services.ServiceProviderProvider;
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.azure.ai.openai.OpenAIAsyncClient;
 import com.datastax.oss.streaming.ai.model.config.OpenAIConfig;
 import com.datastax.oss.streaming.ai.services.ServiceProvider;
@@ -29,11 +30,13 @@ public class OpenAIServiceProvider implements ServiceProviderProvider {
     }
 
     @Override
-    public ServiceProvider createImplementation(Map<String, Object> agentConfiguration) {
+    public ServiceProvider createImplementation(
+            Map<String, Object> agentConfiguration, MetricsReporter metricsReporter) {
         OpenAIConfig config =
                 TransformFunctionUtil.convertFromMap(
                         (Map<String, Object>) agentConfiguration.get("openai"), OpenAIConfig.class);
         OpenAIAsyncClient client = TransformFunctionUtil.buildOpenAsyncAIClient(config);
-        return new com.datastax.oss.streaming.ai.services.OpenAIServiceProvider(client);
+        return new com.datastax.oss.streaming.ai.services.OpenAIServiceProvider(
+                client, metricsReporter);
     }
 }

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/VertexAIProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/services/impl/VertexAIProvider.java
@@ -16,6 +16,7 @@
 package ai.langstream.ai.agents.services.impl;
 
 import ai.langstream.ai.agents.services.ServiceProviderProvider;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.util.ConfigurationUtils;
 import com.datastax.oss.streaming.ai.completions.ChatChoice;
 import com.datastax.oss.streaming.ai.completions.ChatCompletions;
@@ -68,7 +69,8 @@ public class VertexAIProvider implements ServiceProviderProvider {
     }
 
     @Override
-    public ServiceProvider createImplementation(Map<String, Object> agentConfiguration) {
+    public ServiceProvider createImplementation(
+            Map<String, Object> agentConfiguration, MetricsReporter metricsReporter) {
 
         Map<String, Object> config = (Map<String, Object>) agentConfiguration.get("vertex");
         String token = (String) config.get("token");

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/EmbeddingServiceResponse.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/EmbeddingServiceResponse.java
@@ -13,16 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.ai.agents.services;
+package com.datastax.oss.streaming.ai.embeddings;
 
-import ai.langstream.api.runner.code.MetricsReporter;
-import com.datastax.oss.streaming.ai.services.ServiceProvider;
-import java.util.Map;
-
-public interface ServiceProviderProvider {
-
-    boolean supports(Map<String, Object> agentConfiguration);
-
-    ServiceProvider createImplementation(
-            Map<String, Object> agentConfiguration, MetricsReporter metricsReporter);
-}
+public class EmbeddingServiceResponse {}

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
@@ -43,11 +43,11 @@ public class OpenAIEmbeddingsService implements EmbeddingsService {
         this.openAIClient = openAIClient;
         this.model = model;
         this.metricsReporter = metricsReporter;
-        this.totalTokens = metricsReporter.counter("openai_embeddings_total_tokens");
-        this.promptTokens = metricsReporter.counter("openai_embeddings_prompt_tokens");
-        this.numCalls = metricsReporter.counter("openai_embeddings_num_calls");
-        this.numTexts = metricsReporter.counter("openai_embeddings_num_texts");
-        this.numErrors = metricsReporter.counter("openai_embeddings_num_errors");
+        this.totalTokens = metricsReporter.counter("openai_embeddings_total_tokens", "Total number of tokens exchanged with OpenAI");
+        this.promptTokens = metricsReporter.counter("openai_embeddings_prompt_tokens", "Total number of prompt tokens sent to OpenAI");
+        this.numCalls = metricsReporter.counter("openai_embeddings_num_calls", "Total number of calls to OpenAI");
+        this.numTexts = metricsReporter.counter("openai_embeddings_num_texts", "Total number of texts sent to OpenAI");
+        this.numErrors = metricsReporter.counter("openai_embeddings_num_errors", "Total number of errors while calling OpenAI");
     }
 
     @Override

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
@@ -15,8 +15,11 @@
  */
 package com.datastax.oss.streaming.ai.embeddings;
 
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.azure.ai.openai.OpenAIAsyncClient;
+import com.azure.ai.openai.models.EmbeddingItem;
 import com.azure.ai.openai.models.EmbeddingsOptions;
+import com.azure.ai.openai.models.EmbeddingsUsage;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -27,25 +30,54 @@ public class OpenAIEmbeddingsService implements EmbeddingsService {
 
     private final OpenAIAsyncClient openAIClient;
     private final String model;
+    private final MetricsReporter metricsReporter;
 
-    public OpenAIEmbeddingsService(OpenAIAsyncClient openAIClient, String model) {
+    private final MetricsReporter.Counter totalTokens;
+    private final MetricsReporter.Counter promptTokens;
+    private final MetricsReporter.Counter numCalls;
+    private final MetricsReporter.Counter numTexts;
+    private final MetricsReporter.Counter numErrors;
+
+    public OpenAIEmbeddingsService(
+            OpenAIAsyncClient openAIClient, String model, MetricsReporter metricsReporter) {
         this.openAIClient = openAIClient;
         this.model = model;
+        this.metricsReporter = metricsReporter;
+        this.totalTokens = metricsReporter.counter("openai_embeddings_total_tokens");
+        this.promptTokens = metricsReporter.counter("openai_embeddings_prompt_tokens");
+        this.numCalls = metricsReporter.counter("openai_embeddings_num_calls");
+        this.numTexts = metricsReporter.counter("openai_embeddings_num_texts");
+        this.numErrors = metricsReporter.counter("openai_embeddings_num_errors");
     }
 
     @Override
     public CompletableFuture<List<List<Double>>> computeEmbeddings(List<String> texts) {
         try {
             EmbeddingsOptions embeddingsOptions = new EmbeddingsOptions(texts);
-            return openAIClient
-                    .getEmbeddings(model, embeddingsOptions)
-                    .toFuture()
-                    .thenApply(
-                            embeddings ->
-                                    embeddings.getData().stream()
-                                            .map(embedding -> embedding.getEmbedding())
-                                            .collect(Collectors.toList()));
+            numCalls.count(1);
+            numTexts.count(texts.size());
+            CompletableFuture<List<List<Double>>> result =
+                    openAIClient
+                            .getEmbeddings(model, embeddingsOptions)
+                            .toFuture()
+                            .thenApply(
+                                    embeddings -> {
+                                        EmbeddingsUsage usage = embeddings.getUsage();
+                                        totalTokens.count(usage.getTotalTokens());
+                                        promptTokens.count(usage.getPromptTokens());
+                                        return embeddings.getData().stream()
+                                                .map(EmbeddingItem::getEmbedding)
+                                                .collect(Collectors.toList());
+                                    });
 
+            result.exceptionally(
+                    err -> {
+                        // API call error
+                        numErrors.count(1);
+                        return null;
+                    });
+
+            return result;
         } catch (RuntimeException err) {
             log.error("Cannot compute embeddings", err);
             return CompletableFuture.failedFuture(err);

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/OpenAIEmbeddingsService.java
@@ -43,11 +43,24 @@ public class OpenAIEmbeddingsService implements EmbeddingsService {
         this.openAIClient = openAIClient;
         this.model = model;
         this.metricsReporter = metricsReporter;
-        this.totalTokens = metricsReporter.counter("openai_embeddings_total_tokens", "Total number of tokens exchanged with OpenAI");
-        this.promptTokens = metricsReporter.counter("openai_embeddings_prompt_tokens", "Total number of prompt tokens sent to OpenAI");
-        this.numCalls = metricsReporter.counter("openai_embeddings_num_calls", "Total number of calls to OpenAI");
-        this.numTexts = metricsReporter.counter("openai_embeddings_num_texts", "Total number of texts sent to OpenAI");
-        this.numErrors = metricsReporter.counter("openai_embeddings_num_errors", "Total number of errors while calling OpenAI");
+        this.totalTokens =
+                metricsReporter.counter(
+                        "openai_embeddings_total_tokens",
+                        "Total number of tokens exchanged with OpenAI");
+        this.promptTokens =
+                metricsReporter.counter(
+                        "openai_embeddings_prompt_tokens",
+                        "Total number of prompt tokens sent to OpenAI");
+        this.numCalls =
+                metricsReporter.counter(
+                        "openai_embeddings_num_calls", "Total number of calls to OpenAI");
+        this.numTexts =
+                metricsReporter.counter(
+                        "openai_embeddings_num_texts", "Total number of texts sent to OpenAI");
+        this.numErrors =
+                metricsReporter.counter(
+                        "openai_embeddings_num_errors",
+                        "Total number of errors while calling OpenAI");
     }
 
     @Override

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/services/OpenAIServiceProvider.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.streaming.ai.services;
 
 import ai.langstream.ai.agents.services.impl.OpenAICompletionService;
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.azure.ai.openai.OpenAIAsyncClient;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
 import com.datastax.oss.streaming.ai.embeddings.EmbeddingsService;
@@ -27,13 +28,16 @@ import java.util.Map;
 public class OpenAIServiceProvider implements ServiceProvider {
 
     private final OpenAIAsyncClient client;
+    private final MetricsReporter metricsReporter;
 
     public OpenAIServiceProvider(TransformStepConfig config) {
         client = TransformFunctionUtil.buildOpenAsyncAIClient(config.getOpenai());
+        metricsReporter = MetricsReporter.DISABLED;
     }
 
-    public OpenAIServiceProvider(OpenAIAsyncClient client) {
+    public OpenAIServiceProvider(OpenAIAsyncClient client, MetricsReporter metricsReporter) {
         this.client = client;
+        this.metricsReporter = metricsReporter;
     }
 
     @Override
@@ -44,7 +48,7 @@ public class OpenAIServiceProvider implements ServiceProvider {
     @Override
     public EmbeddingsService getEmbeddingsService(Map<String, Object> additionalConfiguration) {
         String model = (String) additionalConfiguration.get("model");
-        return new OpenAIEmbeddingsService(client, model);
+        return new OpenAIEmbeddingsService(client, model, metricsReporter);
     }
 
     @Override

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/GenAIToolKitAgentTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/GenAIToolKitAgentTest.java
@@ -16,7 +16,11 @@
 package ai.langstream.ai.agents;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import ai.langstream.api.runner.code.AgentContext;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -58,6 +62,9 @@ class GenAIToolKitAgentTest {
 
     Object compute(String expression, Object value) throws Exception {
         GenAIToolKitAgent agent = new GenAIToolKitAgent();
+        AgentContext mockContext = mock(AgentContext.class);
+        when(mockContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
+        agent.setContext(mockContext);
         agent.init(
                 Map.of(
                         "steps",

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/HuggingAIProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/HuggingAIProviderTest.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.datastax.oss.streaming.ai.completions.ChatCompletions;
 import com.datastax.oss.streaming.ai.completions.ChatMessage;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
@@ -63,7 +64,8 @@ class HuggingAIProviderTest {
                                         "inference-url",
                                         wmRuntimeInfo.getHttpBaseUrl(),
                                         "access-key",
-                                        "xxxx")));
+                                        "xxxx")),
+                        MetricsReporter.DISABLED);
 
         CompletionsService service = implementation.getCompletionsService(Map.of());
         String message = "The cop arrested the bad [MASK].";

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/OpenAIProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/OpenAIProviderTest.java
@@ -22,6 +22,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import ai.langstream.ai.agents.services.ServiceProviderProvider;
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.datastax.oss.streaming.ai.completions.ChatChoice;
 import com.datastax.oss.streaming.ai.completions.ChatCompletions;
 import com.datastax.oss.streaming.ai.completions.ChatMessage;
@@ -77,7 +78,8 @@ class OpenAIProviderTest {
                                         "access-key",
                                         "xxxxxxx",
                                         "url",
-                                        vmRuntimeInfo.getHttpBaseUrl())));
+                                        vmRuntimeInfo.getHttpBaseUrl())),
+                        MetricsReporter.DISABLED);
 
         List<String> chunks = new CopyOnWriteArrayList<>();
         CompletionsService service = implementation.getCompletionsService(Map.of());
@@ -181,7 +183,8 @@ class OpenAIProviderTest {
                                         "access-key",
                                         "xxxxxxx",
                                         "url",
-                                        vmRuntimeInfo.getHttpBaseUrl())));
+                                        vmRuntimeInfo.getHttpBaseUrl())),
+                        MetricsReporter.DISABLED);
 
         List<String> chunks = new CopyOnWriteArrayList<>();
         CompletionsService service = implementation.getCompletionsService(Map.of());

--- a/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/VertexAIProviderTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/ai/langstream/ai/agents/services/impl/VertexAIProviderTest.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.datastax.oss.streaming.ai.completions.ChatCompletions;
 import com.datastax.oss.streaming.ai.completions.ChatMessage;
 import com.datastax.oss.streaming.ai.completions.CompletionsService;
@@ -73,7 +74,8 @@ class VertexAIProviderTest {
                                         "region",
                                         "us-central1",
                                         "token",
-                                        "xxxx")));
+                                        "xxxx")),
+                        MetricsReporter.DISABLED);
 
         EmbeddingsService embeddingsService =
                 implementation.getEmbeddingsService(Map.of("model", "textembedding-gecko"));
@@ -142,7 +144,8 @@ class VertexAIProviderTest {
                                         "region",
                                         "us-central1",
                                         "token",
-                                        "xxxx")));
+                                        "xxxx")),
+                        MetricsReporter.DISABLED);
         CompletionsService service =
                 implementation.getCompletionsService(
                         Map.of(
@@ -209,7 +212,8 @@ class VertexAIProviderTest {
                                         "region",
                                         "us-central1",
                                         "token",
-                                        "xxxx")));
+                                        "xxxx")),
+                        MetricsReporter.DISABLED);
         CompletionsService service =
                 implementation.getCompletionsService(
                         Map.of(
@@ -249,7 +253,8 @@ class VertexAIProviderTest {
                                         "region",
                                         "us-central1",
                                         "serviceAccountJson",
-                                        "PUT-HERE-YOUR-JSON-KEY")));
+                                        "PUT-HERE-YOUR-JSON-KEY")),
+                        MetricsReporter.DISABLED);
 
         EmbeddingsService embeddingsService =
                 implementation.getEmbeddingsService(Map.of("model", "textembedding-gecko"));

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/GenAITest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/GenAITest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
@@ -209,7 +210,7 @@ public class GenAITest {
                                         new ObjectMapper()
                                                 .readValue(completion, ChatCompletions.class)));
         when(transformFunction.buildServiceProvider(any()))
-                .thenReturn(new OpenAIServiceProvider(client));
+                .thenReturn(new OpenAIServiceProvider(client, MetricsReporter.DISABLED));
 
         Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
         Utils.TestContext context = new Utils.TestContext(record, config);
@@ -271,7 +272,7 @@ public class GenAITest {
                                         new ObjectMapper()
                                                 .readValue(completion, ChatCompletions.class)));
         when(transformFunction.buildServiceProvider(any()))
-                .thenReturn(new OpenAIServiceProvider(client));
+                .thenReturn(new OpenAIServiceProvider(client, MetricsReporter.DISABLED));
 
         Record<GenericObject> record = Utils.createTestAvroKeyValueRecord();
         Utils.TestContext context = new Utils.TestContext(record, config);

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/pulsar/functions/transforms/TransformFunction.java
@@ -21,6 +21,7 @@ import static com.datastax.oss.streaming.ai.util.TransformFunctionUtil.buildStep
 import ai.langstream.ai.agents.commons.MutableRecord;
 import ai.langstream.ai.agents.commons.TransformSchemaType;
 import ai.langstream.ai.agents.services.impl.HuggingFaceProvider;
+import ai.langstream.api.runner.code.MetricsReporter;
 import com.datastax.oss.streaming.ai.StepPredicatePair;
 import com.datastax.oss.streaming.ai.TransformStep;
 import com.datastax.oss.streaming.ai.datasource.QueryStepDataSource;
@@ -495,7 +496,8 @@ public class TransformFunction
             if (config.getHuggingface() != null) {
                 return new HuggingFaceProvider()
                         .createImplementation(
-                                TransformFunctionUtil.convertToMap(config.getHuggingface()));
+                                TransformFunctionUtil.convertToMap(config.getHuggingface()),
+                                MetricsReporter.DISABLED);
             }
         }
         return new ServiceProvider.NoopServiceProvider();

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentContext.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/AgentContext.java
@@ -42,6 +42,10 @@ public interface AgentContext {
 
     TopicConnectionProvider getTopicConnectionProvider();
 
+    default MetricsReporter getMetricsReporter() {
+        return MetricsReporter.DISABLED;
+    }
+
     default BadRecordHandler getBadRecordHandler() {
         return DEFAULT_BAD_RECORD_HANDLER;
     }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/MetricsReporter.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/MetricsReporter.java
@@ -13,16 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ai.langstream.ai.agents.services;
+package ai.langstream.api.runner.code;
 
-import ai.langstream.api.runner.code.MetricsReporter;
-import com.datastax.oss.streaming.ai.services.ServiceProvider;
-import java.util.Map;
+public interface MetricsReporter {
+    static MetricsReporter DISABLED =
+            new MetricsReporter() {
+                public Counter counter(String name) {
+                    return Counter.NOOP;
+                }
+            };
 
-public interface ServiceProviderProvider {
+    default MetricsReporter withPrefix(String prefix) {
+        return this;
+    }
 
-    boolean supports(Map<String, Object> agentConfiguration);
+    Counter counter(String name);
 
-    ServiceProvider createImplementation(
-            Map<String, Object> agentConfiguration, MetricsReporter metricsReporter);
+    interface Counter {
+
+        Counter NOOP = (value) -> {};
+
+        void count(int value);
+    }
 }

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/MetricsReporter.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/MetricsReporter.java
@@ -18,16 +18,16 @@ package ai.langstream.api.runner.code;
 public interface MetricsReporter {
     static MetricsReporter DISABLED =
             new MetricsReporter() {
-                public Counter counter(String name) {
+                public Counter counter(String name, String help) {
                     return Counter.NOOP;
                 }
             };
 
-    default MetricsReporter withPrefix(String prefix) {
+    default MetricsReporter withAgentName(String prefix) {
         return this;
     }
 
-    Counter counter(String name);
+    Counter counter(String name, String help);
 
     interface Counter {
 

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunner.java
@@ -29,6 +29,7 @@ import ai.langstream.api.runner.code.AgentSink;
 import ai.langstream.api.runner.code.AgentSource;
 import ai.langstream.api.runner.code.AgentStatusResponse;
 import ai.langstream.api.runner.code.BadRecordHandler;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.RecordSink;
 import ai.langstream.api.runner.topics.TopicAdmin;
@@ -43,6 +44,7 @@ import ai.langstream.impl.nar.NarFileHandler;
 import ai.langstream.runtime.agent.api.AgentAPIController;
 import ai.langstream.runtime.agent.api.AgentInfoServlet;
 import ai.langstream.runtime.agent.api.MetricsHttpServlet;
+import ai.langstream.runtime.agent.metrics.PrometheusMetricsReporter;
 import ai.langstream.runtime.agent.simple.IdentityAgentProvider;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -87,6 +89,8 @@ public class AgentRunner {
                 log.error("Unexpected error", error);
                 System.exit(-1);
             };
+
+    private static PrometheusMetricsReporter metricsReporter = new PrometheusMetricsReporter();
 
     public interface MainErrorHandler {
         void handleError(Throwable error);
@@ -1045,6 +1049,11 @@ public class AgentRunner {
             this.basePersistentStateDirectory = basePersistentStateDirectory;
             this.agentsWithPersistentState = agentsWithPersistentState;
             ensurePersistentStateDirectoriesExist();
+        }
+
+        @Override
+        public MetricsReporter getMetricsReporter() {
+            return metricsReporter;
         }
 
         private void ensurePersistentStateDirectoriesExist() {

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/metrics/PrometheusMetricsReporter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/metrics/PrometheusMetricsReporter.java
@@ -17,15 +17,13 @@ package ai.langstream.runtime.agent.metrics;
 
 import ai.langstream.api.runner.code.MetricsReporter;
 import io.prometheus.client.Counter;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PrometheusMetricsReporter implements MetricsReporter {
 
     private final String agentName;
-    private static Map<String, io.prometheus.client.Counter> counters
-            = new ConcurrentHashMap<>();
+    private static Map<String, io.prometheus.client.Counter> counters = new ConcurrentHashMap<>();
 
     public PrometheusMetricsReporter(String agentName) {
         this.agentName = agentName;
@@ -42,14 +40,16 @@ public class PrometheusMetricsReporter implements MetricsReporter {
 
     @Override
     public Counter counter(String name, String help) {
-        String finalName = this.agentName.isEmpty() ? agentName : this.agentName + "_" + name;
-        io.prometheus.client.Counter counter = counters.computeIfAbsent(name, k -> {
-            return io.prometheus.client.Counter.build()
-                    .name(sanitizeMetricName(finalName))
-                    .labelNames("agent")
-                    .help(help)
-                    .register();
-        });
+        io.prometheus.client.Counter counter =
+                counters.computeIfAbsent(
+                        name,
+                        k -> {
+                            return io.prometheus.client.Counter.build()
+                                    .name(sanitizeMetricName(name))
+                                    .labelNames("agent_id")
+                                    .help(help)
+                                    .register();
+                        });
 
         io.prometheus.client.Counter.Child counterWithLabel = counter.labels(agentName);
         return new Counter() {
@@ -74,5 +74,4 @@ public class PrometheusMetricsReporter implements MetricsReporter {
 
         return sanitizedName;
     }
-
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/metrics/PrometheusMetricsReporter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/metrics/PrometheusMetricsReporter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.runtime.agent.metrics;
+
+import ai.langstream.api.runner.code.MetricsReporter;
+import io.prometheus.client.Counter;
+
+public class PrometheusMetricsReporter implements MetricsReporter {
+
+    private final String prefix;
+
+    public PrometheusMetricsReporter(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public PrometheusMetricsReporter() {
+        this("");
+    }
+
+    @Override
+    public MetricsReporter withPrefix(String prefix) {
+        String newPrefix = this.prefix.isEmpty() ? prefix : this.prefix + "_" + prefix;
+        return new PrometheusMetricsReporter(newPrefix);
+    }
+
+    @Override
+    public Counter counter(String name) {
+        String finalName = this.prefix.isEmpty() ? prefix : this.prefix + "_" + name;
+        io.prometheus.client.Counter counter =
+                io.prometheus.client.Counter.build().name(finalName).register();
+        return new Counter() {
+            @Override
+            public void count(int value) {
+                counter.inc(value);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Summary:
- add support for Java agents to push metrics to Prometheus
- implement basic metrics for OpenAI consumptions for the Embeddings service

![image](https://github.com/LangStream/langstream/assets/9469110/8bf7151d-1d30-4b7b-8927-cec9704b226d)
