### PR TITLE
Metrics: add basic metrics about sources and sinks

### DIFF
--- a/docker/metrics/dashboards/apps.json
+++ b/docker/metrics/dashboards/apps.json
@@ -37,6 +37,233 @@
         "x": 0,
         "y": 0
       },
+      "id": 139,
+      "panels": [],
+      "repeat": "application",
+      "repeatDirection": "h",
+      "title": "Pipelines",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 140,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "source_out_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{exported_pod}}",
+          "metric": "jvm_memory_bytes_committed",
+          "range": true,
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "title": "Source outputs",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 141,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sink_in_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{exported_pod}}",
+          "metric": "jvm_memory_bytes_committed",
+          "range": true,
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "title": "Sinks inputs",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
       "id": 131,
       "panels": [],
       "repeat": "agent",
@@ -108,7 +335,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 1
+        "y": 8
       },
       "id": 132,
       "links": [],
@@ -227,7 +454,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 1
+        "y": 8
       },
       "id": 133,
       "links": [],
@@ -333,7 +560,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 1
+        "y": 8
       },
       "id": 134,
       "links": [],
@@ -452,7 +679,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 7
+        "y": 14
       },
       "id": 135,
       "links": [],
@@ -571,7 +798,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 7
+        "y": 14
       },
       "id": 137,
       "links": [],
@@ -690,7 +917,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 13
+        "y": 20
       },
       "id": 136,
       "links": [],
@@ -822,7 +1049,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 13
+        "y": 20
       },
       "id": 138,
       "links": [],
@@ -887,7 +1114,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 26
       },
       "id": 41,
       "panels": [],
@@ -960,7 +1187,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 20
+        "y": 27
       },
       "id": 4,
       "links": [],
@@ -1062,7 +1289,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 20
+        "y": 27
       },
       "id": 1,
       "links": [],
@@ -1238,7 +1465,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 20
+        "y": 27
       },
       "id": 3,
       "links": [],
@@ -1338,7 +1565,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 26
+        "y": 33
       },
       "id": 118,
       "links": [],
@@ -1437,7 +1664,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 26
+        "y": 33
       },
       "id": 129,
       "links": [],
@@ -1532,7 +1759,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 26
+        "y": 33
       },
       "id": 130,
       "links": [],
@@ -1573,7 +1800,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 39
       },
       "id": 109,
       "panels": [],
