### PR TITLE
Fix Pinecone config vector.metadata.X

### DIFF
--- a/examples/applications/chatbot-rag-memory/chatbot.yaml
+++ b/examples/applications/chatbot-rag-memory/chatbot.yaml
@@ -184,5 +184,6 @@ pipeline:
     input: "${globals.logTopic}"
     configuration:
       datasource: "AstraVector"
-      table: "${globals.vectorKeyspace}.${globals.chatTable}"
+      table-name: "${globals.chatTable}"
+      keyspace: "${globals.vectorKeyspace}"
       mapping: "sessionid=value.sessionid,question=value.questionNoContext,answer=value.answer,prompt=value.prompt,timestamp=now()"

--- a/examples/applications/chatbot-rag-memory/write-to-astra.yaml
+++ b/examples/applications/chatbot-rag-memory/write-to-astra.yaml
@@ -25,5 +25,5 @@ pipeline:
     input: "${globals.chunksTopic}"
     configuration:
       datasource: "AstraVector"
-      table: "${globals.vectorKeyspace}.${globals.vectorTable}"
+      table-name: "${globals.vectorKeyspace}.${globals.vectorTable}"
       mapping: "filename=value.filename, chunk_id=value.chunk_id, language=value.language, text=value.text, embeddings_vector=value.embeddings_vector, num_tokens=value.chunk_num_tokens"

--- a/examples/applications/rag-aws/ingest.yaml
+++ b/examples/applications/rag-aws/ingest.yaml
@@ -77,7 +77,7 @@ pipeline:
     configuration:
       fields:
         - name: "value.filename"
-          expression: "properties.url"
+          expression: "properties.name"
           type: STRING
   - name: "compute-embeddings"
     type: "compute-ai-embeddings"

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/vectors/PineconeVectorDatabaseWriterConfig.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/vectors/PineconeVectorDatabaseWriterConfig.java
@@ -25,6 +25,7 @@ import lombok.Data;
 @Data
 @AgentConfig(name = "Pinecone", description = """
     Writes data to Pinecone service.
+    To add metadata fields you can add vector.metadata.my-field: "value.my-field". The value is a JSTL Expression to compute the actual value.
 """)
 public class PineconeVectorDatabaseWriterConfig
         extends QueryVectorDBAgentProvider.VectorDatabaseWriterConfig {
@@ -39,7 +40,7 @@ public class PineconeVectorDatabaseWriterConfig
 
     @Override
     public boolean isAgentConfigModelAllowUnknownProperties() {
-        return false;
+        return true;
     }
 
     @ConfigProperty(description = "JSTL Expression to compute the id.")

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/vectors/PineconeVectorDatabaseWriterConfig.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/vectors/PineconeVectorDatabaseWriterConfig.java
@@ -23,7 +23,10 @@ import java.util.Map;
 import lombok.Data;
 
 @Data
-@AgentConfig(name = "Pinecone", description = """
+@AgentConfig(
+        name = "Pinecone",
+        description =
+                """
     Writes data to Pinecone service.
     To add metadata fields you can add vector.metadata.my-field: "value.my-field". The value is a JSTL Expression to compute the actual value.
 """)

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/AgentValidationTestUtil.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/AgentValidationTestUtil.java
@@ -49,6 +49,14 @@ public class AgentValidationTestUtil {
                               contact-points: "xx"
                               loadBalancing-localDc: "xx"
                               port: 999
+                          - type: "vector-database"
+                            name: "PineconeDatasource"
+                            configuration:
+                              service: "pinecone"
+                              api-key: "xx"
+                              index-name: "xx"
+                              project-name: "999x"
+                              environment: "us-east1"
                     """;
         }
         Application applicationInstance =

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
@@ -448,7 +448,7 @@ class QueryVectorDBAgentProviderTest {
                           "vector-db-sink_pinecone" : {
                             "type" : "vector-db-sink",
                             "name" : "Pinecone",
-                            "description" : "Writes data to Pinecone service.",
+                            "description" : "Writes data to Pinecone service.\\n    To add metadata fields you can add vector.metadata.my-field: \\"value.my-field\\". The value is a JSTL Expression to compute the actual value.",
                             "properties" : {
                               "datasource" : {
                                 "description" : "Resource id. The target resource must be type: 'datasource' or 'vector-database' and service: 'pinecone'.",

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
@@ -105,6 +105,27 @@ class QueryVectorDBAgentProviderTest {
                 null);
     }
 
+
+    @Test
+    @SneakyThrows
+    public void testWritePinecone() {
+        validate(
+                """
+                        pipeline:
+                          - name: "db"
+                            type: "vector-db-sink"
+                            configuration:
+                                datasource: "PineconeDatasource"
+                                vector.id: "value.id"
+                                vector.vector: "value.embeddings"
+                                vector.namespace: "value.namespace"
+                                vector.metadata.genre: "value.genre"
+                                vector.metadata.genre2: "value.genre2"
+                                  
+                        """,
+                null);
+    }
+
     private void validate(String pipeline, String expectErrMessage) throws Exception {
         AgentValidationTestUtil.validate(pipeline, expectErrMessage);
     }

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/test/java/ai/langstream/runtime/impl/k8s/agents/QueryVectorDBAgentProviderTest.java
@@ -105,7 +105,6 @@ class QueryVectorDBAgentProviderTest {
                 null);
     }
 
-
     @Test
     @SneakyThrows
     public void testWritePinecone() {
@@ -121,7 +120,7 @@ class QueryVectorDBAgentProviderTest {
                                 vector.namespace: "value.namespace"
                                 vector.metadata.genre: "value.genre"
                                 vector.metadata.genre2: "value.genre2"
-                                  
+
                         """,
                 null);
     }


### PR DESCRIPTION
To pass a metadata field in the pinecone vector-db-sink you have to use the syntax `vector.metadata.my-field`. Starting from 0.4.x, this syntax is blocked by the control plane and it should not