### PR TITLE
[cassandra] Remove legacy driver from classpath

### DIFF
--- a/langstream-agents/langstream-ai-agents/pom.xml
+++ b/langstream-agents/langstream-ai-agents/pom.xml
@@ -77,6 +77,12 @@
       <groupId>com.datastax.astra</groupId>
       <artifactId>astra-sdk</artifactId>
       <version>1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.datastax.oss</groupId>
+          <artifactId>java-driver-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.datastax.stargate</groupId>
@@ -90,6 +96,10 @@
         <exclusion>
           <groupId>com.datastax.stargate</groupId>
           <artifactId>stargate-sdk-graphql</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.datastax.oss</groupId>
+          <artifactId>java-driver-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Summary:
- we recently added a dependency (astra-sdk and stargate-sdk) that introduced back an old version of the DataStax Cassandra Driver 4.15.0, that is not compatible with the VECTOR datatype
- we are using the "shaded" version and so Maven kept both the artifacts, the non-shaded 4.15.0 and the shaded 4.16.0