@@ -1628,8 +1855,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1644,7 +1870,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 33
+        "y": 40
       },
       "id": 87,
       "options": {
@@ -1748,8 +1974,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1764,7 +1989,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 33
+        "y": 40
       },
       "id": 106,
       "options": {
@@ -1844,8 +2069,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1861,7 +2085,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 33
+        "y": 40
       },
       "id": 107,
       "options": {

--- a/langstream-agents/langstream-agent-camel/src/test/java/ai/langstream/agents/camel/CamelSourceTest.java
+++ b/langstream-agents/langstream-agent-camel/src/test/java/ai/langstream/agents/camel/CamelSourceTest.java
@@ -16,9 +16,13 @@
 package ai.langstream.agents.camel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import ai.langstream.api.runner.code.AgentCodeRegistry;
+import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentSource;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import java.util.HashMap;
 import java.util.List;
@@ -56,7 +60,10 @@ public class CamelSourceTest {
         configs.put("component-uri", uri);
         configs.put("component-options", componentOptions);
         configs.put("max-buffered-records", 10);
+        AgentContext agentContext = mock(AgentContext.class);
+        when(agentContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
         agentSource.init(configs);
+        agentSource.setContext(agentContext);
         agentSource.start();
         return agentSource;
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/AbstractGrpcAgent.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/AbstractGrpcAgent.java
@@ -16,7 +16,6 @@
 package ai.langstream.agents.grpc;
 
 import ai.langstream.api.runner.code.AbstractAgentCode;
-import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.util.ConfigurationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -61,7 +60,6 @@ abstract class AbstractGrpcAgent extends AbstractAgentCode {
     // Schemas received from the server
     protected final Map<Integer, Object> serverSchemas = new ConcurrentHashMap<>();
 
-    protected AgentContext agentContext;
     protected AgentServiceGrpc.AgentServiceBlockingStub blockingStub;
 
     protected final AtomicBoolean restarting = new AtomicBoolean(false);
@@ -92,11 +90,6 @@ abstract class AbstractGrpcAgent extends AbstractAgentCode {
         }
         blockingStub =
                 AgentServiceGrpc.newBlockingStub(channel).withDeadlineAfter(30, TimeUnit.SECONDS);
-    }
-
-    @Override
-    public void setContext(AgentContext context) {
-        this.agentContext = context;
     }
 
     @Override

--- a/langstream-agents/langstream-agent-http-request/src/main/java/ai/langstream/agents/http/HttpRequestAgent.java
+++ b/langstream-agents/langstream-agent-http-request/src/main/java/ai/langstream/agents/http/HttpRequestAgent.java
@@ -18,7 +18,6 @@ package ai.langstream.agents.http;
 import ai.langstream.ai.agents.commons.JsonRecord;
 import ai.langstream.ai.agents.commons.MutableRecord;
 import ai.langstream.api.runner.code.AbstractAgentCode;
-import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.RecordSink;
@@ -55,7 +54,6 @@ public class HttpRequestAgent extends AbstractAgentCode implements AgentProcesso
 
     private final Map<Schema, Schema> avroKeySchemaCache = new ConcurrentHashMap<>();
 
-    private AgentContext agentContext;
     private ExecutorService executor;
     private HttpClient httpClient;
     private String url;
@@ -113,11 +111,6 @@ public class HttpRequestAgent extends AbstractAgentCode implements AgentProcesso
                         .cookieHandler(cookieManager)
                         .executor(executor)
                         .build();
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-        this.agentContext = context;
     }
 
     @Override

--- a/langstream-agents/langstream-agent-http-request/src/main/java/ai/langstream/agents/http/LangServeInvokeAgent.java
+++ b/langstream-agents/langstream-agent-http-request/src/main/java/ai/langstream/agents/http/LangServeInvokeAgent.java
@@ -19,7 +19,6 @@ import ai.langstream.ai.agents.commons.JsonRecord;
 import ai.langstream.ai.agents.commons.MutableRecord;
 import ai.langstream.ai.agents.commons.jstl.JstlEvaluator;
 import ai.langstream.api.runner.code.AbstractAgentCode;
-import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.RecordSink;
@@ -61,7 +60,6 @@ public class LangServeInvokeAgent extends AbstractAgentCode implements AgentProc
 
     private final Map<Schema, Schema> avroKeySchemaCache = new ConcurrentHashMap<>();
 
-    private AgentContext agentContext;
     private ExecutorService executor;
     private LangServeClient langServeClient;
     private String url;
@@ -131,11 +129,6 @@ public class LangServeInvokeAgent extends AbstractAgentCode implements AgentProc
                                 .executorService(executor)
                                 .cookieManager(cookieManager)
                                 .build());
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-        this.agentContext = context;
     }
 
     @Override

--- a/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
+++ b/langstream-agents/langstream-agent-s3/src/test/java/ai/langstream/agents/s3/S3SourceTest.java
@@ -19,10 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 import ai.langstream.api.runner.code.AgentCodeRegistry;
+import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentSource;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import io.minio.ListObjectsArgs;
 import io.minio.MinioClient;
@@ -175,6 +179,9 @@ public class S3SourceTest {
         configs.put("endpoint", endpoint);
         configs.put("bucketName", bucket);
         agentSource.init(configs);
+        AgentContext context = mock(AgentContext.class);
+        when(context.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
+        agentSource.setContext(context);
         agentSource.start();
         return agentSource;
     }

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -152,7 +152,8 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
     }
 
     @Override
-    public void setContext(AgentContext context) {
+    public void setContext(AgentContext context) throws Exception {
+        super.setContext(context);
         String globalAgentId = context.getGlobalAgentId();
         statusFileName = globalAgentId + ".webcrawler.status.json";
         log.info("Status file is {}", statusFileName);

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/DispatchAgent.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/DispatchAgent.java
@@ -18,7 +18,6 @@ package ai.langstream.agents.flow;
 import ai.langstream.ai.agents.commons.MutableRecord;
 import ai.langstream.ai.agents.commons.jstl.predicate.JstlPredicate;
 import ai.langstream.api.runner.code.AbstractAgentCode;
-import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.RecordSink;
@@ -38,7 +37,6 @@ public class DispatchAgent extends AbstractAgentCode implements AgentProcessor {
 
     private final List<Route> routes = new ArrayList<>();
     private final Map<String, TopicProducer> producers = new HashMap<>();
-    private AgentContext agentContext;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -75,11 +73,6 @@ public class DispatchAgent extends AbstractAgentCode implements AgentProcessor {
                     }
                     this.routes.add(new Route(destination, drop, new JstlPredicate(when)));
                 });
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-        this.agentContext = context;
     }
 
     @Override

