### PR TITLE
[webcrawler-source] Expose the allow-non-html-contents parameter

### DIFF
--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/WebCrawlerSource.java
@@ -115,11 +115,13 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         String userAgent = getString("user-agent", DEFAULT_USER_AGENT, configuration);
         int maxErrorCount = getInt("max-error-count", 5, configuration);
         int httpTimeout = getInt("http-timeout", 10000, configuration);
+        boolean allowNonHtmlContents = getBoolean("allow-non-html-contents", false, configuration);
 
         boolean handleCookies = getBoolean("handle-cookies", true, configuration);
 
         log.info("allowed-domains: {}", allowedDomains);
         log.info("forbidden-paths: {}", forbiddenPaths);
+        log.info("allow-non-html-contents: {}", allowNonHtmlContents);
         log.info("seed-urls: {}", seedUrls);
         log.info("max-urls: {}", maxUrls);
         log.info("max-depth: {}", maxDepth);
@@ -133,6 +135,7 @@ public class WebCrawlerSource extends AbstractAgentCode implements AgentSource {
         WebCrawlerConfiguration webCrawlerConfiguration =
                 WebCrawlerConfiguration.builder()
                         .allowedDomains(allowedDomains)
+                        .allowNonHtmlContents(allowNonHtmlContents)
                         .maxUrls(maxUrls)
                         .maxDepth(maxDepth)
                         .forbiddenPaths(forbiddenPaths)

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawler.java
@@ -204,7 +204,7 @@ public class WebCrawler {
             // we did something
             return true;
         } catch (UnsupportedMimeTypeException notHtml) {
-            if (configuration.isAllowNonHtmlContent()) {
+            if (configuration.isAllowNonHtmlContents()) {
                 log.info(
                         "Url {} lead to a {} content-type document. allow-not-html-content is true, so we are processing it",
                         current,

--- a/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/main/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerConfiguration.java
@@ -39,7 +39,7 @@ public class WebCrawlerConfiguration {
     @Builder.Default private boolean handleCookies = true;
     @Builder.Default private boolean handleRobotsFile = true;
     @Builder.Default private boolean scanHtmlDocuments = true;
-    @Builder.Default private boolean allowNonHtmlContent = false;
+    @Builder.Default private boolean allowNonHtmlContents = false;
 
     @Builder.Default private Set<String> allowedTags = Set.of("a");
 

--- a/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
+++ b/langstream-agents/langstream-agent-webcrawler/src/test/java/ai/langstream/agents/webcrawler/crawler/WebCrawlerTest.java
@@ -345,7 +345,7 @@ class WebCrawlerTest {
         WebCrawlerConfiguration configuration =
                 WebCrawlerConfiguration.builder()
                         .allowedDomains(Set.of(vmRuntimeInfo.getHttpBaseUrl()))
-                        .allowNonHtmlContent(true)
+                        .allowNonHtmlContents(true)
                         .handleRobotsFile(false)
                         .maxErrorCount(5)
                         .build();

--- a/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
+++ b/langstream-k8s-runtime/langstream-k8s-runtime-core/src/main/java/ai/langstream/runtime/impl/k8s/agents/WebCrawlerSourceAgentProvider.java
@@ -206,6 +206,15 @@ public class WebCrawlerSourceAgentProvider extends AbstractComposableAgentProvid
         @ConfigProperty(
                 description =
                         """
+                Whether to emit non HTML documents to the pipeline (i.e. PDF Files).
+                                """,
+                defaultValue = "false")
+        @JsonProperty("allow-non-html-contents")
+        private boolean allowNonHtmlContents;
+
+        @ConfigProperty(
+                description =
+                        """
                 The starting URLs for the crawl.
                                 """)
         @JsonProperty("seed-urls")

--- a/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
+++ b/langstream-runtime/langstream-runtime-impl/src/test/java/ai/langstream/kafka/WebCrawlerSourceIT.java
@@ -93,6 +93,7 @@ class WebCrawlerSourceIT extends AbstractKafkaApplicationRunner {
                                     output: "${globals.output-topic}"
                                     configuration:\s
                                         seed-urls: ["%s/index.html"]
+                                        allow-non-html-contents: true
                                         allowed-domains: ["%s"]
                                         state-storage: disk
                                 """


### PR DESCRIPTION
Summary:
- allow users to configure "allow-non-html-contents"