### PR TITLE
[python agents] Allow to access resources configured in configuration.yaml

### DIFF
--- a/examples/applications/langchain-chat/configuration.yaml
+++ b/examples/applications/langchain-chat/configuration.yaml
@@ -18,17 +18,20 @@
 configuration:
   resources:
     - type: "open-ai-configuration"
+      id: "openai"
       name: "OpenAI Azure configuration"
       configuration:
         url: "${secrets.open-ai.url}"
         access-key: "${secrets.open-ai.access-key}"
         provider: "${secrets.open-ai.provider}"
     - type: "datasource"
+      id: "database"
       name: "AstraDatasource"
       configuration:
         service: "astra"
         clientId: "${secrets.astra-langchain.clientId}"
         secret: "${secrets.astra-langchain.secret}"
         database: "${secrets.astra-langchain.database}"
+        database-id: "${secrets.astra-langchain.database-id}"
         token: "${secrets.astra-langchain.token}"
         environment: "PROD"

--- a/examples/applications/langchain-chat/crawler.yaml
+++ b/examples/applications/langchain-chat/crawler.yaml
@@ -99,7 +99,7 @@ pipeline:
     resources:
       size: 2
     configuration:
-      datasource: "AstraDatasource"
+      datasource: "database"
       table-name: "documents"
       keyspace: "documents"
       mapping: "row_id=value.row_id, body_blob=value.text, vector=value.embeddings_vector"

--- a/examples/applications/langchain-chat/pipeline.yaml
+++ b/examples/applications/langchain-chat/pipeline.yaml
@@ -30,9 +30,6 @@ pipeline:
       on-failure: "skip"
     configuration:
       className: "langchain_chat.LangChainChat"
-      openai-key: "${ secrets.open-ai.access-key }"
-      astra-db-token: "${ secrets.astra-langchain.token }"
-      astra-db-id: "${ secrets.astra-langchain.database-id }"
       astra-db-keyspace: "${ secrets.astra-langchain.keyspace }"
       astra-db-table: "${ secrets.astra-langchain.table }"
       environment:

