### PR TITLE
Fix service gateway with topics

### DIFF
--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ConsumeGateway.java
@@ -145,6 +145,7 @@ public class ConsumeGateway implements AutoCloseable {
                                 log.debug("[{}] Started reader", logRef);
                                 readMessages(stop, onMessage);
                             } catch (Throwable ex) {
+                                log.error("[{}] Error reading messages", logRef, ex);
                                 throw new RuntimeException(ex);
                             } finally {
                                 closeReader();

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -144,13 +144,18 @@ public class ProduceGateway implements AutoCloseable {
     }
 
     public void produceMessage(String payload) throws ProduceException {
+        final ProduceRequest produceRequest = parseProduceRequest(payload);
+        produceMessage(produceRequest);
+    }
+
+    public static ProduceRequest parseProduceRequest(String payload) throws ProduceException {
         final ProduceRequest produceRequest;
         try {
             produceRequest = mapper.readValue(payload, ProduceRequest.class);
         } catch (JsonProcessingException err) {
-            throw new ProduceException(err.getMessage(), ProduceResponse.Status.BAD_REQUEST);
+            throw new ProduceException("Error while parsing JSON payload: " + err.getMessage(), ProduceResponse.Status.BAD_REQUEST);
         }
-        produceMessage(produceRequest);
+        return produceRequest;
     }
 
     public void produceMessage(ProduceRequest produceRequest) throws ProduceException {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/gateways/ProduceGateway.java
@@ -153,7 +153,9 @@ public class ProduceGateway implements AutoCloseable {
         try {
             produceRequest = mapper.readValue(payload, ProduceRequest.class);
         } catch (JsonProcessingException err) {
-            throw new ProduceException("Error while parsing JSON payload: " + err.getMessage(), ProduceResponse.Status.BAD_REQUEST);
+            throw new ProduceException(
+                    "Error while parsing JSON payload: " + err.getMessage(),
+                    ProduceResponse.Status.BAD_REQUEST);
         }
         return produceRequest;
     }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -255,22 +255,23 @@ public class GatewayResource {
         final String langstreamServiceRequestId = UUID.randomUUID().toString();
 
         final CompletableFuture<ResponseEntity> completableFuture = new CompletableFuture<>();
-        try (
-                final ProduceGateway produceGateway =
-                        new ProduceGateway(
-                                topicConnectionsRuntimeRegistryProvider
-                                        .getTopicConnectionsRuntimeRegistry(),
-                                topicProducerCache); ) {
+        try (final ProduceGateway produceGateway =
+                new ProduceGateway(
+                        topicConnectionsRuntimeRegistryProvider
+                                .getTopicConnectionsRuntimeRegistry(),
+                        topicProducerCache); ) {
 
             final ConsumeGateway consumeGateway =
                     new ConsumeGateway(
                             topicConnectionsRuntimeRegistryProvider
                                     .getTopicConnectionsRuntimeRegistry());
-            completableFuture.thenRunAsync(() -> {
-                if (consumeGateway != null) {
-                    consumeGateway.close();
-                }
-            }, consumeThreadPool);
+            completableFuture.thenRunAsync(
+                    () -> {
+                        if (consumeGateway != null) {
+                            consumeGateway.close();
+                        }
+                    },
+                    consumeThreadPool);
 
             final Gateway.ServiceOptions serviceOptions = authContext.gateway().getServiceOptions();
             try {

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -286,7 +286,9 @@ public class GatewayResource {
                 passedHeaders = new HashMap<>();
             }
             passedHeaders.put(SERVICE_REQUEST_ID_HEADER, langstreamServiceRequestId);
-            produceGateway.produceMessage(new ProduceRequest(produceRequest.key(), produceRequest.value(), passedHeaders));
+            produceGateway.produceMessage(
+                    new ProduceRequest(
+                            produceRequest.key(), produceRequest.value(), passedHeaders));
         } catch (Throwable t) {
             completableFuture.completeExceptionally(t);
         }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/GatewayResource.java
@@ -90,9 +90,7 @@ public class GatewayResource {
             Executors.newCachedThreadPool(
                     new BasicThreadFactory.Builder().namingPattern("http-consume-%d").build());
 
-    @PostMapping(
-            value = "/produce/{tenant}/{application}/{gateway}",
-            consumes = "*/*")
+    @PostMapping(value = "/produce/{tenant}/{application}/{gateway}", consumes = "*/*")
     ProduceResponse produce(
             WebRequest request,
             @NotBlank @PathVariable("tenant") String tenant,
@@ -243,7 +241,9 @@ public class GatewayResource {
                 throw new ResponseStatusException(
                         HttpStatus.BAD_REQUEST, "Only POST method is supported");
             }
-            final String payload = new String(servletRequest.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            final String payload =
+                    new String(
+                            servletRequest.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
             final ProduceRequest produceRequest = parseProduceRequest(request, payload);
             return handleServiceWithTopics(produceRequest, authContext);
         }

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/ResourceErrorsHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/ResourceErrorsHandler.java
@@ -22,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.server.ResponseStatusException;
 
 @ControllerAdvice
@@ -37,6 +38,10 @@ public class ResourceErrorsHandler {
         if (exception instanceof IllegalArgumentException) {
             log.error("Bad request", exception);
             return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, exception.getMessage());
+        }
+        if (exception instanceof AsyncRequestTimeoutException) {
+            log.error("Request timed out", exception);
+            return ProblemDetail.forStatusAndDetail(HttpStatus.REQUEST_TIMEOUT, "Request timed out");
         }
         log.error("Internal error", exception);
         return ProblemDetail.forStatusAndDetail(

--- a/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/ResourceErrorsHandler.java
+++ b/langstream-api-gateway/src/main/java/ai/langstream/apigateway/http/ResourceErrorsHandler.java
@@ -41,7 +41,8 @@ public class ResourceErrorsHandler {
         }
         if (exception instanceof AsyncRequestTimeoutException) {
             log.error("Request timed out", exception);
-            return ProblemDetail.forStatusAndDetail(HttpStatus.REQUEST_TIMEOUT, "Request timed out");
+            return ProblemDetail.forStatusAndDetail(
+                    HttpStatus.REQUEST_TIMEOUT, "Request timed out");
         }
         log.error("Internal error", exception);
         return ProblemDetail.forStatusAndDetail(

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -233,7 +233,6 @@ abstract class GatewayResourceTest {
                 {"status":"OK","reason":null}""", response.body());
     }
 
-
     @SneakyThrows
     String produceTextAndGetBody(String url, String content) {
         final HttpRequest request =
@@ -317,8 +316,7 @@ abstract class GatewayResourceTest {
                 HttpRequest.newBuilder(URI.create(url))
                         .POST(HttpRequest.BodyPublishers.ofString("my-string"))
                         .build();
-        HttpResponse<String> response =
-                CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(200, response.statusCode());
         assertEquals("""
                 {"status":"OK","reason":null}""", response.body());
@@ -328,12 +326,10 @@ abstract class GatewayResourceTest {
                         .header("Content-Type", "plain/text")
                         .POST(HttpRequest.BodyPublishers.ofString("my-string"))
                         .build();
-        response =
-                CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(200, response.statusCode());
         assertEquals("""
                 {"status":"OK","reason":null}""", response.body());
-
     }
 
     @Test
@@ -482,7 +478,8 @@ abstract class GatewayResourceTest {
 
         produceJsonAndExpectUnauthorized(baseUrl, "{\"value\": \"my-value\"}");
         produceJsonAndExpectUnauthorized(baseUrl + "?credentials=", "{\"value\": \"my-value\"}");
-        produceJsonAndExpectUnauthorized(baseUrl + "?credentials=error", "{\"value\": \"my-value\"}");
+        produceJsonAndExpectUnauthorized(
+                baseUrl + "?credentials=error", "{\"value\": \"my-value\"}");
         produceJsonAndExpectOk(
                 baseUrl + "?credentials=test-user-password", "{\"value\": \"my-value\"}");
     }
@@ -569,8 +566,7 @@ abstract class GatewayResourceTest {
                 produceJsonAndGetBody(url, "{\"key\": \"my-key2\", \"value\": \"my-value\"}"));
 
         assertMessageContent(
-                new MsgRecord(null, "my-text", Map.of()),
-                produceTextAndGetBody(url, "my-text"));
+                new MsgRecord(null, "my-text", Map.of()), produceTextAndGetBody(url, "my-text"));
         assertMessageContent(
                 new MsgRecord("my-key2", "my-value", Map.of("header1", "value1")),
                 produceJsonAndGetBody(

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -323,10 +323,11 @@ abstract class GatewayResourceTest {
 
         request =
                 HttpRequest.newBuilder(URI.create(url))
-                        .header("Content-Type", "plain/text")
+                        .header("Content-Type", "text/plain")
                         .POST(HttpRequest.BodyPublishers.ofString("my-string"))
                         .build();
         response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+        log.info("Response body: {}", response.body());
         assertEquals(200, response.statusCode());
         assertEquals("""
                 {"status":"OK","reason":null}""", response.body());

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -584,24 +584,27 @@ abstract class GatewayResourceTest {
                                     topicConnectionsRuntimeProvider
                                             .getTopicConnectionsRuntimeRegistry();
                             final StreamingCluster streamingCluster = getStreamingCluster();
-                            final TopicConnectionsRuntime runtime = topicConnectionsRuntimeRegistry
-                                    .getTopicConnectionsRuntime(streamingCluster)
-                                    .asTopicConnectionsRuntime();
+                            final TopicConnectionsRuntime runtime =
+                                    topicConnectionsRuntimeRegistry
+                                            .getTopicConnectionsRuntime(streamingCluster)
+                                            .asTopicConnectionsRuntime();
                             runtime.init(streamingCluster);
                             try (final TopicConsumer consumer =
-                                    runtime
-                                            .createConsumer(
-                                                    null,
-                                                    streamingCluster,
-                                                    Map.of("topic", fromTopic, "subscriptionName", "s")); ) {
+                                    runtime.createConsumer(
+                                            null,
+                                            streamingCluster,
+                                            Map.of(
+                                                    "topic",
+                                                    fromTopic,
+                                                    "subscriptionName",
+                                                    "s")); ) {
                                 consumer.start();
 
                                 try (final TopicProducer producer =
-                                             runtime
-                                                .createProducer(
-                                                        null,
-                                                        streamingCluster,
-                                                        Map.of("topic", toTopic)); ) {
+                                        runtime.createProducer(
+                                                null,
+                                                streamingCluster,
+                                                Map.of("topic", toTopic)); ) {
 
                                     producer.start();
                                     while (true) {
@@ -609,12 +612,20 @@ abstract class GatewayResourceTest {
                                         if (records.isEmpty()) {
                                             continue;
                                         }
-                                        log.info("read {} records from {}: {}", records.size(), fromTopic, records);
+                                        log.info(
+                                                "read {} records from {}: {}",
+                                                records.size(),
+                                                fromTopic,
+                                                records);
                                         for (Record record : records) {
                                             producer.write(record).get();
                                         }
                                         consumer.commit(records);
-                                        log.info("written {} records to {}: {}", records.size(), toTopic, records);
+                                        log.info(
+                                                "written {} records to {}: {}",
+                                                records.size(),
+                                                toTopic,
+                                                records);
                                     }
                                 }
                             } catch (Throwable e) {

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/http/GatewayResourceTest.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -542,34 +541,45 @@ abstract class GatewayResourceTest {
     }
 
     private void startTopicExchange(String fromTopic, String toTopic) throws Exception {
-        final CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
-            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry =
-                    topicConnectionsRuntimeProvider.getTopicConnectionsRuntimeRegistry();
-            final StreamingCluster streamingCluster = getStreamingCluster();
-            try (final TopicConsumer consumer = topicConnectionsRuntimeRegistry
-                    .getTopicConnectionsRuntime(streamingCluster)
-                    .asTopicConnectionsRuntime()
-                    .createConsumer(null, streamingCluster, Map.of("topic", fromTopic));) {
-                consumer.start();
+        final CompletableFuture<Void> future =
+                CompletableFuture.runAsync(
+                        () -> {
+                            TopicConnectionsRuntimeRegistry topicConnectionsRuntimeRegistry =
+                                    topicConnectionsRuntimeProvider
+                                            .getTopicConnectionsRuntimeRegistry();
+                            final StreamingCluster streamingCluster = getStreamingCluster();
+                            try (final TopicConsumer consumer =
+                                    topicConnectionsRuntimeRegistry
+                                            .getTopicConnectionsRuntime(streamingCluster)
+                                            .asTopicConnectionsRuntime()
+                                            .createConsumer(
+                                                    null,
+                                                    streamingCluster,
+                                                    Map.of("topic", fromTopic)); ) {
+                                consumer.start();
 
-                try (final TopicProducer producer = topicConnectionsRuntimeRegistry
-                        .getTopicConnectionsRuntime(streamingCluster)
-                        .asTopicConnectionsRuntime()
-                        .createProducer(null, streamingCluster, Map.of("topic", toTopic));) {
+                                try (final TopicProducer producer =
+                                        topicConnectionsRuntimeRegistry
+                                                .getTopicConnectionsRuntime(streamingCluster)
+                                                .asTopicConnectionsRuntime()
+                                                .createProducer(
+                                                        null,
+                                                        streamingCluster,
+                                                        Map.of("topic", toTopic)); ) {
 
-                    producer.start();
-                    while (true) {
+                                    producer.start();
+                                    while (true) {
 
-                        final List<Record> records = consumer.read();
-                        for (Record record : records) {
-                            producer.write(record);
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        });
+                                        final List<Record> records = consumer.read();
+                                        for (Record record : records) {
+                                            producer.write(record);
+                                        }
+                                    }
+                                }
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
+                        });
         futures.add(future);
     }
 
@@ -581,10 +591,7 @@ abstract class GatewayResourceTest {
         final Map<String, String> headers = consume.record().headers();
         assertNotNull(headers.remove("langstream-service-request-id"));
         final MsgRecord actualMsgRecord =
-                new MsgRecord(
-                        consume.record().key(),
-                        consume.record().value(),
-                        headers);
+                new MsgRecord(consume.record().key(), consume.record().value(), headers);
 
         assertEquals(expected, actualMsgRecord);
     }

--- a/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
+++ b/langstream-api-gateway/src/test/java/ai/langstream/apigateway/websocket/handlers/ProduceConsumeHandlerTest.java
@@ -858,7 +858,7 @@ abstract class ProduceConsumeHandlerTest {
 
         assertEquals(ProduceResponse.Status.BAD_REQUEST, response.status());
         assertEquals(
-                "Unrecognized token 'invalid': was expecting (JSON String, Number, Array, Object or token "
+                "Error while parsing JSON payload: Unrecognized token 'invalid': was expecting (JSON String, Number, Array, Object or token "
                         + "'null', 'true' or 'false')\n"
                         + " at [Source: (String)\"invalid-json\"; line: 1, column: 8]",
                 response.reason());


### PR DESCRIPTION
Changes:
* Invert input and output topic as expected
* add fixed header `langstream-service-request-id` to ensure getting the response to the previously sent message
* Http gateways now by default expects a plain/text that will be part the message value. By passing Content-Type application/json you can still pass the entire body 
* improved tests