### PR TITLE
Add examples and utility function to deal with Cassio

### DIFF
--- a/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlEvaluator.java
+++ b/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlEvaluator.java
@@ -88,9 +88,7 @@ public class JstlEvaluator<T> {
         this.expressionContext
                 .getFunctionMapper()
                 .mapFunction(
-                        "fn",
-                        "concat",
-                        JstlFunctions.class.getMethod("concat", Object.class, Object.class));
+                        "fn", "concat", JstlFunctions.class.getMethod("concat", Object[].class));
         this.expressionContext
                 .getFunctionMapper()
                 .mapFunction(
@@ -129,6 +127,10 @@ public class JstlEvaluator<T> {
                         JstlFunctions.class.getMethod("addAll", Object.class, Object.class));
         this.expressionContext
                 .getFunctionMapper()
+                .mapFunction(
+                        "fn", "listOf", JstlFunctions.class.getMethod("listOf", Object[].class));
+        this.expressionContext
+                .getFunctionMapper()
                 .mapFunction("fn", "emptyList", JstlFunctions.class.getMethod("emptyList"));
         this.expressionContext
                 .getFunctionMapper()
@@ -153,6 +155,24 @@ public class JstlEvaluator<T> {
         this.expressionContext
                 .getFunctionMapper()
                 .mapFunction("fn", "emptyMap", JstlFunctions.class.getMethod("emptyMap"));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "mapPut",
+                        JstlFunctions.class.getMethod(
+                                "mapPut", Object.class, Object.class, Object.class));
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction("fn", "mapOf", JstlFunctions.class.getMethod("mapOf", Object[].class));
+
+        this.expressionContext
+                .getFunctionMapper()
+                .mapFunction(
+                        "fn",
+                        "mapRemove",
+                        JstlFunctions.class.getMethod("mapRemove", Object.class, Object.class));
+
         this.expressionContext
                 .getFunctionMapper()
                 .mapFunction("fn", "toInt", JstlFunctions.class.getMethod("toInt", Object.class));

--- a/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlFunctions.java
+++ b/langstream-agents/langstream-agents-commons/src/main/java/ai/langstream/ai/agents/commons/jstl/JstlFunctions.java
@@ -26,6 +26,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -164,6 +165,52 @@ public class JstlFunctions {
         return Map.of();
     }
 
+    public static Map<String, Object> mapOf(Object... field) {
+        Map<String, Object> result = new HashMap<>();
+        for (int i = 0; i < field.length; i += 2) {
+            result.put(field[i].toString(), field[i + 1]);
+        }
+        return result;
+    }
+
+    public static List<Object> listOf(Object... field) {
+        List<Object> result = new ArrayList<>();
+        result.addAll(Arrays.asList(field));
+        return result;
+    }
+
+    public static Map<String, Object> mapPut(Object map, Object field, Object value) {
+        Map<String, Object> result = new HashMap<>();
+        if (map != null) {
+            if (map instanceof Map m) {
+                result.putAll(m);
+            } else {
+                throw new IllegalArgumentException("mapPut doesn't allow a non-map value");
+            }
+        }
+        if (field == null || field.toString().isEmpty()) {
+            throw new IllegalArgumentException("mapPut doesn't allow a null field");
+        }
+        result.put(field.toString(), value);
+        return result;
+    }
+
+    public static Map<String, Object> mapRemove(Object map, Object field) {
+        Map<String, Object> result = new HashMap<>();
+        if (map != null) {
+            if (map instanceof Map m) {
+                result.putAll(m);
+            } else {
+                throw new IllegalArgumentException("mapPut doesn't allow a non-map value");
+            }
+        }
+        if (field == null || field.toString().isEmpty()) {
+            throw new IllegalArgumentException("mapPut doesn't allow a null field");
+        }
+        result.remove(field.toString());
+        return result;
+    }
+
     public static List<Object> mapToListOfStructs(Object object, String fields) {
         if (object == null) {
             throw new IllegalArgumentException("listOf doesn't allow a null value");
@@ -282,12 +329,18 @@ public class JstlFunctions {
         return input == null ? null : toString(input).trim();
     }
 
-    public static String concat(Object first, Object second) {
-        return toString(first) + toString(second);
+    public static String concat(Object... elements) {
+        StringBuilder sb = new StringBuilder();
+        for (Object o : elements) {
+            if (o != null) {
+                sb.append(toString(o));
+            }
+        }
+        return sb.toString();
     }
 
     public static String concat3(Object first, Object second, Object third) {
-        return toString(first) + toString(second) + toString(third);
+        return concat(first, second, third);
     }
 
     public static Object coalesce(Object value, Object valueIfNull) {

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/ComputeStep.java
@@ -319,6 +319,9 @@ public class ComputeStep implements TransformStep {
             case BYTES:
                 schemaType = Schema.Type.BYTES;
                 break;
+            case MAP:
+                schemaType = Schema.Type.MAP;
+                break;
             case ARRAY:
                 schemaType = Schema.Type.ARRAY;
                 break;
@@ -341,6 +344,10 @@ public class ComputeStep implements TransformStep {
                         // we don't know the element type of the array, so we can't create a schema
                         return Schema.createArray(
                                 Schema.createMap(Schema.create(Schema.Type.STRING)));
+                    }
+                    if (schemaType == Schema.Type.MAP) {
+                        // we don't know the element type of the array, so we can't create a schema
+                        return Schema.createMap(Schema.create(Schema.Type.STRING));
                     }
 
                     // Handle logical types:
@@ -516,6 +523,9 @@ public class ComputeStep implements TransformStep {
         }
         if (List.class.isAssignableFrom(value.getClass())) {
             return ComputeFieldType.ARRAY;
+        }
+        if (Map.class.isAssignableFrom(value.getClass())) {
+            return ComputeFieldType.MAP;
         }
         throw new UnsupportedOperationException("Got an unsupported type: " + value.getClass());
     }

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/ComputeFieldType.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/model/ComputeFieldType.java
@@ -39,5 +39,6 @@ public enum ComputeFieldType {
     DATETIME,
     BYTES,
     DECIMAL,
-    ARRAY
+    ARRAY,
+    MAP
 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraVectorAssetQueryWriteIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/CassandraVectorAssetQueryWriteIT.java
@@ -296,7 +296,7 @@ class CassandraVectorAssetQueryWriteIT extends AbstractKafkaApplicationRunner {
                                          - name: "value.metadata_s"
                                            expression: "fn:mapOf('filename', properties.filename, 'chunk_id', properties.chunk_id)"
                                          - name: "value.row_id"
-                                           expression: "fn:concat(properties.filename, '-', properties.chunk_id)"
+                                           expression: "fn:uuid()"
                                          - name: "value.vector"
                                            expression: "fn:listOf(0,1,2,3,4)"
                                          - name: "value.attributes_blob"


### PR DESCRIPTION
Summary:
- add mapOf(...), listOf(...), concat(....),mapAll(), mapRemove() EL functions
- add integration test about how to deal with map<string, string> objects in Cassandra, that is used by Cass.io

```yaml

pipeline:
    - id: step1
      type: compute
      name: "Compute metadata"
      input: "input-topic-cassio"
      configuration:
        fields:
           - name: "value.metadata_s"
             expression: "fn:mapOf('filename', value.filename, 'chunk_id', value.chunk_id)"
    - name: "Write a new record to Cassandra"
      type: "vector-db-sink"
      configuration:
        datasource: "CassandraDatasource"
        table-name: "documents"
        keyspace: "cassio"
        mapping: "row_id=value.row_id,attributes_blob=value.attributes_blob,body_blob=value.body_blob,metadata_s=value.metadata_s,vector=value.vector"
  
```