--- a/examples/applications/langchain-chat/python/langchain_chat.py
+++ b/examples/applications/langchain-chat/python/langchain_chat.py
@@ -201,12 +201,13 @@ def create_chain(
 class LangChainChat(Processor):
 
     def init(self, config):
-        self.openai_key = config.get("openai-key", "")
-        self.astra_db_token = config.get("astra-db-token", "")
-        self.astra_db_id = config.get("astra-db-id", "")
-        self.astra_keyspace = config.get("astra-db-keyspace", "")
-        self.astra_table_name = config.get("astra-db-table", "")
 
+        # the values are configured in the resources section in configuration.yaml
+        self.openai_key = config.resources.openai.get("access-key", "");
+        self.astra_db_token = config.resources.database.get("token", "")
+        self.astra_db_id = config.resources.database.get("database-id", "")
+        self.astra_keyspace = config.resources.database.get("keyspace", "")
+        self.astra_table_name = config.resources.database.get("table", "")
 
         cassio.init(token=self.astra_db_token, database_id=self.astra_db_id)
 

--- a/examples/applications/langchain-chat/python/langchain_chat.py
+++ b/examples/applications/langchain-chat/python/langchain_chat.py
@@ -210,13 +210,14 @@ class LangChainChat(Processor):
         self.astra_keyspace = config["astra-db-keyspace"]
         self.astra_table_name = config["astra-db-table"]
 
-        cassio.init(token=self.astra_db_token, database_id=self.astra_db_id, keyspace=self.astra_keyspace)
+        cassio.init(token=self.astra_db_token, database_id=self.astra_db_id)
 
         self.embedings_model = OpenAIEmbeddings(openai_api_key=self.openai_key)
 
         self.astra_vector_store = Cassandra(
             embedding=self.embedings_model,
             session=None,
+            keyspace=self.astra_keyspace,
             table_name=self.astra_table_name,
         )
 

--- a/examples/applications/langchain-chat/python/langchain_chat.py
+++ b/examples/applications/langchain-chat/python/langchain_chat.py
@@ -36,6 +36,7 @@ from langchain.schema.runnable import (
 )
 from pydantic import BaseModel
 import cassio
+import logging
 
 RESPONSE_TEMPLATE = """\
 You are an expert programmer and problem-solver, tasked with answering any question \
@@ -201,22 +202,21 @@ def create_chain(
 class LangChainChat(Processor):
 
     def init(self, config):
-
+        logging.info("Initializing LangChain Chat with config %s", config)
         # the values are configured in the resources section in configuration.yaml
-        self.openai_key = config.resources.openai.get("access-key", "");
-        self.astra_db_token = config.resources.database.get("token", "")
-        self.astra_db_id = config.resources.database.get("database-id", "")
-        self.astra_keyspace = config.resources.database.get("keyspace", "")
-        self.astra_table_name = config.resources.database.get("table", "")
+        self.openai_key = config["resources"]["openai"]["access-key"]
+        self.astra_db_token = config["resources"]["database"]["token"]
+        self.astra_db_id = config["resources"]["database"]["database-id"]
+        self.astra_keyspace = config["astra-db-keyspace"]
+        self.astra_table_name = config["astra-db-table"]
 
-        cassio.init(token=self.astra_db_token, database_id=self.astra_db_id)
+        cassio.init(token=self.astra_db_token, database_id=self.astra_db_id, keyspace=self.astra_keyspace)
 
         self.embedings_model = OpenAIEmbeddings(openai_api_key=self.openai_key)
 
         self.astra_vector_store = Cassandra(
             embedding=self.embedings_model,
             session=None,
-            keyspace=self.astra_keyspace,
             table_name=self.astra_table_name,
         )
 

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/datasource/CassandraDataSource.java
@@ -276,19 +276,23 @@ public class CassandraDataSource implements QueryStepDataSource {
     }
 
     public static DatabaseClient buildAstraClient(
-            String astraToken, String astraDatabase, String astraDatabaseId, String astraEnvironment) {
+            String astraToken,
+            String astraDatabase,
+            String astraDatabaseId,
+            String astraEnvironment) {
         if (astraToken.isEmpty()) {
             throw new IllegalArgumentException("You must configure the AstraDB token");
         }
-        AstraDbClient astraDbClient = new AstraDbClient(astraToken, ApiLocator.AstraEnvironment.valueOf(astraEnvironment));
+        AstraDbClient astraDbClient =
+                new AstraDbClient(
+                        astraToken, ApiLocator.AstraEnvironment.valueOf(astraEnvironment));
         if (!astraDatabase.isEmpty()) {
-            return astraDbClient
-                    .databaseByName(astraDatabase);
+            return astraDbClient.databaseByName(astraDatabase);
         } else if (!astraDatabaseId.isEmpty()) {
-            return astraDbClient
-                    .database(astraDatabaseId);
+            return astraDbClient.database(astraDatabaseId);
         } else {
-            throw new IllegalArgumentException("You must configure the database name or the database id");
+            throw new IllegalArgumentException(
+                    "You must configure the database name or the database id");
         }
     }
 

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraWriter.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraWriter.java
@@ -106,23 +106,24 @@ public class CassandraWriter implements VectorDatabaseWriterProvider {
                                         configuration.put(
                                                 "cloud.secureConnectBundle", secureBundleString);
                                     } else {
-                                        // AstraDB, token/database
+                                        // AstraDB, token/database/databaseId
                                         String token =
                                                 ConfigurationUtils.getString(
                                                         "token", "", datasource);
                                         String database =
                                                 ConfigurationUtils.getString(
                                                         "database", "", datasource);
+                                        String databaseId =
+                                                ConfigurationUtils.getString(
+                                                        "database-id", "", datasource);
                                         String environment =
                                                 ConfigurationUtils.getString(
                                                         "environment", "PROD", datasource);
-                                        if (!token.isEmpty() && !database.isEmpty()) {
+                                        if (!token.isEmpty() && (!database.isEmpty() || !databaseId.isEmpty())) {
                                             DatabaseClient databaseClient =
                                                     CassandraDataSource.buildAstraClient(
-                                                            token, database, environment);
-                                            log.info(
-                                                    "Automatically downloading the secure bundle for database {} from AstraDB",
-                                                    database);
+                                                            token, database, databaseId, environment);
+                                            log.info("Automatically downloading the secure bundle from AstraDB");
                                             byte[] secureBundle =
                                                     CassandraDataSource.downloadSecureBundle(
                                                             databaseClient);

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraWriter.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/cassandra/CassandraWriter.java
@@ -119,11 +119,16 @@ public class CassandraWriter implements VectorDatabaseWriterProvider {
                                         String environment =
                                                 ConfigurationUtils.getString(
                                                         "environment", "PROD", datasource);
-                                        if (!token.isEmpty() && (!database.isEmpty() || !databaseId.isEmpty())) {
+                                        if (!token.isEmpty()
+                                                && (!database.isEmpty() || !databaseId.isEmpty())) {
                                             DatabaseClient databaseClient =
                                                     CassandraDataSource.buildAstraClient(
-                                                            token, database, databaseId, environment);
-                                            log.info("Automatically downloading the secure bundle from AstraDB");
+                                                            token,
+                                                            database,
+                                                            databaseId,
+                                                            environment);
+                                            log.info(
+                                                    "Automatically downloading the secure bundle from AstraDB");
                                             byte[] secureBundle =
                                                     CassandraDataSource.downloadSecureBundle(
                                                             databaseClient);

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/AstraDatasourceConfig.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/AstraDatasourceConfig.java
@@ -21,10 +21,9 @@ import ai.langstream.api.model.Resource;
 import ai.langstream.api.util.ConfigurationUtils;
 import ai.langstream.impl.resources.BaseDataSourceResourceProvider;
 import ai.langstream.impl.uti.ClassConfigValidator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Base64;
 import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data

--- a/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/AstraDatasourceConfig.java
+++ b/langstream-core/src/main/java/ai/langstream/impl/resources/datasource/AstraDatasourceConfig.java
@@ -23,6 +23,8 @@ import ai.langstream.impl.resources.BaseDataSourceResourceProvider;
 import ai.langstream.impl.uti.ClassConfigValidator;
 import java.util.Base64;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
@@ -92,6 +94,14 @@ public class AstraDatasourceConfig extends BaseDatasourceConfig {
                             Astra Database name to connect to. If secureBundle is provided, this field is ignored.
                             """)
     private String database;
