### PR TITLE
[webcrawler] Support emitting non HTML documents (like PDFs...)

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -41,7 +41,6 @@ import io.minio.MinioClient;
 import io.minio.errors.ErrorResponseException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -269,7 +268,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         processed(0, 1);
         return List.of(
                 new WebCrawlerSourceRecord(
-                        document.content().getBytes(StandardCharsets.UTF_8), document.url()));
+                        document.content(), document.url(), document.contentType()));
     }
 
     private void checkReindexIsNeeded() {
@@ -336,10 +335,12 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
     private static class WebCrawlerSourceRecord implements Record {
         private final byte[] read;
         private final String url;
+        private final String contentType;
 
-        public WebCrawlerSourceRecord(byte[] read, String url) {
+        public WebCrawlerSourceRecord(byte[] read, String url, String contentType) {
             this.read = read;
             this.url = url;
+            this.contentType = contentType;
         }
 
         /**
@@ -370,7 +371,9 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
 
         @Override
         public Collection<Header> headers() {
-            return List.of(new SimpleRecord.SimpleHeader("url", url));
+            return List.of(
+                    new SimpleRecord.SimpleHeader("url", url),
+                    new SimpleRecord.SimpleHeader("content_type", contentType));
         }
 
         @Override

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/Document.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/Document.java
@@ -15,4 +15,4 @@
  */
 package ai.langstream.agents.webcrawler.crawler;
 
-public record Document(String url, String content) {}
+public record Document(String url, byte[] content, String contentType) {}

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
@@ -39,6 +39,7 @@ public class WebCrawlerConfiguration {
     @Builder.Default private boolean handleCookies = true;
     @Builder.Default private boolean handleRobotsFile = true;
     @Builder.Default private boolean scanHtmlDocuments = true;
+    @Builder.Default private boolean allowNonHtmlContent = false;
 
     @Builder.Default private Set<String> allowedTags = Set.of("a");
 


### PR DESCRIPTION
Summary:
- add new option "allow-non-html-contents" to the webcrawler-source

Please note that in LangStream it is expected that the source only emits the records, it is up to the next agent in the pipeline to extract the text or manipulate the contents.

The "text-extractor" agent already handles pretty well PDF documents, thanks to Apache Tika