### PR TITLE
Fix for handling big messages from Python agent

### DIFF
--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentProcessor.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentProcessor.java
@@ -59,7 +59,7 @@ public class GrpcAgentProcessor extends AbstractGrpcAgent implements AgentProces
     @Override
     public void start() throws Exception {
         super.start();
-        request = AgentServiceGrpc.newStub(channel).withWaitForReady().process(responseObserver);
+        request = asyncStub.process(responseObserver);
         restarting.set(false);
         startFailedButDevelopmentMode = false;
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentSink.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentSink.java
@@ -53,7 +53,7 @@ public class GrpcAgentSink extends AbstractGrpcAgent implements AgentSink {
     @Override
     public void start() throws Exception {
         super.start();
-        request = AgentServiceGrpc.newStub(channel).withWaitForReady().write(responseObserver);
+        request = asyncStub.write(responseObserver);
         restarting.set(false);
         startFailedButDevelopmentMode = false;
     }

--- a/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentSource.java
+++ b/langstream-agents/langstream-agent-grpc/src/main/java/ai/langstream/agents/grpc/GrpcAgentSource.java
@@ -53,7 +53,7 @@ public class GrpcAgentSource extends AbstractGrpcAgent implements AgentSource {
     @Override
     public void start() throws Exception {
         super.start();
-        request = AgentServiceGrpc.newStub(channel).withWaitForReady().read(responseObserver);
+        request = asyncStub.read(responseObserver);
         restarting.set(false);
         startFailedButDevelopmentMode = false;
     }


### PR DESCRIPTION
This fix uses the asyncStub which was configured to handle 2GB messages with Python agents.