--- a/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/TriggerEventProcessor.java
+++ b/langstream-agents/langstream-agents-flow-control/src/main/java/ai/langstream/agents/flow/TriggerEventProcessor.java
@@ -19,7 +19,6 @@ import ai.langstream.ai.agents.commons.MutableRecord;
 import ai.langstream.ai.agents.commons.jstl.JstlEvaluator;
 import ai.langstream.ai.agents.commons.jstl.predicate.JstlPredicate;
 import ai.langstream.api.runner.code.AbstractAgentCode;
-import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.RecordSink;
@@ -41,7 +40,6 @@ public class TriggerEventProcessor extends AbstractAgentCode implements AgentPro
     private TopicProducer topicProducer;
     private String destination;
     private JstlPredicate predicate;
-    private AgentContext agentContext;
 
     private boolean continueProcessing;
 
@@ -69,11 +67,6 @@ public class TriggerEventProcessor extends AbstractAgentCode implements AgentPro
     @Override
     public ComponentType componentType() {
         return ComponentType.PROCESSOR;
-    }
-
-    @Override
-    public void setContext(AgentContext context) throws Exception {
-        this.agentContext = context;
     }
 
     private Record emitRecord(Record originalRecord) {

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/GenAIToolKitAgent.java
@@ -57,7 +57,6 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
     private TransformStepConfig config;
     private QueryStepDataSource dataSource;
     private ServiceProvider serviceProvider;
-    private AgentContext agentContext;
     private Map<String, Object> configuration;
 
     private TopicProducerStreamingAnswersConsumerFactory streamingAnswersConsumerFactory;
@@ -65,11 +64,6 @@ public class GenAIToolKitAgent extends AbstractAgentCode implements AgentProcess
     @Override
     public ComponentType componentType() {
         return ComponentType.PROCESSOR;
-    }
-
-    @Override
-    public void setContext(AgentContext context) {
-        this.agentContext = context;
     }
 
     @Override

--- a/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/flare/FlareControllerAgent.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/ai/langstream/ai/agents/flare/FlareControllerAgent.java
@@ -88,6 +88,7 @@ public class FlareControllerAgent extends AbstractAgentCode implements AgentProc
 
     @Override
     public void setContext(AgentContext context) throws Exception {
+        super.setContext(context);
         this.loopTopicProducer =
                 context.getTopicConnectionProvider()
                         .createProducer(context.getGlobalAgentId(), loopTopic, Map.of());

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
@@ -51,6 +51,7 @@ public class VectorDBSinkAgent extends AbstractAgentCode implements AgentSink {
     public CompletableFuture<?> write(Record record) {
         // naive implementation, no batching
         Map<String, Object> context = Map.of();
-        return writer.upsert(record, context);
+        return writer.upsert(record, context)
+                .thenRun(() -> processed(1, 0));
     }
 }

--- a/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
+++ b/langstream-agents/langstream-vector-agents/src/main/java/ai/langstream/agents/vector/VectorDBSinkAgent.java
@@ -51,7 +51,6 @@ public class VectorDBSinkAgent extends AbstractAgentCode implements AgentSink {
     public CompletableFuture<?> write(Record record) {
         // naive implementation, no batching
         Map<String, Object> context = Map.of();
-        return writer.upsert(record, context)
-                .thenRun(() -> processed(1, 0));
+        return writer.upsert(record, context).thenRun(() -> processed(1, 0));
     }
 }

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/CassandraWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/CassandraWriterTest.java
@@ -81,6 +81,7 @@ public class CassandraWriterTest {
         AgentContext agentContext = mock(AgentContext.class);
         when(agentContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
         agent.init(configuration);
+        agent.setContext(agentContext);
         agent.start();
         List<Record> committed = new CopyOnWriteArrayList<>();
 
@@ -123,6 +124,7 @@ public class CassandraWriterTest {
         AgentContext agentContext = mock(AgentContext.class);
         when(agentContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
         agent.init(configuration);
+        agent.setContext(agentContext);
         agent.start();
         List<Record> committed = new CopyOnWriteArrayList<>();
 

--- a/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/CassandraWriterTest.java
+++ b/langstream-agents/langstream-vector-agents/src/test/java/ai/langstream/agents/vector/datasource/impl/CassandraWriterTest.java
@@ -16,9 +16,13 @@
 package ai.langstream.agents.vector.datasource.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import ai.langstream.agents.vector.VectorDBSinkAgent;
 import ai.langstream.api.runner.code.AgentCodeRegistry;
+import ai.langstream.api.runner.code.AgentContext;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -74,6 +78,8 @@ public class CassandraWriterTest {
         configuration.put("table", "vsearch.products");
         configuration.put("mapping", "id=value.id,description=value.description,name=value.name");
 
+        AgentContext agentContext = mock(AgentContext.class);
+        when(agentContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
         agent.init(configuration);
         agent.start();
         List<Record> committed = new CopyOnWriteArrayList<>();
@@ -114,6 +120,8 @@ public class CassandraWriterTest {
         configuration.put("table", "vsearch.products");
         configuration.put("mapping", "id=value.id,description=value.description,name=value.name");
 
+        AgentContext agentContext = mock(AgentContext.class);
+        when(agentContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
         agent.init(configuration);
         agent.start();
         List<Record> committed = new CopyOnWriteArrayList<>();

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/MetricsReporter.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/MetricsReporter.java
@@ -23,11 +23,15 @@ public interface MetricsReporter {
                 }
             };
 
-    default MetricsReporter withAgentName(String prefix) {
+    default MetricsReporter withAgentName(String agentName) {
         return this;
     }
 
     Counter counter(String name, String help);
+
+    default MetricsReporter withPodName(String podName) {
+        return this;
+    }
 
     interface Counter {
 

--- a/langstream-api/src/main/java/ai/langstream/api/runner/code/SimpleCounter.java
+++ b/langstream-api/src/main/java/ai/langstream/api/runner/code/SimpleCounter.java
@@ -15,26 +15,19 @@
  */
 package ai.langstream.api.runner.code;
 
-public interface MetricsReporter {
-    static MetricsReporter DISABLED =
-            new MetricsReporter() {
-                public Counter counter(String name, String help) {
-                    return Counter.NOOP;
-                }
-            };
+import java.util.concurrent.atomic.AtomicLong;
 
-    default MetricsReporter withAgentName(String prefix) {
-        return this;
+class SimpleCounter implements MetricsReporter.Counter {
+
+    private final AtomicLong value = new AtomicLong(0);
+
+    @Override
+    public void count(long value) {
+        this.value.addAndGet(value);
     }
 
-    Counter counter(String name, String help);
-
-    interface Counter {
-
-        Counter NOOP = new SimpleCounter();
-
-        void count(long value);
-
-        long value();
+    @Override
+    public long value() {
+        return this.value.get();
     }
 }

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/kafkaconnect/KafkaConnectSinkAgent.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/kafkaconnect/KafkaConnectSinkAgent.java
@@ -447,7 +447,7 @@ public class KafkaConnectSinkAgent extends AbstractAgentCode implements AgentSin
             log.warn("Agent already started {} / {}", this.getClass(), kafkaConnectorFQClassName);
             return;
         }
-        this.consumer = (Consumer<?, ?>) context.getTopicConsumer().getNativeConsumer();
+        this.consumer = (Consumer<?, ?>) agentContext.getTopicConsumer().getNativeConsumer();
         log.info("Getting consumer from context {}", consumer);
         Objects.requireNonNull(consumer);
         log.info(

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/kafkaconnect/KafkaConnectSinkAgent.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/kafkaconnect/KafkaConnectSinkAgent.java
@@ -16,7 +16,6 @@
 package ai.langstream.kafka.runner.kafkaconnect;
 
 import ai.langstream.api.runner.code.AbstractAgentCode;
-import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentSink;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.kafka.runner.KafkaRecord;
@@ -150,21 +149,12 @@ public class KafkaConnectSinkAgent extends AbstractAgentCode implements AgentSin
 
     private Consumer<?, ?> consumer;
 
-    private AgentContext context;
-
     private final AtomicReference<AvroData> lazyAvroData = new AtomicReference<>();
 
     private final ConcurrentLinkedDeque<ConsumerCommand> consumerCqrsQueue =
             new ConcurrentLinkedDeque<>();
 
     private int errorsToInject = 0;
-
-    // has to be the same consumer as used to read records to process,
-    // otherwise pause/resume won't work
-    @Override
-    public void setContext(AgentContext context) {
-        this.context = context;
-    }
 
     protected void submitCommand(ConsumerCommand cmd) {
         consumerCqrsQueue.add(cmd);
@@ -197,7 +187,8 @@ public class KafkaConnectSinkAgent extends AbstractAgentCode implements AgentSin
             op = (KafkaRecord.KafkaConsumerOffsetProvider) kr;
         } catch (Throwable t) {
             // can throw RuntimeException, let it bubble up
-            context.getBadRecordHandler()
+            agentContext
+                    .getBadRecordHandler()
                     .handle(
                             rec,
                             t,

--- a/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/kafkaconnect/KafkaConnectSourceAgent.java
+++ b/langstream-kafka-runtime/src/main/java/ai/langstream/kafka/runner/kafkaconnect/KafkaConnectSourceAgent.java
@@ -247,7 +247,8 @@ public class KafkaConnectSourceAgent extends AbstractAgentCode implements AgentS
         valueConverter.configure(configuration, false);
     }
 
-    public void setContext(AgentContext context) {
+    public void setContext(AgentContext context) throws Exception {
+        super.setContext(context);
         this.topicAdmin = (TopicAdmin) context.getTopicAdmin().getNativeTopicAdmin();
         this.agentId = context.getGlobalAgentId();
         this.topicConnectionProvider = context.getTopicConnectionProvider();

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/AgentRunnerStarter.java
@@ -24,8 +24,10 @@ import static ai.langstream.runtime.api.agent.AgentRunnerConstants.PERSISTENT_VO
 import static ai.langstream.runtime.api.agent.AgentRunnerConstants.POD_CONFIG_ENV;
 import static ai.langstream.runtime.api.agent.AgentRunnerConstants.POD_CONFIG_ENV_DEFAULT;
 
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.runtime.RuntimeStarter;
 import ai.langstream.runtime.agent.api.AgentAPIController;
+import ai.langstream.runtime.agent.metrics.PrometheusMetricsReporter;
 import ai.langstream.runtime.api.agent.RuntimePodConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -38,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AgentRunnerStarter extends RuntimeStarter {
     private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+    private static final MetricsReporter metricsReporter = new PrometheusMetricsReporter();
 
     private static final MainErrorHandler mainErrorHandler =
             error -> {
@@ -126,6 +129,7 @@ public class AgentRunnerStarter extends RuntimeStarter {
                 continueLoop::get,
                 null,
                 true,
-                null);
+                null,
+                metricsReporter);
     }
 }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/CompositeAgentProcessor.java
@@ -126,6 +126,7 @@ public class CompositeAgentProcessor extends AbstractAgentCode implements AgentP
 
     @Override
     public void setContext(AgentContext context) throws Exception {
+        super.setContext(context);
         for (AgentProcessor agent : processors) {
             agent.setContext(context);
         }

--- a/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/metrics/PrometheusMetricsReporter.java
+++ b/langstream-runtime/langstream-runtime-impl/src/main/java/ai/langstream/runtime/agent/metrics/PrometheusMetricsReporter.java
@@ -54,8 +54,13 @@ public class PrometheusMetricsReporter implements MetricsReporter {
         io.prometheus.client.Counter.Child counterWithLabel = counter.labels(agentName);
         return new Counter() {
             @Override
-            public void count(int value) {
+            public void count(long value) {
                 counterWithLabel.inc(value);
+            }
+
+            @Override
+            public long value() {
+                return (long) counterWithLabel.get();
             }
         };
     }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/AbstractApplicationRunner.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.langstream.api.model.Application;
 import ai.langstream.api.runner.assets.AssetManagerRegistry;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.topics.TopicConnectionsRuntimeRegistry;
 import ai.langstream.api.runtime.ClusterRuntimeRegistry;
 import ai.langstream.api.runtime.ExecutionPlan;
@@ -241,7 +242,8 @@ public abstract class AbstractApplicationRunner {
                                         },
                                         () -> validateAgentInfoBeforeStop(agentAPIController),
                                         false,
-                                        narFileHandler);
+                                        narFileHandler,
+                                        MetricsReporter.DISABLED);
                                 List<?> infos = agentAPIController.serveWorkerStatus();
                                 log.info(
                                         "{} AgentPod {} AgentInfo {}",

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/GenIAgentsRunnerIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/GenIAgentsRunnerIT.java
@@ -17,6 +17,7 @@ package ai.langstream.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.langstream.api.runner.code.AgentStatusResponse;
 import java.nio.charset.StandardCharsets;
@@ -150,8 +151,8 @@ class GenIAgentsRunnerIT extends AbstractKafkaApplicationRunner {
                     default:
                         throw new IllegalStateException("Unexpected value: " + p.getAgentId());
                 }
-                assertEquals(0L, p.getMetrics().getTotalIn());
-                assertEquals(0L, p.getMetrics().getTotalOut());
+                assertTrue(p.getMetrics().getTotalIn() > 0);
+                assertTrue(p.getMetrics().getTotalOut() > 0);
                 if (!mayHaveProcessed) {
                     assertEquals(0L, p.getMetrics().getLastProcessedAt());
                 }

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockProcessorAgentsCodeProvider.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/mockagents/MockProcessorAgentsCodeProvider.java
@@ -78,6 +78,7 @@ public class MockProcessorAgentsCodeProvider implements AgentCodeProvider {
 
         @Override
         public void setContext(AgentContext context) throws Exception {
+            super.setContext(context);
             this.statusFile =
                     context.getPersistentStateDirectoryForAgent(agentId())
                             .orElseThrow()

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/LoadAgentCodeTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/LoadAgentCodeTest.java
@@ -18,10 +18,14 @@ package ai.langstream.runtime;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import ai.langstream.api.runner.code.AgentCodeRegistry;
+import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentProcessor;
 import ai.langstream.api.runner.code.Header;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +39,7 @@ class LoadAgentCodeTest {
     public void testLoadNoop() throws Exception {
         AgentCodeRegistry registry = new AgentCodeRegistry();
         AgentProcessor noop = (AgentProcessor) registry.getAgentCode("noop").agentCode();
+        setContext(noop);
         MyRecord myRecord = new MyRecord();
         List<AgentProcessor.SourceRecordAndResult> res = new ArrayList<>();
         noop.process(List.of(myRecord), res::add);
@@ -46,6 +51,7 @@ class LoadAgentCodeTest {
     public void testLoadIdentity() throws Exception {
         AgentCodeRegistry registry = new AgentCodeRegistry();
         AgentProcessor noop = (AgentProcessor) registry.getAgentCode("identity").agentCode();
+        setContext(noop);
         MyRecord myRecord = new MyRecord();
         List<AgentProcessor.SourceRecordAndResult> res = new ArrayList<>();
         noop.process(List.of(myRecord), res::add);
@@ -56,6 +62,12 @@ class LoadAgentCodeTest {
         res.clear();
         noop.process(List.of(myRecord), res::add);
         assertSame(myRecord, res.get(0).sourceRecord());
+    }
+
+    private static void setContext(AgentProcessor noop) throws Exception {
+        AgentContext agentContext = mock(AgentContext.class);
+        noop.setContext(agentContext);
+        when(agentContext.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
     }
 
     private static class MyRecord implements Record {

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerStarterTest.java
@@ -101,6 +101,7 @@ class AgentRunnerStarterTest {
                         Mockito.any(Supplier.class),
                         Mockito.any(),
                         eq(true),
+                        Mockito.any(),
                         Mockito.any());
     }
 

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerTest.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/runtime/agent/AgentRunnerTest.java
@@ -18,11 +18,13 @@ package ai.langstream.runtime.agent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import ai.langstream.api.runner.code.AbstractAgentCode;
 import ai.langstream.api.runner.code.AgentContext;
 import ai.langstream.api.runner.code.AgentSink;
 import ai.langstream.api.runner.code.AgentSource;
+import ai.langstream.api.runner.code.MetricsReporter;
 import ai.langstream.api.runner.code.Record;
 import ai.langstream.api.runner.code.SimpleRecord;
 import ai.langstream.api.runner.code.SingleRecordAgentProcessor;
@@ -44,11 +46,18 @@ class AgentRunnerTest {
         SimpleAgentProcessor processor = new SimpleAgentProcessor(Set.of("fail-me"));
         StandardErrorsHandler errorHandler =
                 new StandardErrorsHandler(Map.of("retries", 0, "onFailure", "skip"));
-        AgentContext context = mock(AgentContext.class);
+        AgentContext context = createMockAgentContext();
+
         AgentRunner.runMainLoop(
                 source, processor, sink, context, errorHandler, source::hasMoreRecords);
         processor.expectExecutions(1);
         source.expectUncommitted(0);
+    }
+
+    private static AgentContext createMockAgentContext() {
+        AgentContext context = mock(AgentContext.class);
+        when(context.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
+        return context;
     }
 
     @Test
@@ -58,7 +67,8 @@ class AgentRunnerTest {
         SimpleAgentProcessor processor = new SimpleAgentProcessor(Set.of("fail-me"));
         StandardErrorsHandler errorHandler =
                 new StandardErrorsHandler(Map.of("retries", 3, "onFailure", "fail"));
-        AgentContext context = mock(AgentContext.class);
+        AgentContext context = createMockAgentContext();
+        when(context.getMetricsReporter()).thenReturn(MetricsReporter.DISABLED);
         assertThrows(
                 AgentRunner.PermanentFailureException.class,
                 () ->
@@ -80,7 +90,7 @@ class AgentRunnerTest {
         SimpleAgentProcessor processor = new SimpleAgentProcessor(Set.of("fail-me"));
         StandardErrorsHandler errorHandler =
                 new StandardErrorsHandler(Map.of("retries", 0, "onFailure", "fail"));
-        AgentContext context = mock(AgentContext.class);
+        AgentContext context = createMockAgentContext();
         assertThrows(
                 AgentRunner.PermanentFailureException.class,
                 () ->
@@ -106,7 +116,7 @@ class AgentRunnerTest {
         SimpleAgentProcessor processor = new SimpleAgentProcessor(Set.of("fail-me"));
         StandardErrorsHandler errorHandler =
                 new StandardErrorsHandler(Map.of("retries", 0, "onFailure", "skip"));
-        AgentContext context = mock(AgentContext.class);
+        AgentContext context = createMockAgentContext();
         AgentRunner.runMainLoop(
                 source, processor, sink, context, errorHandler, source::hasMoreRecords);
         processor.expectExecutions(2);
@@ -124,7 +134,7 @@ class AgentRunnerTest {
         SimpleAgentProcessor processor = new SimpleAgentProcessor(Set.of("fail-me"));
         StandardErrorsHandler errorHandler =
                 new StandardErrorsHandler(Map.of("retries", 0, "onFailure", "skip"));
-        AgentContext context = mock(AgentContext.class);
+        AgentContext context = createMockAgentContext();
         AgentRunner.runMainLoop(
                 source, processor, sink, context, errorHandler, source::hasMoreRecords);
         processor.expectExecutions(2);
@@ -143,7 +153,7 @@ class AgentRunnerTest {
         SimpleAgentProcessor processor = new SimpleAgentProcessor(Set.of("fail-me"));
         StandardErrorsHandler errorHandler =
                 new StandardErrorsHandler(Map.of("retries", 0, "onFailure", "skip"));
-        AgentContext context = mock(AgentContext.class);
+        AgentContext context = createMockAgentContext();
         AgentRunner.runMainLoop(
                 source, processor, sink, context, errorHandler, source::hasMoreRecords);
         processor.expectExecutions(2);
@@ -162,7 +172,7 @@ class AgentRunnerTest {
         SimpleAgentProcessor processor = new SimpleAgentProcessor(Set.of("fail-me"));
         StandardErrorsHandler errorHandler =
                 new StandardErrorsHandler(Map.of("retries", 0, "onFailure", "skip"));
-        AgentContext context = mock(AgentContext.class);
+        AgentContext context = createMockAgentContext();
         AgentRunner.runMainLoop(
                 source, processor, sink, context, errorHandler, source::hasMoreRecords);
         // all the records are processed in one batch


### PR DESCRIPTION
Summary:
- add metrics around the source and the sink in each "executor"
- refactor some code in order to reduce code duplication

The new metrics are:

- `source_out`: This is the number of records emitted by the source
- `sink_in`: This is the number of records sent to the sink