+
+    @ConfigProperty(
+            description =
+                    """
+                            Astra Database ID name to connect to. If secureBundle is provided, this field is ignored.
+                            """)
+    @JsonProperty("database-id")
+    private String databaseId;
 
     @ConfigProperty(
             description =

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PythonCodeAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PythonCodeAgentProvider.java
@@ -75,6 +75,12 @@ public class PythonCodeAgentProvider extends AbstractComposableAgentProvider {
 
         copy.put("resources", resources);
 
+        Map<String, Object> globals = executionPlan.getApplication().getInstance().globals();
+        if (globals == null) {
+            globals = Map.of();
+        }
+        copy.put("globals", globals);
+
         return copy;
     }
 

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PythonCodeAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/PythonCodeAgentProvider.java
@@ -27,7 +27,6 @@ import ai.langstream.api.runtime.ExecutionPlan;
 import ai.langstream.api.runtime.PluginsRegistry;
 import ai.langstream.impl.agents.AbstractComposableAgentProvider;
 import ai.langstream.runtime.impl.k8s.KubernetesClusterRuntime;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,27 +49,40 @@ public class PythonCodeAgentProvider extends AbstractComposableAgentProvider {
     }
 
     @Override
-    protected Map<String, Object> computeAgentConfiguration(AgentConfiguration agentConfiguration,
-                                                            Module module,
-                                                            Pipeline pipeline,
-                                                            ExecutionPlan executionPlan,
-                                                            ComputeClusterRuntime clusterRuntime,
-                                                            PluginsRegistry pluginsRegistry) {
-        Map<String, Object>  copy =
-                super.computeAgentConfiguration(agentConfiguration, module, pipeline, executionPlan, clusterRuntime, pluginsRegistry);
-
+    protected Map<String, Object> computeAgentConfiguration(
+            AgentConfiguration agentConfiguration,
+            Module module,
+            Pipeline pipeline,
+            ExecutionPlan executionPlan,
+            ComputeClusterRuntime clusterRuntime,
+            PluginsRegistry pluginsRegistry) {
+        Map<String, Object> copy =
+                super.computeAgentConfiguration(
+                        agentConfiguration,
+                        module,
+                        pipeline,
+                        executionPlan,
+                        clusterRuntime,
+                        pluginsRegistry);
 
         Map<String, Object> resources = new HashMap<>();
 
         // with this trick Python agents can access the resources configuration
         Map<String, Resource> resourcesDef = executionPlan.getApplication().getResources();
         if (resourcesDef != null) {
-            resourcesDef.forEach((key, r) -> {
-                String id = r.id();
-                Map<String, Object> data = r.configuration();
-                log.info("Passing resource configuration to Python agent: {} -> {}", id, data.keySet());
-                resources.put(id, data);
-            });
+            resourcesDef.forEach(
+                    (key, r) -> {
+                        String id = r.id();
+                        if (id == null) {
+                            id = r.name();
+                        }
+                        Map<String, Object> data = r.configuration();
+                        log.info(
+                                "Passing resource configuration to Python agent: {} -> {}",
+                                id,
+                                data.keySet());
+                        resources.put(id, data);
+                    });
         }
 
         copy.put("resources", resources);


### PR DESCRIPTION
Summary:
- in python agents LangStream is now passing all the "Resources" to the configuration of the agent
- add support for using database-id in AstraDB datasources

With this change you can declare the access to DataSources/Vector Database and to AI service providers only once in your application, then in Python you can use the values.
This way there is no need to add boilerplate to map the access keys in the pipeline files.



In python now you can access resources and globals:

- config["resources"]
- config["globals"]