### PR TITLE
Apps: implement force deletion and improve status

### DIFF
--- a/helm/crds/applications.langstream.ai-v1.yml
+++ b/helm/crds/applications.langstream.ai-v1.yml
@@ -27,6 +27,8 @@ spec:
                 type: string
               imagePullPolicy:
                 type: string
+              options:
+                type: string
               tenant:
                 type: string
             required:

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/AdminClient.java
@@ -292,8 +292,8 @@ public class AdminClient implements AutoCloseable {
 
         @Override
         @SneakyThrows
-        public void delete(String application) {
-            http(newDelete(tenantAppPath("/" + application)));
+        public void delete(String application, boolean force) {
+            http(newDelete(tenantAppPath("/" + application + "?force=" + force)));
         }
 
         @Override

--- a/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
+++ b/langstream-admin-client/src/main/java/ai/langstream/admin/client/model/Applications.java
@@ -29,7 +29,7 @@ public interface Applications {
 
     void update(String application, MultiPartBodyPublisher multiPartBodyPublisher);
 
-    void delete(String application);
+    void delete(String application, boolean force);
 
     String get(String application, boolean stats);
 

--- a/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
+++ b/langstream-api/src/main/java/ai/langstream/api/storage/ApplicationStore.java
@@ -49,7 +49,7 @@ public interface ApplicationStore extends GenericStore {
 
     Secrets getSecrets(String tenant, String applicationId);
 
-    void delete(String tenant, String applicationId);
+    void delete(String tenant, String applicationId, boolean force);
 
     Map<String, StoredApplication> list(String tenant);
 

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
@@ -37,15 +37,9 @@ public class DeleteApplicationCmd extends BaseApplicationCmd {
     public void run() {
         getClient().applications().delete(applicationId, force);
         if (force) {
-            log(
-                    String.format(
-                            "Application deletion request accepted (forced) for application %s",
-                            applicationId));
+            log(String.format("Application '%s' marked for deletion (forced)", applicationId));
         } else {
-            log(
-                    String.format(
-                            "Application deletion request accepted for application %s",
-                            applicationId));
+            log(String.format("Application '%s' marked for deletion", applicationId));
         }
     }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
@@ -18,16 +18,26 @@ package ai.langstream.cli.commands.applications;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "delete", header = "Delete an application")
+@CommandLine.Command(name = "delete", header = "Delete an application. The deletion of the application it's asynchronous.")
 public class DeleteApplicationCmd extends BaseApplicationCmd {
 
     @CommandLine.Parameters(description = "ID of the application")
     private String applicationId;
 
+    @CommandLine.Option(
+            names = {"-f", "--force"},
+            description = "Force application deletion. This could cause orphaned assets and topics.")
+    private boolean force;
+
     @Override
     @SneakyThrows
     public void run() {
-        getClient().applications().delete(applicationId);
-        log(String.format("Application %s deleted", applicationId));
+        getClient().applications().delete(applicationId, force);
+        if (force) {
+            log(String.format("Application deletion request accepted (forced) for application %s", applicationId));
+        } else {
+            log(String.format("Application deletion request accepted for application %s", applicationId));
+        }
+
     }
 }

--- a/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
+++ b/langstream-cli/src/main/java/ai/langstream/cli/commands/applications/DeleteApplicationCmd.java
@@ -18,7 +18,9 @@ package ai.langstream.cli.commands.applications;
 import lombok.SneakyThrows;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "delete", header = "Delete an application. The deletion of the application it's asynchronous.")
+@CommandLine.Command(
+        name = "delete",
+        header = "Delete an application. The deletion of the application it's asynchronous.")
 public class DeleteApplicationCmd extends BaseApplicationCmd {
 
     @CommandLine.Parameters(description = "ID of the application")
@@ -26,7 +28,8 @@ public class DeleteApplicationCmd extends BaseApplicationCmd {
 
     @CommandLine.Option(
             names = {"-f", "--force"},
-            description = "Force application deletion. This could cause orphaned assets and topics.")
+            description =
+                    "Force application deletion. This could cause orphaned assets and topics.")
     private boolean force;
 
     @Override
@@ -34,10 +37,15 @@ public class DeleteApplicationCmd extends BaseApplicationCmd {
     public void run() {
         getClient().applications().delete(applicationId, force);
         if (force) {
-            log(String.format("Application deletion request accepted (forced) for application %s", applicationId));
+            log(
+                    String.format(
+                            "Application deletion request accepted (forced) for application %s",
+                            applicationId));
         } else {
-            log(String.format("Application deletion request accepted for application %s", applicationId));
+            log(
+                    String.format(
+                            "Application deletion request accepted for application %s",
+                            applicationId));
         }
-
     }
 }

--- a/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
+++ b/langstream-cli/src/test/java/ai/langstream/cli/commands/applications/AppsCmdTest.java
@@ -352,13 +352,25 @@ class AppsCmdTest extends CommandTestBase {
     @Test
     public void testDelete() {
         wireMock.register(
-                WireMock.delete(String.format("/api/applications/%s/my-app", TENANT))
+                WireMock.delete(String.format("/api/applications/%s/my-app?force=false", TENANT))
                         .willReturn(WireMock.ok()));
 
         CommandResult result = executeCommand("apps", "delete", "my-app");
         Assertions.assertEquals(0, result.exitCode());
         Assertions.assertEquals("", result.err());
-        Assertions.assertEquals("Application my-app deleted", result.out());
+        Assertions.assertEquals("Application 'my-app' marked for deletion", result.out());
+    }
+
+    @Test
+    public void testForceDelete() {
+        wireMock.register(
+                WireMock.delete(String.format("/api/applications/%s/my-app?force=true", TENANT))
+                        .willReturn(WireMock.ok()));
+
+        CommandResult result = executeCommand("apps", "delete", "my-app", "-f");
+        Assertions.assertEquals(0, result.exitCode());
+        Assertions.assertEquals("", result.err());
+        Assertions.assertEquals("Application 'my-app' marked for deletion (forced)", result.out());
     }
 
     @Test

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/AppLifecycleIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/AppLifecycleIT.java
@@ -19,10 +19,8 @@ import ai.langstream.tests.util.BaseEndToEndTest;
 import ai.langstream.tests.util.TestSuites;
 import java.io.File;
 import java.nio.file.Files;
-import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,21 +50,13 @@ public class AppLifecycleIT extends BaseEndToEndTest {
         YAML_MAPPER.writeValue(BaseEndToEndTest.instanceFile, instanceContent);
 
         deployLocalApplication(
-                tenant,
-                false,
-                applicationId,
-                "python-processor",
-                instanceFile,
-                Map.of());
+                tenant, false, applicationId, "python-processor", instanceFile, Map.of());
         awaitApplicationInStatus(applicationId, "ERROR_DEPLOYING");
-        executeCommandOnClient("bin/langstream apps delete %s "
-                        .formatted(applicationId)
-                        .split(" "));
+        executeCommandOnClient(
+                "bin/langstream apps delete %s ".formatted(applicationId).split(" "));
         awaitApplicationInStatus(applicationId, "ERROR_DELETING");
-        executeCommandOnClient("bin/langstream apps delete -f %s"
-                .formatted(applicationId)
-                .split(" "));
+        executeCommandOnClient(
+                "bin/langstream apps delete -f %s".formatted(applicationId).split(" "));
         awaitApplicationCleanup(tenant, applicationId);
     }
-
 }

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/AppLifecycleIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/AppLifecycleIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.langstream.tests;
+
+import ai.langstream.tests.util.BaseEndToEndTest;
+import ai.langstream.tests.util.TestSuites;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Slf4j
+@ExtendWith(BaseEndToEndTest.class)
+@Tag(TestSuites.CATEGORY_OTHER)
+public class AppLifecycleIT extends BaseEndToEndTest {
+
+    @Test
+    public void testDeleteBrokenApplication() throws Exception {
+        installLangStreamCluster(true);
+        final String tenant = "ten-" + System.currentTimeMillis();
+        setupTenant(tenant);
+        final String applicationId = "my-test-app";
+
+        final Map<String, Map<String, Object>> instanceContent =
+                Map.of(
+                        "instance",
+                        Map.of(
+                                "streamingCluster",
+                                Map.of("kafka", Map.of("bootstrapServers", "wrong:9092")),
+                                "computeCluster",
+                                Map.of("type", "kubernetes")));
+
+        final File instanceFile = Files.createTempFile("ls-test", ".yaml").toFile();
+        YAML_MAPPER.writeValue(BaseEndToEndTest.instanceFile, instanceContent);
+
+        deployLocalApplication(
+                tenant,
+                false,
+                applicationId,
+                "python-processor",
+                instanceFile,
+                Map.of());
+        awaitApplicationInStatus(applicationId, "ERROR_DEPLOYING");
+        executeCommandOnClient("bin/langstream apps delete %s "
+                        .formatted(applicationId)
+                        .split(" "));
+        awaitApplicationInStatus(applicationId, "ERROR_DELETING");
+        executeCommandOnClient("bin/langstream apps delete -f %s"
+                .formatted(applicationId)
+                .split(" "));
+        awaitApplicationCleanup(tenant, applicationId);
+    }
+
+}

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/AppLifecycleIT.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/AppLifecycleIT.java
@@ -42,12 +42,16 @@ public class AppLifecycleIT extends BaseEndToEndTest {
                         "instance",
                         Map.of(
                                 "streamingCluster",
-                                Map.of("kafka", Map.of("bootstrapServers", "wrong:9092")),
+                                Map.of(
+                                        "type",
+                                        "kafka",
+                                        "configuration",
+                                        Map.of("bootstrapServers", "wrong:9092")),
                                 "computeCluster",
                                 Map.of("type", "kubernetes")));
 
         final File instanceFile = Files.createTempFile("ls-test", ".yaml").toFile();
-        YAML_MAPPER.writeValue(BaseEndToEndTest.instanceFile, instanceContent);
+        YAML_MAPPER.writeValue(instanceFile, instanceContent);
 
         deployLocalApplication(
                 tenant, false, applicationId, "python-processor", instanceFile, Map.of());

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
@@ -893,7 +893,7 @@ public class BaseEndToEndTest implements TestWatcher {
                     final File outputFile =
                             new File(
                                     TEST_LOGS_DIR,
-                                    "%s.%s.%s.log".formatted(filePrefix, podName, container));
+                                    "%s.%s.%s.%s.log".formatted(filePrefix, namespace, podName, container));
                     try (FileWriter writer = new FileWriter(outputFile)) {
                         writer.write(logs);
                     } catch (IOException e) {

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
@@ -893,7 +893,8 @@ public class BaseEndToEndTest implements TestWatcher {
                     final File outputFile =
                             new File(
                                     TEST_LOGS_DIR,
-                                    "%s.%s.%s.%s.log".formatted(filePrefix, namespace, podName, container));
+                                    "%s.%s.%s.%s.log"
+                                            .formatted(filePrefix, namespace, podName, container));
                     try (FileWriter writer = new FileWriter(outputFile)) {
                         writer.write(logs);
                     } catch (IOException e) {

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
@@ -1092,9 +1092,10 @@ public class BaseEndToEndTest implements TestWatcher {
             return true;
         }
         log.info(
-                "application {} is not in expected status {}, dumping status",
+                "application {} is not in expected status {} but is in {}, dumping:",
                 applicationId,
-                expectedStatus);
+                expectedStatus,
+                status);
         executeCommandOnClient(
                 "bin/langstream apps get %s -o yaml".formatted(applicationId).split(" "));
         return false;

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
@@ -1070,6 +1070,39 @@ public class BaseEndToEndTest implements TestWatcher {
                 expectedRunningTotalExecutors + "/" + expectedRunningTotalExecutors);
     }
 
+    protected static void awaitApplicationInStatus(
+            String applicationId, String status) {
+        Awaitility.await()
+                .atMost(3, TimeUnit.MINUTES)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> isApplicationInStatus(applicationId, status));
+    }
+
+    protected static boolean isApplicationInStatus(
+            String applicationId, String expectedStatus) {
+        final String response =
+                executeCommandOnClient(
+                        "bin/langstream apps get %s".formatted(applicationId).split(" "));
+        final List<String> lines = response.lines().collect(Collectors.toList());
+        final String appLine = lines.get(1);
+        final List<String> lineAsList =
+                Arrays.stream(appLine.split(" "))
+                        .filter(s -> !s.isBlank())
+                        .collect(Collectors.toList());
+        final String status = lineAsList.get(3);
+        if (status != null && status.equals(expectedStatus)) {
+            return true;
+        }
+        log.info(
+                "application {} is not in expected status {}, dumping status",
+                applicationId,
+                expectedStatus);
+        executeCommandOnClient(
+                "bin/langstream apps get %s -o yaml".formatted(applicationId).split(" "));
+        return false;
+    }
+
+
     @SneakyThrows
     protected static void deployLocalApplicationAndAwaitReady(
             String tenant,
@@ -1100,59 +1133,8 @@ public class BaseEndToEndTest implements TestWatcher {
             String appDirName,
             Map<String, String> env,
             int expectedNumExecutors) {
-        String testAppsBaseDir = "src/test/resources/apps";
-        String testSecretBaseDir = "src/test/resources/secrets";
-
-        final File appDir = Paths.get(testAppsBaseDir, appDirName).toFile();
-        final File secretFile = Paths.get(testSecretBaseDir, "secret1.yaml").toFile();
-        validateApp(appDir, secretFile);
-        copyFileToClientContainer(appDir, "/tmp/app");
-        copyFileToClientContainer(instanceFile, "/tmp/instance.yaml");
-
-        copyFileToClientContainer(secretFile, "/tmp/secrets.yaml");
-
-        String beforeCmd = "";
-        if (env != null && !env.isEmpty()) {
-            beforeCmd =
-                    env.entrySet().stream()
-                            .map(
-                                    e -> {
-                                        final String safeValue =
-                                                e.getValue() == null ? "" : e.getValue();
-                                        return "export '%s'='%s'"
-                                                .formatted(
-                                                        e.getKey(), safeValue.replace("'", "''"));
-                                    })
-                            .collect(Collectors.joining(" && "));
-            beforeCmd += " && ";
-        }
         final String tenantNamespace = TENANT_NAMESPACE_PREFIX + tenant;
-
-        final String podUids;
-        if (isUpdate) {
-            podUids =
-                    client
-                            .pods()
-                            .inNamespace(tenantNamespace)
-                            .withLabels(
-                                    Map.of(
-                                            "langstream-application",
-                                            applicationId,
-                                            "app",
-                                            "langstream-runtime"))
-                            .list()
-                            .getItems()
-                            .stream()
-                            .map(p -> p.getMetadata().getUid())
-                            .sorted()
-                            .collect(Collectors.joining(","));
-        } else {
-            podUids = "";
-        }
-        final String command =
-                "bin/langstream apps %s %s -app /tmp/app -i /tmp/instance.yaml -s /tmp/secrets.yaml"
-                        .formatted(isUpdate ? "update" : "deploy", applicationId);
-        executeCommandOnClient((beforeCmd + command).split(" "));
+        final String podUids = deployLocalApplication(tenant, isUpdate, applicationId, appDirName, instanceFile, env);
 
         awaitApplicationReady(applicationId, expectedNumExecutors);
         Awaitility.await()
@@ -1190,6 +1172,65 @@ public class BaseEndToEndTest implements TestWatcher {
                                 assertTrue(checkPodReadiness(pod));
                             }
                         });
+    }
+
+    @SneakyThrows
+    protected static String deployLocalApplication(String tenant, boolean isUpdate, String applicationId, String appDirName, File instanceFile, Map<String, String> env)  {
+        final String tenantNamespace = TENANT_NAMESPACE_PREFIX + tenant;
+        String testAppsBaseDir = "src/test/resources/apps";
+        String testSecretBaseDir = "src/test/resources/secrets";
+
+        final File appDir = Paths.get(testAppsBaseDir, appDirName).toFile();
+        final File secretFile = Paths.get(testSecretBaseDir, "secret1.yaml").toFile();
+        validateApp(appDir, secretFile);
+        copyFileToClientContainer(appDir, "/tmp/app");
+        copyFileToClientContainer(instanceFile, "/tmp/instance.yaml");
+
+        copyFileToClientContainer(secretFile, "/tmp/secrets.yaml");
+
+        String beforeCmd = "";
+        if (env != null && !env.isEmpty()) {
+            beforeCmd =
+                    env.entrySet().stream()
+                            .map(
+                                    e -> {
+                                        final String safeValue =
+                                                e.getValue() == null ? "" : e.getValue();
+                                        return "export '%s'='%s'"
+                                                .formatted(
+                                                        e.getKey(), safeValue.replace("'", "''"));
+                                    })
+                            .collect(Collectors.joining(" && "));
+            beforeCmd += " && ";
+        }
+
+
+        final String podUids;
+        if (isUpdate) {
+            podUids =
+                    client
+                            .pods()
+                            .inNamespace(tenantNamespace)
+                            .withLabels(
+                                    Map.of(
+                                            "langstream-application",
+                                            applicationId,
+                                            "app",
+                                            "langstream-runtime"))
+                            .list()
+                            .getItems()
+                            .stream()
+                            .map(p -> p.getMetadata().getUid())
+                            .sorted()
+                            .collect(Collectors.joining(","));
+        } else {
+            podUids = "";
+        }
+        final String command =
+                "bin/langstream apps %s %s -app /tmp/app -i /tmp/instance.yaml -s /tmp/secrets.yaml"
+                        .formatted(isUpdate ? "update" : "deploy", applicationId);
+        executeCommandOnClient((beforeCmd + command).split(" "));
+        return podUids;
     }
 
     private static void validateApp(File appDir, File secretFile) throws Exception {
@@ -1265,10 +1306,10 @@ public class BaseEndToEndTest implements TestWatcher {
     protected void deleteAppAndAwaitCleanup(String tenant, String applicationId) {
         executeCommandOnClient("bin/langstream apps delete %s".formatted(applicationId).split(" "));
 
-        awaitCleanup(tenant, applicationId);
+        awaitApplicationCleanup(tenant, applicationId);
     }
 
-    private static void awaitCleanup(String tenant, String applicationId) {
+    protected static void awaitApplicationCleanup(String tenant, String applicationId) {
         final String tenantNamespace = TENANT_NAMESPACE_PREFIX + tenant;
         Awaitility.await()
                 .atMost(2, TimeUnit.MINUTES)

--- a/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
+++ b/langstream-e2e-tests/src/test/java/ai/langstream/tests/util/BaseEndToEndTest.java
@@ -1070,16 +1070,14 @@ public class BaseEndToEndTest implements TestWatcher {
                 expectedRunningTotalExecutors + "/" + expectedRunningTotalExecutors);
     }
 
-    protected static void awaitApplicationInStatus(
-            String applicationId, String status) {
+    protected static void awaitApplicationInStatus(String applicationId, String status) {
         Awaitility.await()
                 .atMost(3, TimeUnit.MINUTES)
                 .pollInterval(5, TimeUnit.SECONDS)
                 .until(() -> isApplicationInStatus(applicationId, status));
     }
 
-    protected static boolean isApplicationInStatus(
-            String applicationId, String expectedStatus) {
+    protected static boolean isApplicationInStatus(String applicationId, String expectedStatus) {
         final String response =
                 executeCommandOnClient(
                         "bin/langstream apps get %s".formatted(applicationId).split(" "));
@@ -1101,7 +1099,6 @@ public class BaseEndToEndTest implements TestWatcher {
                 "bin/langstream apps get %s -o yaml".formatted(applicationId).split(" "));
         return false;
     }
-
 
     @SneakyThrows
     protected static void deployLocalApplicationAndAwaitReady(
@@ -1134,7 +1131,9 @@ public class BaseEndToEndTest implements TestWatcher {
             Map<String, String> env,
             int expectedNumExecutors) {
         final String tenantNamespace = TENANT_NAMESPACE_PREFIX + tenant;
-        final String podUids = deployLocalApplication(tenant, isUpdate, applicationId, appDirName, instanceFile, env);
+        final String podUids =
+                deployLocalApplication(
+                        tenant, isUpdate, applicationId, appDirName, instanceFile, env);
 
         awaitApplicationReady(applicationId, expectedNumExecutors);
         Awaitility.await()
@@ -1175,7 +1174,13 @@ public class BaseEndToEndTest implements TestWatcher {
     }
 
     @SneakyThrows
-    protected static String deployLocalApplication(String tenant, boolean isUpdate, String applicationId, String appDirName, File instanceFile, Map<String, String> env)  {
+    protected static String deployLocalApplication(
+            String tenant,
+            boolean isUpdate,
+            String applicationId,
+            String appDirName,
+            File instanceFile,
+            Map<String, String> env) {
         final String tenantNamespace = TENANT_NAMESPACE_PREFIX + tenant;
         String testAppsBaseDir = "src/test/resources/apps";
         String testSecretBaseDir = "src/test/resources/secrets";
@@ -1203,7 +1208,6 @@ public class BaseEndToEndTest implements TestWatcher {
                             .collect(Collectors.joining(" && "));
             beforeCmd += " && ";
         }
-
 
         final String podUids;
         if (isUpdate) {

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpec.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpec.java
@@ -18,7 +18,6 @@ package ai.langstream.deployer.k8s.api.crds.apps;
 import ai.langstream.deployer.k8s.api.crds.NamespacedSpec;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpec.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpec.java
@@ -42,6 +42,19 @@ public class ApplicationSpec extends NamespacedSpec {
         return mapper.readValue(serializedApplicationInstance, SerializedApplicationInstance.class);
     }
 
+    @SneakyThrows
+    public static ApplicationSpecOptions deserializeOptions(String options) {
+        if (options == null) {
+            return new ApplicationSpecOptions();
+        }
+        return mapper.readValue(options, ApplicationSpecOptions.class);
+    }
+
+    @SneakyThrows
+    public static String serializeOptions(ApplicationSpecOptions options) {
+        return mapper.writeValueAsString(options);
+    }
+
     @Deprecated private String image;
     @Deprecated private String imagePullPolicy;
 
@@ -52,18 +65,5 @@ public class ApplicationSpec extends NamespacedSpec {
     private String application;
 
     private String codeArchiveId;
-
-    @Builder
-    public ApplicationSpec(
-            String tenant,
-            String image,
-            String imagePullPolicy,
-            String application,
-            String codeArchiveId) {
-        super(tenant);
-        this.image = image;
-        this.imagePullPolicy = imagePullPolicy;
-        this.application = application;
-        this.codeArchiveId = codeArchiveId;
-    }
+    private String options;
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpecOptions.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpecOptions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ai.langstream.deployer.k8s.api.crds.apps;
 
 import lombok.Data;
@@ -12,8 +27,6 @@ public class ApplicationSpecOptions {
         CLEANUP_BEST_EFFORT;
     }
 
-
     private DeleteMode deleteMode = DeleteMode.CLEANUP_REQUIRED;
     private boolean markedForDeletion;
-
 }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpecOptions.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-api/src/main/java/ai/langstream/deployer/k8s/api/crds/apps/ApplicationSpecOptions.java
@@ -1,0 +1,19 @@
+package ai.langstream.deployer.k8s.api.crds.apps;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ApplicationSpecOptions {
+
+    public enum DeleteMode {
+        CLEANUP_REQUIRED,
+        CLEANUP_BEST_EFFORT;
+    }
+
+
+    private DeleteMode deleteMode = DeleteMode.CLEANUP_REQUIRED;
+    private boolean markedForDeletion;
+
+}

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
@@ -77,10 +77,12 @@ public class KubeUtil {
             return null;
         }
         final String uid = job.getMetadata().getUid();
-        final List<Pod> pods = client.pods().inNamespace(job.getMetadata().getNamespace())
-                .withLabel("controller-uid", uid)
-                .list()
-                .getItems();
+        final List<Pod> pods =
+                client.pods()
+                        .inNamespace(job.getMetadata().getNamespace())
+                        .withLabel("controller-uid", uid)
+                        .list()
+                        .getItems();
         if (pods.isEmpty()) {
             return null;
         }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-core/src/main/java/ai/langstream/deployer/k8s/util/KubeUtil.java
@@ -64,6 +64,29 @@ public class KubeUtil {
         return succeeded != null && succeeded > 0;
     }
 
+    public static boolean isJobFailed(Job job) {
+        if (job == null) {
+            return false;
+        }
+        final Integer failed = job.getStatus().getFailed();
+        return failed != null && failed > 0;
+    }
+
+    public static Pod getJobPod(Job job, KubernetesClient client) {
+        if (job == null) {
+            return null;
+        }
+        final String uid = job.getMetadata().getUid();
+        final List<Pod> pods = client.pods().inNamespace(job.getMetadata().getNamespace())
+                .withLabel("controller-uid", uid)
+                .list()
+                .getItems();
+        if (pods.isEmpty()) {
+            return null;
+        }
+        return pods.get(0);
+    }
+
     public static boolean isStatefulSetReady(StatefulSet sts) {
         if (sts == null || sts.getStatus() == null) {
             return false;

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/main/java/ai/langstream/deployer/k8s/controllers/apps/AppController.java
@@ -17,6 +17,8 @@ package ai.langstream.deployer.k8s.controllers.apps;
 
 import ai.langstream.api.model.ApplicationLifecycleStatus;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationSpec;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationSpecOptions;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationStatus;
 import ai.langstream.deployer.k8s.apps.AppResourcesFactory;
 import ai.langstream.deployer.k8s.controllers.BaseController;
@@ -28,7 +30,9 @@ import ai.langstream.deployer.k8s.util.SpecDiffer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.openshift.api.model.config.v1.Update;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
@@ -37,6 +41,7 @@ import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusHandler;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import java.time.Duration;
+import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
@@ -85,27 +90,42 @@ public class AppController extends BaseController<ApplicationCustomResource>
         String runtimeDeployer;
     }
 
+    public record HandleJobResult(boolean proceed, Duration reschedule) {}
+    public class ApplicationDeletedException extends Exception {}
+
     @Override
     protected PatchResult patchResources(
             ApplicationCustomResource resource, Context<ApplicationCustomResource> context) {
+        final ApplicationSpecOptions applicationSpecOptions =
+                ApplicationSpec.deserializeOptions(resource.getSpec().getOptions());
         AppLastApplied appLastApplied = getAppLastApplied(resource);
-        Duration rescheduleDuration = handleJob(resource, appLastApplied, true, false);
-        if (rescheduleDuration == null) {
-            log.infof(
-                    "setup job for %s is completed, checking deployer",
-                    resource.getMetadata().getName());
-            rescheduleDuration = handleJob(resource, appLastApplied, false, false);
-            log.infof(
-                    "setup job for %s is %s",
-                    resource.getMetadata().getName(),
-                    rescheduleDuration != null ? "not completed" : "completed");
-            appLastApplied.setRuntimeDeployer(SerializationUtil.writeAsJson(resource.getSpec()));
-        } else {
-            if (appLastApplied == null) {
-                appLastApplied = new AppLastApplied();
+        Duration rescheduleDuration;
+        if (applicationSpecOptions.isMarkedForDeletion()) {
+            try {
+                rescheduleDuration = cleanupApplication(resource, appLastApplied);
+            } catch (ApplicationDeletedException exception) {
+                return PatchResult.patch(UpdateControl.noUpdate());
             }
-            appLastApplied.setSetup(SerializationUtil.writeAsJson(resource.getSpec()));
-            log.infof("setup job for %s is not completed yet", resource.getMetadata().getName());
+        } else {
+            final HandleJobResult setupJobResult = handleJob(resource, appLastApplied, true, false);
+            if (setupJobResult.proceed()) {
+                log.infof(
+                        "setup job for %s is completed, checking deployer",
+                        resource.getMetadata().getName());
+                final HandleJobResult deployerJobResult =
+                        handleJob(resource, appLastApplied, false, false);
+                log.infof(
+                        "setup job for %s is %s",
+                        resource.getMetadata().getName(),
+                        deployerJobResult.proceed() ? "completed" : "not completed");
+
+                rescheduleDuration = deployerJobResult.reschedule();
+            } else {
+
+                log.infof(
+                        "setup job for %s is not completed yet", resource.getMetadata().getName());
+                rescheduleDuration = setupJobResult.reschedule();
+            }
         }
         final UpdateControl<ApplicationCustomResource> updateControl =
                 rescheduleDuration != null
@@ -117,29 +137,55 @@ public class AppController extends BaseController<ApplicationCustomResource>
     @Override
     protected DeleteControl cleanupResources(
             ApplicationCustomResource resource, Context<ApplicationCustomResource> context) {
-        appResourcesLimiter.onAppBeingDeleted(resource);
-        final AppLastApplied appLastApplied = getAppLastApplied(resource);
-        Duration rescheduleDuration = handleJob(resource, appLastApplied, false, true);
+        AppLastApplied appLastApplied = getAppLastApplied(resource);
+        Duration rescheduleDuration;
+        try {
+            rescheduleDuration = cleanupApplication(resource, appLastApplied);
+        } catch (ApplicationDeletedException ex) {
+            rescheduleDuration = null;
+        }
+
         if (rescheduleDuration == null) {
+            appResourcesLimiter.onAppBeingDeleted(resource);
+            return DeleteControl.defaultDelete();
+        } else {
+            return DeleteControl.noFinalizerRemoval().rescheduleAfter(rescheduleDuration);
+        }
+    }
+
+    private Duration cleanupApplication(
+            ApplicationCustomResource resource, AppLastApplied appLastApplied) throws ApplicationDeletedException{
+        final HandleJobResult deployerJobResult = handleJob(resource, appLastApplied, false, true);
+        Duration rescheduleDuration;
+        if (deployerJobResult.proceed()) {
             log.infof(
                     "deployer cleanup job for %s is completed, checking setup cleanup",
                     resource.getMetadata().getName());
-            rescheduleDuration = handleJob(resource, appLastApplied, true, true);
+
+            final HandleJobResult setupJobResult = handleJob(resource, appLastApplied, true, true);
             log.infof(
                     "setup cleanup job for %s is %s",
                     resource.getMetadata().getName(),
-                    rescheduleDuration != null ? "not completed" : "completed");
+                    setupJobResult.proceed() ? "completed" : "not completed");
+            if (setupJobResult.proceed()) {
+                if (!resource.isMarkedForDeletion()) {
+                    client.resource(resource).delete();
+                    throw new ApplicationDeletedException();
+                }
+                return null;
+            } else {
+                return setupJobResult.reschedule();
+            }
         } else {
             log.infof(
                     "deployer cleanup job for %s is not completed yet",
                     resource.getMetadata().getName());
+            rescheduleDuration = deployerJobResult.reschedule();
         }
-        return rescheduleDuration != null
-                ? DeleteControl.noFinalizerRemoval().rescheduleAfter(rescheduleDuration)
-                : DeleteControl.defaultDelete();
+        return rescheduleDuration;
     }
 
-    private Duration handleJob(
+    private HandleJobResult handleJob(
             ApplicationCustomResource application,
             AppLastApplied appLastApplied,
             boolean isSetupJob,
@@ -154,6 +200,16 @@ public class AppController extends BaseController<ApplicationCustomResource>
         final Job currentJob =
                 client.batch().v1().jobs().inNamespace(namespace).withName(jobName).get();
         if (currentJob == null || areSpecChanged(application, appLastApplied, isSetupJob)) {
+            if (appLastApplied == null) {
+                appLastApplied = new AppLastApplied();
+            }
+            if (isSetupJob) {
+                appLastApplied.setSetup(
+                        SerializationUtil.writeAsJson(application.getSpec()));
+            } else {
+                appLastApplied.setRuntimeDeployer(
+                        SerializationUtil.writeAsJson(application.getSpec()));
+            }
             if (isSetupJob && !delete) {
                 final boolean isDeployable = appResourcesLimiter.checkLimitsForTenant(application);
                 if (!isDeployable) {
@@ -168,7 +224,7 @@ public class AppController extends BaseController<ApplicationCustomResource>
                     application
                             .getStatus()
                             .setResourceLimitStatus(ApplicationStatus.ResourceLimitStatus.REJECTED);
-                    return Duration.ofSeconds(30);
+                    return new HandleJobResult(false, Duration.ofSeconds(30));
                 } else {
                     application
                             .getStatus()
@@ -181,15 +237,53 @@ public class AppController extends BaseController<ApplicationCustomResource>
             } else {
                 application.getStatus().setStatus(ApplicationLifecycleStatus.DELETING);
             }
-            return DEFAULT_RESCHEDULE_DURATION;
+            return new HandleJobResult(false, DEFAULT_RESCHEDULE_DURATION);
         } else {
-            if (KubeUtil.isJobCompleted(currentJob)) {
+            if (KubeUtil.isJobFailed(currentJob)) {
+                if (isSetupJob && delete) {
+                    // failed cleaning up the assets/topics
+                    final ApplicationSpecOptions applicationSpecOptions =
+                            ApplicationSpec.deserializeOptions(application.getSpec().getOptions());
+                    if (applicationSpecOptions.getDeleteMode()
+                            == ApplicationSpecOptions.DeleteMode.CLEANUP_BEST_EFFORT) {
+                        return new HandleJobResult(true, null);
+                    }
+                }
+
+                String errorMessage = "?";
+                final Pod pod = KubeUtil.getJobPod(currentJob, client);
+                if (pod != null) {
+                    final KubeUtil.PodStatus status = KubeUtil.getPodsStatuses(List.of(pod)).values().iterator().next();
+                    if (status.getState() == KubeUtil.PodStatus.State.ERROR) {
+                        errorMessage = status.getMessage();
+                    }
+                }
+
+                if (delete) {
+                    final String errMessageJobDescription = isSetupJob ? "assets/topics" : "agents";
+                    application
+                            .getStatus()
+                            .setStatus(
+                                    ApplicationLifecycleStatus.errorDeleting(
+                                            "Failed to cleanup the %s, to delete the application, please cleanup the assets/topics manually and force-delete the application again. Error was:\n%s"
+                                                    .formatted(errMessageJobDescription, errorMessage)));
+                } else {
+                    final String errMessageJobDescription = isSetupJob ? "setup" : "deployer";
+                    application
+
+                            .getStatus()
+                            .setStatus(
+                                    ApplicationLifecycleStatus.errorDeploying(
+                                            "Failed to deploy the application, error during job: %s. Error was:\n%s".formatted(errMessageJobDescription, errorMessage)));
+                }
+                return new HandleJobResult(false, null);
+            } else if (KubeUtil.isJobCompleted(currentJob)) {
                 if (!isSetupJob && !delete) {
                     application.getStatus().setStatus(ApplicationLifecycleStatus.DEPLOYED);
                 }
-                return null;
+                return new HandleJobResult(true, null);
             } else {
-                return DEFAULT_RESCHEDULE_DURATION;
+                return new HandleJobResult(false, DEFAULT_RESCHEDULE_DURATION);
             }
         }
     }

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/AppControllerIT.java
@@ -91,7 +91,11 @@ public class AppControllerIT {
         deployment
                 .getClient()
                 .resource(
-                        new SecretBuilder().withNewMetadata().withName(applicationId).endMetadata().build())
+                        new SecretBuilder()
+                                .withNewMetadata()
+                                .withName(applicationId)
+                                .endMetadata()
+                                .build())
                 .inNamespace(namespace)
                 .serverSideApply();
         final ApplicationCustomResource createdCr =
@@ -126,7 +130,6 @@ public class AppControllerIT {
         createMockJob(namespace, client, job.getMetadata().getName());
         patchCustomResourceWithStatusDone(createdCr);
         awaitJobCompleted(namespace, job.getMetadata().getName());
-
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))

--- a/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/OperatorExtension.java
+++ b/langstream-k8s-deployer/langstream-k8s-deployer-operator/src/test/java/ai/langstream/deployer/k8s/controllers/OperatorExtension.java
@@ -115,6 +115,7 @@ public class OperatorExtension implements BeforeAllCallback, AfterAllCallback, B
         container.withEnv(
                 "QUARKUS_LOG_CATEGORY__IO_JAVAOPERATORSDK_OPERATOR_PROCESSING_EVENT_SOURCE_CONTROLLER",
                 "debug");
+        container.withEnv("QUARKUS_LOG_CATEGORY__AI_LANGSTREAM_DEPLOYER_K8S_APPS", "debug");
         env.forEach(container::withEnv);
         container.withExposedPorts(8080);
         container.withAccessToHost(true);

--- a/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
+++ b/langstream-k8s-storage/src/main/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStore.java
@@ -254,7 +254,8 @@ public class KubernetesApplicationStore implements ApplicationStore {
 
     @Override
     public void delete(String tenant, String applicationId, boolean force) {
-        final ApplicationCustomResource existing = getApplicationCustomResource(tenant, applicationId);
+        final ApplicationCustomResource existing =
+                getApplicationCustomResource(tenant, applicationId);
         if (existing == null || existing.isMarkedForDeletion()) {
             return;
         }

--- a/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
+++ b/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
@@ -89,7 +89,7 @@ class KubernetesApplicationStoreTest {
         assertNotNull(store.get(tenant, "myapp", false));
         store.delete(tenant, "myapp", false);
 
-        assertNull(
+        assertNotNull(
                 k3s.getClient()
                         .resources(ApplicationCustomResource.class)
                         .inNamespace("s" + tenant)
@@ -100,15 +100,6 @@ class KubernetesApplicationStoreTest {
         // deletion until the cleanup job is finished
         assertNotNull(k3s.getClient().secrets().inNamespace("s" + tenant).withName("myapp").get());
 
-        Awaitility.await()
-                .untilAsserted(
-                        () ->
-                                assertNull(
-                                        k3s.getClient()
-                                                .secrets()
-                                                .inNamespace("s" + tenant)
-                                                .withName("myapp")
-                                                .get()));
         store.onTenantDeleted(tenant);
         assertTrue(k3s.getClient().namespaces().withName("s" + tenant).get().isMarkedForDeletion());
     }

--- a/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
+++ b/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
@@ -85,7 +85,7 @@ class KubernetesApplicationStoreTest {
         assertEquals(1, store.list(tenant).size());
 
         assertNotNull(store.get(tenant, "myapp", false));
-        store.delete(tenant, "myapp");
+        store.delete(tenant, "myapp", false);
 
         assertNull(
                 k3s.getClient()
@@ -140,7 +140,7 @@ class KubernetesApplicationStoreTest {
                         .get();
         createdCr.getMetadata().setFinalizers(List.of("test-finalizer"));
         k3s.getClient().resource(createdCr).update();
-        store.delete(tenant, "myapp");
+        store.delete(tenant, "myapp", false);
         assertTrue(k3s.getClient().resource(createdCr).get().isMarkedForDeletion());
 
         try {

--- a/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
+++ b/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import ai.langstream.api.model.Application;
 import ai.langstream.api.model.Secrets;
 import ai.langstream.deployer.k8s.api.crds.apps.ApplicationCustomResource;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationSpec;
+import ai.langstream.deployer.k8s.api.crds.apps.ApplicationSpecOptions;
 import ai.langstream.impl.k8s.tests.KubeK3sServer;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -132,16 +134,30 @@ class KubernetesApplicationStoreTest {
         store.onTenantCreated(tenant);
         final Application app = new Application();
         store.put(tenant, "myapp", app, "code-1", null);
-        ApplicationCustomResource createdCr =
+        ApplicationCustomResource applicationCustomResource =
                 k3s.getClient()
                         .resources(ApplicationCustomResource.class)
                         .inNamespace("s" + tenant)
                         .withName("myapp")
                         .get();
-        createdCr.getMetadata().setFinalizers(List.of("test-finalizer"));
-        k3s.getClient().resource(createdCr).update();
+        applicationCustomResource.getMetadata().setFinalizers(List.of("test-finalizer"));
+        k3s.getClient().resource(applicationCustomResource).update();
         store.delete(tenant, "myapp", false);
-        assertTrue(k3s.getClient().resource(createdCr).get().isMarkedForDeletion());
+        applicationCustomResource = k3s.getClient().resource(applicationCustomResource).get();
+        assertFalse(applicationCustomResource.isMarkedForDeletion());
+        assertTrue(ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                .isMarkedForDeletion());
+        assertEquals(ApplicationSpecOptions.DeleteMode.CLEANUP_REQUIRED, ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                .getDeleteMode());
+
+        store.delete(tenant, "myapp", true);
+        applicationCustomResource = k3s.getClient().resource(applicationCustomResource).get();
+        assertFalse(applicationCustomResource.isMarkedForDeletion());
+        assertTrue(ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                .isMarkedForDeletion());
+        assertEquals(ApplicationSpecOptions.DeleteMode.CLEANUP_BEST_EFFORT, ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                .getDeleteMode());
+
 
         try {
             store.put(tenant, "myapp", app, "code-1", null);
@@ -149,9 +165,10 @@ class KubernetesApplicationStoreTest {
         } catch (IllegalArgumentException aie) {
             assertEquals("Application myapp is marked for deletion.", aie.getMessage());
         }
-        createdCr = k3s.getClient().resource(createdCr).get();
-        createdCr.getMetadata().setFinalizers(List.of());
-        k3s.getClient().resource(createdCr).update();
+        applicationCustomResource = applicationCustomResource;
+        applicationCustomResource.getMetadata().setFinalizers(List.of());
+        k3s.getClient().resource(applicationCustomResource).update();
+        k3s.getClient().resource(applicationCustomResource).delete();
 
         Awaitility.await()
                 .until(

--- a/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
+++ b/langstream-k8s-storage/src/test/java/ai/langstream/impl/storage/k8s/apps/KubernetesApplicationStoreTest.java
@@ -145,19 +145,24 @@ class KubernetesApplicationStoreTest {
         store.delete(tenant, "myapp", false);
         applicationCustomResource = k3s.getClient().resource(applicationCustomResource).get();
         assertFalse(applicationCustomResource.isMarkedForDeletion());
-        assertTrue(ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
-                .isMarkedForDeletion());
-        assertEquals(ApplicationSpecOptions.DeleteMode.CLEANUP_REQUIRED, ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
-                .getDeleteMode());
+        assertTrue(
+                ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                        .isMarkedForDeletion());
+        assertEquals(
+                ApplicationSpecOptions.DeleteMode.CLEANUP_REQUIRED,
+                ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                        .getDeleteMode());
 
         store.delete(tenant, "myapp", true);
         applicationCustomResource = k3s.getClient().resource(applicationCustomResource).get();
         assertFalse(applicationCustomResource.isMarkedForDeletion());
-        assertTrue(ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
-                .isMarkedForDeletion());
-        assertEquals(ApplicationSpecOptions.DeleteMode.CLEANUP_BEST_EFFORT, ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
-                .getDeleteMode());
-
+        assertTrue(
+                ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                        .isMarkedForDeletion());
+        assertEquals(
+                ApplicationSpecOptions.DeleteMode.CLEANUP_BEST_EFFORT,
+                ApplicationSpec.deserializeOptions(applicationCustomResource.getSpec().getOptions())
+                        .getDeleteMode());
 
         try {
             store.put(tenant, "myapp", app, "code-1", null);

--- a/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
+++ b/langstream-runtime/langstream-runtime-tester/src/main/java/ai/langstream/runtime/tester/InMemoryApplicationStore.java
@@ -134,7 +134,7 @@ public class InMemoryApplicationStore implements ApplicationStore {
     }
 
     @Override
-    public void delete(String tenant, String applicationId) {
+    public void delete(String tenant, String applicationId, boolean force) {
         APPLICATIONS.remove(getKey(tenant, applicationId));
         SECRETS.remove(getKey(tenant, applicationId));
     }

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationResource.java
@@ -283,10 +283,11 @@ public class ApplicationResource {
     void deleteApplication(
             Authentication authentication,
             @NotBlank @PathVariable("tenant") String tenant,
-            @NotBlank @PathVariable("applicationId") String applicationId) {
+            @NotBlank @PathVariable("applicationId") String applicationId,
+            @RequestParam(value = "force", required = false) boolean force) {
         performAuthorization(authentication, tenant);
         getAppOrThrow(tenant, applicationId);
-        applicationService.deleteApplication(tenant, applicationId);
+        applicationService.deleteApplication(tenant, applicationId, force);
         log.info("Deleted application {}", applicationId);
     }
 

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/application/ApplicationService.java
@@ -347,9 +347,9 @@ public class ApplicationService {
     }
 
     @SneakyThrows
-    public void deleteApplication(String tenant, String applicationId) {
+    public void deleteApplication(String tenant, String applicationId, boolean force) {
         checkTenant(tenant);
-        applicationStore.delete(tenant, applicationId);
+        applicationStore.delete(tenant, applicationId, force);
     }
 
     private void checkTenant(String tenant) {

--- a/langstream-webservice/src/main/java/ai/langstream/webservice/common/TenantResource.java
+++ b/langstream-webservice/src/main/java/ai/langstream/webservice/common/TenantResource.java
@@ -120,7 +120,7 @@ public class TenantResource {
                 .forEach(
                         app -> {
                             try {
-                                applicationService.deleteApplication(tenant, app);
+                                applicationService.deleteApplication(tenant, app, true);
                             } catch (Exception e) {
                                 log.error(
                                         "Error deleting application {} for tenant {}",

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationResourceTest.java
@@ -152,7 +152,8 @@ class ApplicationResourceTest {
 
         mockMvc.perform(delete("/api/applications/my-tenant/test")).andExpect(status().isOk());
 
-        mockMvc.perform(get("/api/applications/my-tenant/test")).andExpect(status().isNotFound());
+        // the delete is actually a crd update
+        mockMvc.perform(get("/api/applications/my-tenant/test")).andExpect(status().isOk());
     }
 
     @Test

--- a/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
+++ b/langstream-webservice/src/test/java/ai/langstream/webservice/application/ApplicationServiceResourceLimitTest.java
@@ -219,7 +219,7 @@ class ApplicationServiceResourceLimitTest {
         }
 
         @Override
-        public void delete(String tenant, String applicationId) {
+        public void delete(String tenant, String applicationId, boolean force) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
Changes:
* If the deployer/setup job during deploy or deletion fails, we now report the error in the application status
* There's a new option in the deletion `-f`, to skip cleanup errors and go ahead with the application deletion

Implementation:
* There's a new field in the application crd that handles wether the application can skip the cleanup or not in case of failures (only 1 attempt).
* The deletion process totally changes:
  * Before: the control plane deletes the app CRD and the finalizer is triggered in the operator. This triggers the cleanup and in case of failures, nothing can be done. 
  * Now: the control plane puts a flag "marked for deletion" in the crd specs. In this way it's then possible to force the deletion of the app after the app failed to be deleted. This was not possible before because once you delete a custom resource, you cannot change his config. So now the operator reacts to this new flag by starting the deletion process, handling errors reading the new skipErrors flag. Once done, it finally deletes the custom resource. The finalizer is still there to verify the cleanup ran and to update the tenant resource usage, but now it's much more lightweight.