### PR TITLE
[HuggingFace] Make hugging face embeddings work in docker run with multiple pipelines

### DIFF
--- a/examples/applications/ollama-chatbot/README.md
+++ b/examples/applications/ollama-chatbot/README.md
@@ -9,7 +9,7 @@ In this example we are using [HerdDB](ps://github.com/diennea/herddb) as a vecto
 but you can use any Vector databases.
 
 As LLM we are using [Ollama](https://ollama.ai), that is a service that runs on your machine. 
-We are using OpenAI to compute the embeddings of the texts.
+We are using Hugging Face to compute the embeddings of the texts.
 
 ## Install Ollama
 
@@ -26,19 +26,6 @@ If you want to use another model export this variable before starting the applic
 ```bash
 export OLLAMA_MODEL=llama2:13b
 ```
-
-## Configure you OpenAI API Key
-
-At the moment it the embeddings computed by Ollama models are not performing well, so we are using OpenAI to compute them. 
-
-Export to the ENV the access key to OpenAI
-
-```
-export OPEN_AI_ACCESS_KEY=...
-```
-
-The default [secrets file](../../secrets/secrets.yaml) reads from the ENV. Check out the file to learn more about
-the default settings, you can change them by exporting other ENV variables.
 
 ## Deploy the LangStream application in docker
 

--- a/examples/applications/ollama-chatbot/chatbot.yaml
+++ b/examples/applications/ollama-chatbot/chatbot.yaml
@@ -32,8 +32,9 @@ pipeline:
   - name: "compute-embeddings"
     type: "compute-ai-embeddings"
     configuration:
-      ai-service: "openai"
-      model: "${secrets.open-ai.embeddings-model}"
+      ai-service: "huggingface"
+      model: "${secrets.hugging-face.embeddings-model}" # This is the id of the model
+      model-url: "${secrets.hugging-face.embeddings-model-url}" # This is the URL of the repository containing the model
       embeddings-field: "value.question_embeddings"
       text: "{{ value.question }}"
       flush-interval: 0

--- a/examples/applications/ollama-chatbot/configuration.yaml
+++ b/examples/applications/ollama-chatbot/configuration.yaml
@@ -30,13 +30,11 @@ configuration:
       id: "ollama"
       configuration:
         url: "${secrets.ollama.url}"
-    - type: "open-ai-configuration"
-      name: "OpenAI Azure configuration"
-      id: "openai"
+    - type: "hugging-face-configuration"
+      name: "Hugging Face AI configuration"
+      id: "huggingface"
       configuration:
-        url: "${secrets.open-ai.url}"
-        access-key: "${secrets.open-ai.access-key}"
-        provider: "${secrets.open-ai.provider}"
+        provider: "local"
   dependencies:
     - name: "HerdDB.org JDBC Driver"
       url: "https://repo1.maven.org/maven2/org/herddb/herddb-jdbc/0.28.0/herddb-jdbc-0.28.0-thin.jar"

--- a/examples/applications/ollama-chatbot/crawler.yaml
+++ b/examples/applications/ollama-chatbot/crawler.yaml
@@ -46,10 +46,10 @@ pipeline:
     type: "text-splitter"
     configuration:
       splitter_type: "RecursiveCharacterTextSplitter"
-      chunk_size: 400
+      chunk_size: 200
       separators: ["\n\n", "\n", " ", ""]
       keep_separator: false
-      chunk_overlap: 100
+      chunk_overlap: 20
       length_function: "cl100k_base"
   - name: "Convert to structured data"
     type: "document-to-json"
@@ -76,8 +76,9 @@ pipeline:
     id: "step1"
     type: "compute-ai-embeddings"
     configuration:
-      ai-service: "openai"
-      model: "${secrets.open-ai.embeddings-model}"
+      ai-service: "huggingface"
+      model: "${secrets.hugging-face.embeddings-model}" # This is the id of the model
+      model-url: "${secrets.hugging-face.embeddings-model-url}" # This is the URL of the repository containing the model
       embeddings-field: "value.embeddings_vector"
       text: "{{ value.text }}"
       batch-size: 10

--- a/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingService.java
+++ b/langstream-agents/langstream-ai-agents/src/main/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingService.java
@@ -39,7 +39,8 @@ public class HuggingFaceEmbeddingService
             throws IOException,
                     ModelNotFoundException,
                     MalformedModelException,
-                    IllegalAccessException {
+                    IllegalAccessException,
+                    InterruptedException {
         super(conf);
     }
 

--- a/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingServiceTest.java
+++ b/langstream-agents/langstream-ai-agents/src/test/java/com/datastax/oss/streaming/ai/embeddings/HuggingFaceEmbeddingServiceTest.java
@@ -15,25 +15,31 @@
  */
 package com.datastax.oss.streaming.ai.embeddings;
 
-import java.util.List;
-import org.junit.jupiter.api.Disabled;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// disabled, just for experiments/usage demo
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
 public class HuggingFaceEmbeddingServiceTest {
 
-    @Disabled
-    public void testMain() throws Exception {
+    @Test
+    public void testEmbeddings() throws Exception {
         AbstractHuggingFaceEmbeddingService.HuggingFaceConfig conf =
                 AbstractHuggingFaceEmbeddingService.HuggingFaceConfig.builder()
                         .engine("PyTorch")
-                        .modelUrl(
-                                "file:///Users/andreyyegorov/src/djl/model/nlp/text_embedding/ai/djl/huggingface/pytorch/sentence-transformers/all-MiniLM-L6-v2/0.0.1/all-MiniLM-L6-v2.zip")
+                        .modelName("multilingual-e5-small")
+                        .modelUrl("djl://ai.djl.huggingface.pytorch/intfloat/multilingual-e5-small")
                         .build();
 
         try (EmbeddingsService service = new HuggingFaceEmbeddingService(conf)) {
-            List<List<Double>> result =
-                    service.computeEmbeddings(List.of("hello world", "stranger things")).get();
-            result.forEach(System.out::println);
+
+            List<List<Double>> lists =
+                    service.computeEmbeddings(List.of("Hello", "my friend")).get();
+            assertEquals(2, lists.size());
+            assertEquals(List.of(384), List.of(lists.get(0).size()));
+            assertEquals(List.of(384), List.of(lists.get(1).size()));
         }
     }
 }


### PR DESCRIPTION
Summary:
when running in docker we use thread to simulate pods and the pipelines share the JVM.
There are some issues with PyTorch/DJL and classloading.
This patch fixes them and moved the Ollame example to using HuggingFace