### PR TITLE
LangStream Home from Property, support Symlinks

### DIFF
--- a/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLI.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/LangStreamCLI.java
@@ -27,12 +27,22 @@ import picocli.CommandLine;
 
 public class LangStreamCLI {
 
+    /**
+     * @return ${LANGSTREAM_HOME} if set, otherwise ${user.home}/.langstream
+     */
     @SneakyThrows
     public static Path getLangstreamCLIHomeDirectory() {
+        final String langStreamHome = System.getProperty("LANGSTREAM_HOME");
+        if (langStreamHome != null && !langStreamHome.isBlank()) {
+            return Path.of(langStreamHome);
+        }
+
         final String userHome = System.getProperty("user.home");
         if (!userHome.isBlank() && !"?".equals(userHome)) {
             final Path langstreamDir = Path.of(userHome, ".langstream");
-            Files.createDirectories(langstreamDir);
+            if (!Files.exists(langstreamDir)) {
+                Files.createDirectories(langstreamDir);
+            }
             return langstreamDir;
         }
         return null;


### PR DESCRIPTION
Allow specifying the LangStream home directory, via the LANGSTREAM_HOME property (or environment variable).

If not specified, continue to use .langstream in the user's home directory, but allow that to be a symlink. Fixes #697